### PR TITLE
Fix: hide Manage/Settings nav for unauthenticated users

### DIFF
--- a/src/__tests__/navigation-platform.test.tsx
+++ b/src/__tests__/navigation-platform.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Navigation from '@/components/layout/Navigation';
 
 // Mock next/navigation
@@ -23,46 +23,80 @@ vi.mock('@/lib/config/client', () => ({
   }),
 }));
 
-describe('Navigation platform context hiding', () => {
+// Mock Supabase client — control auth state per test
+let mockUser: any = null;
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: () => Promise.resolve({ data: { user: mockUser }, error: null }),
+    },
+  }),
+}));
+
+describe('Navigation', () => {
   afterEach(() => {
-    // Clear the cookie
     document.cookie = 'x-tenant-source=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     mockPathname = '/';
+    mockUser = null;
   });
 
-  it('renders navigation in org context (no platform cookie)', () => {
-    mockPathname = '/map';
-    const { container } = render(<Navigation />);
+  describe('platform context hiding', () => {
+    it('renders navigation in org context (no platform cookie)', () => {
+      mockPathname = '/map';
+      const { container } = render(<Navigation />);
 
-    // Should render navigation elements (desktop + mobile = multiple nav elements)
-    expect(container.innerHTML).not.toBe('');
-    expect(container.querySelector('nav, header')).not.toBeNull();
+      expect(container.innerHTML).not.toBe('');
+      expect(container.querySelector('nav, header')).not.toBeNull();
+    });
+
+    it('returns null when x-tenant-source=platform cookie is set', () => {
+      document.cookie = 'x-tenant-source=platform; path=/';
+      mockPathname = '/';
+      const { container } = render(<Navigation />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders navigation when cookie has a different value', () => {
+      document.cookie = 'x-tenant-source=custom_domain; path=/';
+      mockPathname = '/map';
+      const { container } = render(<Navigation />);
+
+      expect(container.innerHTML).not.toBe('');
+    });
+
+    it('renders navigation on org routes without platform cookie', () => {
+      mockPathname = '/map';
+      const { container } = render(<Navigation />);
+
+      expect(container.innerHTML).not.toBe('');
+      const mapLinks = screen.getAllByText('Map');
+      expect(mapLinks.length).toBeGreaterThan(0);
+    });
   });
 
-  it('returns null when x-tenant-source=platform cookie is set', () => {
-    document.cookie = 'x-tenant-source=platform; path=/';
-    mockPathname = '/';
-    const { container } = render(<Navigation />);
+  describe('auth-gated nav items', () => {
+    it('hides Manage and Settings when not authenticated', async () => {
+      mockUser = null;
+      mockPathname = '/map';
+      render(<Navigation />);
 
-    // Should render nothing
-    expect(container.innerHTML).toBe('');
-  });
+      // Wait for auth check to resolve
+      await waitFor(() => {
+        expect(screen.queryByText('Manage')).toBeNull();
+      });
+      expect(screen.queryByTitle('Site Settings')).toBeNull();
+    });
 
-  it('renders navigation when cookie has a different value', () => {
-    document.cookie = 'x-tenant-source=custom_domain; path=/';
-    mockPathname = '/map';
-    const { container } = render(<Navigation />);
+    it('shows Manage and Settings when authenticated', async () => {
+      mockUser = { id: 'user-1', email: 'test@test.com' };
+      mockPathname = '/map';
+      render(<Navigation />);
 
-    expect(container.innerHTML).not.toBe('');
-  });
-
-  it('renders navigation on org routes without platform cookie', () => {
-    mockPathname = '/map';
-    const { container } = render(<Navigation />);
-
-    expect(container.innerHTML).not.toBe('');
-    // Check that map link exists (getAllByText since desktop + mobile)
-    const mapLinks = screen.getAllByText('Map');
-    expect(mapLinks.length).toBeGreaterThan(0);
+      await waitFor(() => {
+        // Desktop nav has text "Manage", mobile has "Manage" too
+        expect(screen.getAllByText('Manage').length).toBeGreaterThan(0);
+      });
+    });
   });
 });

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -2,13 +2,22 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useConfig } from '@/lib/config/client';
+import { createClient } from '@/lib/supabase/client';
 
 export default function Navigation() {
   const pathname = usePathname();
   const config = useConfig();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsAuthenticated(!!user);
+    });
+  }, []);
 
   // Hide org navigation on platform pages — they render their own PlatformNav.
   // Detect via cookie set by middleware for platform context.
@@ -65,28 +74,32 @@ export default function Navigation() {
                   {link.label}
                 </Link>
               ))}
