### PR TITLE
fix: admin mobile scroll and tokens & grants layout

### DIFF
--- a/src/app/admin/AdminShell.tsx
+++ b/src/app/admin/AdminShell.tsx
@@ -73,7 +73,7 @@ export function AdminShell({
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="h-screen flex flex-col overflow-hidden">
       {/* Top header bar */}
       <div className="bg-amber-800 text-white flex-shrink-0">
         <div className="px-4 flex items-center justify-between h-12">

--- a/src/app/admin/access/page.tsx
+++ b/src/app/admin/access/page.tsx
@@ -472,7 +472,7 @@ export default function AccessPage() {
               : 'text-sage hover:text-forest-dark'
           }`}
         >
-          Tokens &amp; Grants
+          Tokens & Grants
         </button>
       </div>
 
@@ -642,8 +642,6 @@ export default function AccessPage() {
               <EmptyState
                 title="No tokens"
                 description="Create an anonymous access token to allow public access to properties."
-                actionLabel="+ Create Token"
-                onAction={() => setShowCreateToken(true)}
               />
             ) : (
               <div className="card overflow-hidden p-0">
@@ -844,8 +842,6 @@ export default function AccessPage() {
               <EmptyState
                 title="No grants"
                 description="Create a temporary access grant to give time-limited access to a user."
-                actionLabel="+ Create Grant"
-                onAction={() => setShowCreateGrant(true)}
               />
             ) : (
               <div className="card overflow-hidden p-0">


### PR DESCRIPTION
Fixes two bugs reported from mobile testing.

## #76 — Mobile admin view does not scroll to bottom

**Root cause:** `AdminShell` used `min-h-screen` on the root div, which lets the flex container grow beyond the viewport height. This prevents `overflow-auto` on `<main>` from ever activating — content just overflows instead of scrolling.

**Fix:** Change root div to `h-screen overflow-hidden` so the flex layout is constrained to the viewport and `overflow-auto` on `<main>` works correctly on all screen sizes.

## #77 — Tokens & Grants: confusing layout with 4 create buttons

**Root cause:** Each section (Tokens, Grants) had a create button in the header *and* an `actionLabel` on the `EmptyState` component, producing 2–4 create buttons visible at once.

**Fix:** Remove `actionLabel`/`onAction` from both `EmptyState` calls. The header toggle button is the single, consistent entry point for creating tokens and grants.

Also fixed HTML entity `&amp;` → `&` in the tab label.

Closes #76
Closes #77