### PR TITLE
fix: property admin mobile - dismissable menu and fix letter cutoff (#64)

### DIFF
--- a/e2e/tests/admin/property-admin-mobile.spec.ts
+++ b/e2e/tests/admin/property-admin-mobile.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { TEST_DATA } from '../../fixtures/test-data';
+
+const ADMIN_AUTH = path.join(__dirname, '..', '..', '.auth', 'admin.json');
+
+test.describe('Property Admin Mobile', () => {
+  test.use({
+    storageState: ADMIN_AUTH,
+    viewport: { width: 375, height: 667 },
+  });
+
+  test('hamburger button is visible at mobile width', async ({ page }) => {
+    await page.goto(`/admin/properties/${TEST_DATA.property.slug}/settings`);
+    await page.waitForLoadState('networkidle');
+
+    const hamburger = page.getByRole('button', { name: 'Open menu' });
+    await expect(hamburger).toBeVisible({ timeout: 10000 });
+  });
+
+  test('clicking hamburger opens the drawer', async ({ page }) => {
+    await page.goto(`/admin/properties/${TEST_DATA.property.slug}/settings`);
+    await page.waitForLoadState('networkidle');
+
+    const hamburger = page.getByRole('button', { name: 'Open menu' });
+    await expect(hamburger).toBeVisible({ timeout: 10000 });
+    await hamburger.click();
+
+    // Drawer nav should be visible — look for a nav link that's only in the drawer
+    const settingsLink = page.getByRole('link', { name: 'Settings' }).first();
+    await expect(settingsLink).toBeVisible({ timeout: 5000 });
+  });
+
+  test('clicking backdrop closes the drawer', async ({ page }) => {
+    await page.goto(`/admin/properties/${TEST_DATA.property.slug}/settings`);
+    await page.waitForLoadState('networkidle');
+
+    const hamburger = page.getByRole('button', { name: 'Open menu' });
+    await expect(hamburger).toBeVisible({ timeout: 10000 });
+    await hamburger.click();
+
+    // Wait for drawer to open
+    await expect(page.locator('.fixed.inset-0')).toBeVisible({ timeout: 5000 });
+
+    // Click the semi-transparent backdrop (the div with aria-hidden inside the overlay)
+    await page.locator('div[aria-hidden="true"]').click({ force: true });
+
+    // Drawer should be dismissed
+    await expect(page.locator('.fixed.inset-0')).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/src/__tests__/property-admin-layout.test.tsx
+++ b/src/__tests__/property-admin-layout.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PropertyAdminLayout from '@/app/admin/properties/[slug]/layout';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: 'test-prop' }),
+  usePathname: () => '/admin/properties/test-prop/settings',
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === 'properties') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({ data: { name: 'Elm Preserve', org_id: 'org-1' } }),
+            }),
+          }),
+        };
+      }
+      if (table === 'entity_types') {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => Promise.resolve({ data: [] }),
+            }),
+          }),
+        };
+      }
+      return { select: () => ({}) };
+    },
+  }),
+}));
+
+describe('PropertyAdminLayout (mobile)', () => {
+  it('renders hamburger button with correct aria-label', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    const btn = screen.getByRole('button', { name: 'Open menu' });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it('hamburger button is inside md:hidden container', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    const btn = screen.getByRole('button', { name: 'Open menu' });
+    const mobileNav = btn.closest('.md\\:hidden');
+    expect(mobileNav).toBeInTheDocument();
+  });
+
+  it('drawer is not rendered initially', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    // No backdrop visible before opening
+    expect(screen.queryByRole('navigation', { hidden: false })).not.toBeNull();
+    // There should be exactly one nav (the desktop one in hidden md:block)
+    const navs = screen.getAllByRole('navigation');
+    expect(navs).toHaveLength(1);
+  });
+
+  it('clicking hamburger opens the drawer (second nav appears)', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    const btn = screen.getByRole('button', { name: 'Open menu' });
+    fireEvent.click(btn);
+    const navs = screen.getAllByRole('navigation');
+    expect(navs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('clicking the backdrop closes the drawer', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getAllByRole('navigation').length).toBeGreaterThanOrEqual(2);
+    // Click the backdrop (aria-hidden div)
+    const backdrop = document.querySelector('div[aria-hidden="true"]') as HTMLElement;
+    expect(backdrop).toBeTruthy();
+    fireEvent.click(backdrop);
+    expect(screen.getAllByRole('navigation')).toHaveLength(1);
+  });
+
+  it('desktop sidebar is wrapped in hidden md:block container', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    const nav = screen.getByRole('navigation');
+    expect(nav.parentElement?.className).toContain('hidden');
+    expect(nav.parentElement?.className).toContain('md:block');
+  });
+
+  it('content area does not have negative margin class', () => {
+    const { container } = render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    const allDivs = container.querySelectorAll('div');
+    allDivs.forEach((div) => {
+      expect(div.className).not.toContain('-m-6');
+    });
+  });
+
+  it('renders children in the content area', () => {
+    render(<PropertyAdminLayout><div data-testid="child">hello</div></PropertyAdminLayout>);
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('property name shown in mobile nav bar', async () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    await waitFor(() => {
+      const matches = screen.getAllByText('Elm Preserve');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('drawer nav items close drawer on click', () => {
+    render(<PropertyAdminLayout><div>content</div></PropertyAdminLayout>);
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getAllByRole('navigation').length).toBeGreaterThanOrEqual(2);
+    // Click one of the nav links in the drawer
+    const drawerNavs = screen.getAllByRole('navigation');
+    const drawerLinks = drawerNavs[0].querySelectorAll('a');
+    if (drawerLinks.length > 0) {
+      fireEvent.click(drawerLinks[0]);
+      expect(screen.getAllByRole('navigation')).toHaveLength(1);
+    }
+  });
+});

--- a/src/app/admin/properties/[slug]/layout.tsx
+++ b/src/app/admin/properties/[slug]/layout.tsx
@@ -11,6 +11,7 @@ export default function PropertyAdminLayout({ children }: { children: React.Reac
   const slug = params.slug as string;
   const [propertyName, setPropertyName] = useState(slug);
   const [entityTypes, setEntityTypes] = useState<EntityType[]>([]);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   useEffect(() => {
     const supabase = createClient();
@@ -44,15 +45,60 @@ export default function PropertyAdminLayout({ children }: { children: React.Reac
     { label: 'Invites', href: `${base}/invites` },
   ];
 
+  const backLink = { label: 'Back to Org', href: '/admin' };
+
   return (
-    <div className="flex flex-1 -m-6">
-      <AdminSidebar
-        title={propertyName}
-        items={items}
-        backLink={{ label: 'Back to Org', href: '/admin' }}
-      />
-      <div className="flex-1 p-6">
-        {children}
+    <div className="flex flex-col flex-1">
+      {/* Mobile top nav bar */}
+      <div className="md:hidden bg-parchment border-b border-sage-light flex-shrink-0">
+        <div className="px-4 flex items-center h-12 gap-3">
+          <button
+            aria-label="Open menu"
+            onClick={() => setDrawerOpen(true)}
+            className="text-forest-dark/80 hover:text-forest-dark transition-colors"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <rect x="2" y="4" width="16" height="2" rx="1" />
+              <rect x="2" y="9" width="16" height="2" rx="1" />
+              <rect x="2" y="14" width="16" height="2" rx="1" />
+            </svg>
+          </button>
+          <span className="text-sm font-medium text-forest-dark">{propertyName}</span>
+        </div>
+      </div>
+
+      {/* Mobile drawer overlay */}
+      {drawerOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setDrawerOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute left-0 top-0 bottom-0 shadow-xl">
+            <AdminSidebar
+              title={propertyName}
+              items={items}
+              backLink={backLink}
+              onNavClick={() => setDrawerOpen(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Body: sidebar + content */}
+      <div className="flex flex-1">
+        {/* Desktop sidebar — hidden on mobile */}
+        <div className="hidden md:block">
+          <AdminSidebar
+            title={propertyName}
+            items={items}
+            backLink={backLink}
+          />
+        </div>
+        <div className="flex-1 p-6">
+          {children}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #64

- Remove `-m-6` negative margin causing letter cutoff
- Add mobile hamburger + dismissable overlay drawer
- 10 unit tests
- Playwright e2e mobile sidebar test