### PR TITLE
fix: surface Supabase errors and add missing photos UPDATE policy

### DIFF
--- a/src/components/manage/EditItemForm.tsx
+++ b/src/components/manage/EditItemForm.tsx
@@ -257,7 +257,8 @@ export default function EditItemForm({
       router.push('/manage');
       router.refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save changes.');
+      const message = err instanceof Error ? err.message : typeof err === 'object' && err !== null && 'message' in err ? String((err as { message: unknown }).message) : 'Failed to save changes.';
+      setError(message);
       setSaving(false);
     }
   }

--- a/supabase/migrations/006_photos_update_policy.sql
+++ b/supabase/migrations/006_photos_update_policy.sql
@@ -1,0 +1,13 @@
+-- 006_photos_update_policy.sql — Add missing UPDATE policy for photos table
+-- The edit form needs to reassign is_primary when the primary photo is removed
+
+create policy "Authenticated users can update photos"
+  on photos for update
+  to authenticated
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role in ('admin', 'editor')
+    )
+  );


### PR DESCRIPTION
## Summary
- Fix error handling in `EditItemForm` — `PostgrestError` is a plain object (not `Error` instance), so `instanceof Error` was always false and users only saw "Failed to save changes." instead of the actual DB error
- Add missing RLS UPDATE policy on `photos` table so `is_primary` reassignment works for admin/editor users

## Migration required
Run `006_photos_update_policy.sql` in the Supabase SQL editor after deploying.

## Test plan
- [ ] Edit an item and save — verify no error for admin/editor users
- [ ] Remove the primary photo while other photos exist — verify `is_primary` is reassigned
- [ ] Trigger a real DB error (e.g., invalid data) — verify the actual error message is shown, not the generic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)