### PR TITLE
feat: add QR code redirect system

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -29,8 +29,31 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // --- Setup complete check ---
   const pathname = request.nextUrl.pathname;
+
+  // --- QR code redirect handler ---
+  if (pathname.startsWith('/go/')) {
+    const slug = pathname.slice(4); // strip "/go/"
+    if (slug) {
+      const { data } = await supabase
+        .from('redirects')
+        .select('destination_url')
+        .eq('slug', slug)
+        .single();
+
+      if (data?.destination_url) {
+        // Increment scan count in the background (fire-and-forget)
+        supabase.rpc('increment_scan_count', { slug_param: slug });
+        return NextResponse.redirect(data.destination_url, 302);
+      }
+    }
+    // Slug not found — return 404
+    const url = request.nextUrl.clone();
+    url.pathname = '/not-found';
+    return NextResponse.rewrite(url);
+  }
+
+  // --- Setup complete check ---
   const isSetupRoute = pathname === '/setup' || pathname.startsWith('/setup/');
   const isAuthCallback = pathname.startsWith('/api/auth/');
   const isStaticAsset = pathname.startsWith('/_next/');

--- a/supabase/migrations/003_redirects.sql
+++ b/supabase/migrations/003_redirects.sql
@@ -1,0 +1,75 @@
+-- 003_redirects.sql — QR code redirect system
+-- Allows QR codes to point to /go/:slug which redirects to a configurable destination
+
+-- ======================
+-- Redirects table
+-- ======================
+
+create table redirects (
+  slug text primary key,
+  destination_url text not null,
+  scan_count integer not null default 0,
+  created_at timestamptz default now()
+);
+
+-- ======================
+-- RLS policies
+-- ======================
+
+alter table redirects enable row level security;
+
+-- Public can look up redirects (needed for the middleware redirect)
+create policy "Public can view redirects"
+  on redirects for select
+  to anon, authenticated
+  using (true);
+
+-- Admins can manage redirects
+create policy "Admins can insert redirects"
+  on redirects for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+create policy "Admins can update redirects"
+  on redirects for update
+  to authenticated
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+create policy "Admins can delete redirects"
+  on redirects for delete
+  to authenticated
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+-- ======================
+-- Scan count increment function
+-- ======================
+
+-- SECURITY DEFINER so anonymous/public requests can increment the counter
+-- without needing UPDATE permission on the redirects table
+create or replace function increment_scan_count(slug_param text)
+returns void
+language sql
+security definer
+as $$
+  update redirects
+  set scan_count = scan_count + 1
+  where slug = slug_param;
+$$;


### PR DESCRIPTION
## Summary
- Adds `redirects` Supabase table (`slug`, `destination_url`, `scan_count`, `created_at`) with RLS policies and a `SECURITY DEFINER` function for anonymous scan count incrementing
- Adds `/go/:slug` handler in Next.js middleware that looks up the slug, returns a 302 redirect, and increments the scan count
- Unknown slugs rewrite to `/not-found`

## Test plan
- [ ] Run migration `003_redirects.sql` against Supabase
- [ ] Insert test row: `INSERT INTO redirects (slug, destination_url) VALUES ('test', 'https://example.com');`
- [ ] Visit `/go/test` — should 302 redirect to example.com
- [ ] Verify `scan_count` incremented to 1 in Supabase
- [ ] Update `destination_url` — confirm same slug now redirects to the new URL
- [ ] Visit `/go/nonexistent` — should show 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)