### PR TITLE
fix: lenient generation schema with defaults for AI output

### DIFF
--- a/src/lib/landing/schemas.ts
+++ b/src/lib/landing/schemas.ts
@@ -85,15 +85,67 @@ const landingBlockSchema = z.discriminatedUnion('type', [
 
 export const landingBlocksSchema = z.array(landingBlockSchema);
 
+/**
+ * Lenient schemas for AI generation — no `id` field (added post-generation),
+ * and sensible defaults for fields Claude might omit.
+ */
 export const generationBlocksSchema = z.array(
   z.discriminatedUnion('type', [
-    heroBlockSchema.omit({ id: true }),
-    textBlockSchema.omit({ id: true }),
-    imageBlockSchema.omit({ id: true }),
-    buttonBlockSchema.omit({ id: true }),
-    linksBlockSchema.omit({ id: true }),
-    statsBlockSchema.omit({ id: true }),
-    galleryBlockSchema.omit({ id: true }),
-    spacerBlockSchema.omit({ id: true }),
+    z.object({
+      type: z.literal('hero'),
+      title: z.string().default('Welcome'),
+      subtitle: z.string().optional(),
+      backgroundImageUrl: z.string().optional(),
+      overlay: z.boolean().default(true),
+    }),
+    z.object({
+      type: z.literal('text'),
+      content: z.string().default(''),
+      alignment: z.enum(['left', 'center']).default('left'),
+    }),
+    z.object({
+      type: z.literal('image'),
+      url: z.string().default('placeholder'),
+      alt: z.string().default('Image'),
+      caption: z.string().optional(),
+      width: z.enum(['small', 'medium', 'full']).default('medium'),
+    }),
+    z.object({
+      type: z.literal('button'),
+      label: z.string().default('Explore the Map'),
+      href: z.string().default('/map'),
+      style: z.enum(['primary', 'outline']).default('primary'),
+      size: z.enum(['default', 'large']).default('default'),
+    }),
+    z.object({
+      type: z.literal('links'),
+      items: z.array(z.object({
+        label: z.string(),
+        url: z.string(),
+        description: z.string().optional(),
+      })).default([]),
+      layout: z.enum(['inline', 'stacked']).default('stacked'),
+    }),
+    z.object({
+      type: z.literal('stats'),
+      source: z.enum(['manual', 'auto']).default('auto'),
+      items: z.array(z.object({
+        label: z.string(),
+        value: z.string(),
+      })).optional(),
+    }),
+    z.object({
+      type: z.literal('gallery'),
+      images: z.array(z.object({
+        url: z.string(),
+        alt: z.string().default('Image'),
+        caption: z.string().optional(),
+      })).default([]),
+      columns: z.union([z.literal(2), z.literal(3), z.literal(4)]).default(3),
+    }),
+    z.object({
+      type: z.literal('spacer'),
+      size: z.enum(['small', 'medium', 'large']).default('medium'),
+    }),
   ])
 );


### PR DESCRIPTION
## Summary
- Make the AI generation Zod schema lenient with sensible defaults for fields Claude may omit
- Fixes: `AI returned invalid block structure: href expected string, received undefined`
- Button defaults to `href: "/map"`, image defaults to `url: "placeholder"`, etc.
- Strict validation schemas unchanged (used for saving to DB)

## Test plan
- [ ] Generate a landing page — blocks render without validation errors
- [ ] 9 schema tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)