-              <div className="w-px h-6 bg-sage-light mx-2" />
-              <Link
-                href="/manage"
-                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isManage && !pathname.startsWith('/admin/settings')
-                    ? 'bg-forest text-white'
-                    : 'text-sage hover:text-forest-dark hover:bg-sage-light'
-                }`}
-              >
-                Manage
-              </Link>
-              <Link
-                href="/admin/settings"
-                className={`p-2 rounded-lg transition-colors ${
-                  pathname.startsWith('/admin/settings')
-                    ? 'bg-forest text-white'
-                    : 'text-sage hover:text-forest-dark hover:bg-sage-light'
-                }`}
-                title="Site Settings"
-              >
-                <SettingsIcon className="w-4 h-4" />
-              </Link>
+              {isAuthenticated && (
+                <>
+                  <div className="w-px h-6 bg-sage-light mx-2" />
+                  <Link
+                    href="/manage"
+                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                      isManage && !pathname.startsWith('/admin/settings')
+                        ? 'bg-forest text-white'
+                        : 'text-sage hover:text-forest-dark hover:bg-sage-light'
+                    }`}
+                  >
+                    Manage
+                  </Link>
+                  <Link
+                    href="/admin/settings"
+                    className={`p-2 rounded-lg transition-colors ${
+                      pathname.startsWith('/admin/settings')
+                        ? 'bg-forest text-white'
+                        : 'text-sage hover:text-forest-dark hover:bg-sage-light'
+                    }`}
+                    title="Site Settings"
+                  >
+                    <SettingsIcon className="w-4 h-4" />
+                  </Link>
+                </>
+              )}
             </nav>
           </div>
         </div>
@@ -127,30 +140,34 @@ export default function Navigation() {
                   {link.label}
                 </Link>
               ))}
-              <Link
-                href="/manage"
-                onClick={() => setMobileMenuOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
-                  isManage && !pathname.startsWith('/admin/settings')
-                    ? 'bg-forest text-white'
-                    : 'text-sage hover:bg-sage-light'
-                }`}
-              >
-                <SettingsIcon className="w-5 h-5" />
-                Manage
-              </Link>
-              <Link
-                href="/admin/settings"
-                onClick={() => setMobileMenuOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
-                  pathname.startsWith('/admin/settings')
-                    ? 'bg-forest text-white'
-                    : 'text-sage hover:bg-sage-light'
-                }`}
-              >
-                <GearIcon className="w-5 h-5" />
-                Settings
-              </Link>
+              {isAuthenticated && (
+                <>
+                  <Link
+                    href="/manage"
+                    onClick={() => setMobileMenuOpen(false)}
+                    className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                      isManage && !pathname.startsWith('/admin/settings')
+                        ? 'bg-forest text-white'
+                        : 'text-sage hover:bg-sage-light'
+                    }`}
+                  >
+                    <SettingsIcon className="w-5 h-5" />
+                    Manage
+                  </Link>
+                  <Link
+                    href="/admin/settings"
+                    onClick={() => setMobileMenuOpen(false)}
+                    className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                      pathname.startsWith('/admin/settings')
+                        ? 'bg-forest text-white'
+                        : 'text-sage hover:bg-sage-light'
+                    }`}
+                  >
+                    <GearIcon className="w-5 h-5" />
+                    Settings
+                  </Link>
+                </>
+              )}
             </nav>
           </div>
         )}


### PR DESCRIPTION
## Summary

The Manage tab and Settings gear icon in the navigation were visible to all visitors, including unauthenticated users. They should only show for authenticated users.

## Changes

- Navigation component checks auth state via `supabase.auth.getUser()` on mount
- Manage link and Settings icon (desktop nav, mobile hamburger menu) wrapped in `isAuthenticated` guard
- Links hidden by default, shown only after auth check confirms a logged-in user

## Tests (170 passing)

- Added: "hides Manage and Settings when not authenticated"
- Added: "shows Manage and Settings when authenticated"

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)