### PR TITLE
Fix: don't prompt for location permission on non-map pages

### DIFF
--- a/src/lib/location/provider.tsx
+++ b/src/lib/location/provider.tsx
@@ -86,15 +86,17 @@ export function UserLocationProvider({ children }: { children: ReactNode }) {
     startWatching();
   }, [startWatching]);
 
-  // Start watching on mount
+  // Clean up watcher on unmount — don't auto-start on mount.
+  // Location tracking only begins when startTracking() is called
+  // (e.g., by the map's locate button). This prevents the browser
+  // from prompting for location permission on non-map pages.
   useEffect(() => {
-    startWatching();
     return () => {
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current);
       }
     };
-  }, [startWatching]);
+  }, []);
 
   return (
     <LocationContext.Provider


### PR DESCRIPTION
## Summary

The browser's location permission prompt was appearing on every page load — including the platform landing page, about page, and list view — because `UserLocationProvider` called `navigator.geolocation.watchPosition()` automatically on mount.

## Root Cause

`UserLocationProvider` (in the root layout, wrapping all pages) had a `useEffect` that called `startWatching()` on mount. This triggered the geolocation permission prompt regardless of whether the page had a map.

## Fix

Changed to lazy initialization: the provider mounts globally but does **not** activate geolocation until `startTracking()` is explicitly called. The map's `LocateButton` component calls `startTracking()` when the user clicks the locate button — this is the only place that should trigger the permission prompt.

## Before/After

- **Before**: Visit any page → browser prompts "Allow location access?"
- **After**: Visit any page → no prompt. Click locate button on map → prompt appears.

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)