### PR TITLE
fix: mobile UX improvements - touch targets, spacing (#mobile-audit)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -91,17 +91,17 @@ export default function OrgDashboardPage() {
 
       {/* Summary cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
-        <Link href="/admin/properties" className="card hover:shadow-md transition-shadow">
+        <Link href="/admin/properties" className="card py-4 md:py-6 hover:shadow-md transition-shadow">
           <p className="text-xs font-medium text-sage uppercase tracking-wide mb-1">Properties</p>
           <p className="text-3xl font-semibold text-forest-dark">{properties.length}</p>
         </Link>
 
-        <Link href="/admin/members" className="card hover:shadow-md transition-shadow">
+        <Link href="/admin/members" className="card py-4 md:py-6 hover:shadow-md transition-shadow">
           <p className="text-xs font-medium text-sage uppercase tracking-wide mb-1">Members</p>
           <p className="text-3xl font-semibold text-forest-dark">{membersCount}</p>
         </Link>
 
-        <Link href="/admin/domains" className="card hover:shadow-md transition-shadow">
+        <Link href="/admin/domains" className="card py-4 md:py-6 hover:shadow-md transition-shadow">
           <p className="text-xs font-medium text-sage uppercase tracking-wide mb-1">Custom Domains</p>
           <p className="text-3xl font-semibold text-forest-dark">{domainsCount}</p>
         </Link>

--- a/src/app/admin/properties/[slug]/entity-types/page.tsx
+++ b/src/app/admin/properties/[slug]/entity-types/page.tsx
@@ -131,15 +131,15 @@ export default function EntityTypesPage() {
                 </p>
               </div>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-1 flex-wrap">
               <a
                 href={`entities/${et.id}`}
-                className="text-xs text-forest hover:text-forest-dark"
+                className="text-xs text-forest hover:text-forest-dark py-2 px-3 min-h-[44px] flex items-center"
               >
                 Manage
               </a>
-              <button onClick={() => setEditing(et)} className="text-xs text-forest hover:text-forest-dark">Edit</button>
-              <button onClick={() => handleDelete(et)} className="text-xs text-red-600 hover:text-red-800">Delete</button>
+              <button onClick={() => setEditing(et)} className="text-xs text-forest hover:text-forest-dark py-2 px-3 min-h-[44px] flex items-center">Edit</button>
+              <button onClick={() => handleDelete(et)} className="text-xs text-red-600 hover:text-red-800 py-2 px-3 min-h-[44px] flex items-center">Delete</button>
             </div>
           </div>
         ))}

--- a/src/components/manage/LocationPicker.tsx
+++ b/src/components/manage/LocationPicker.tsx
@@ -114,7 +114,7 @@ function CoordinateInputs({
   const inputBase = 'input-field w-28 text-xs py-1 px-2';
 
   return (
-    <div className={`flex items-center gap-2 ${className ?? ''}`}>
+    <div className={`flex items-center gap-2 flex-wrap ${className ?? ''}`}>
       <label className="text-xs text-sage font-medium">Lat</label>
       <input
         type="text"


### PR DESCRIPTION
Improves mobile usability based on visual review of e2e screenshots:

- Larger touch targets for action buttons (Manage/Edit/Delete) on entity types page — `min-h-[44px]` with `py-2 px-3`, buttons wrap on narrow screens
- Tighter mobile padding on admin dashboard stat cards — `py-4 md:py-6`
- `CoordinateInputs` row in LocationPicker now wraps on narrow viewports

No functional changes.