### PR TITLE
fix: auth session UX — stale sessions, existing login detection, user indicator

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -33,6 +33,10 @@ export async function GET(request: Request) {
       }
     );
 
+    // Clear any existing session so the code exchange creates a clean session
+    // for the verified user — prevents stale sessions from interfering
+    await supabase.auth.signOut();
+
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import Footer from '@/components/layout/Footer';
@@ -18,6 +18,18 @@ function LoginForm() {
   );
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [existingUser, setExistingUser] = useState<string | null>(null);
+  const [checkingSession, setCheckingSession] = useState(true);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user?.email) {
+        setExistingUser(user.email);
+      }
+      setCheckingSession(false);
+    });
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -57,6 +69,52 @@ function LoginForm() {
       setGoogleLoading(false);
     }
     // On success the browser navigates away; no need to reset loading state
+  }
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    setExistingUser(null);
+  }
+
+  if (checkingSession) {
+    return (
+      <div className="w-full max-w-sm flex justify-center py-16">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (existingUser) {
+    return (
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <span className="text-4xl mb-3 block">📍</span>
+          <h1 className="font-heading text-2xl font-semibold text-forest-dark">
+            Welcome back
+          </h1>
+        </div>
+        <div className="card space-y-4 text-center">
+          <p className="text-sm text-gray-600">
+            You&apos;re signed in as
+          </p>
+          <p className="font-medium text-gray-900">{existingUser}</p>
+          <a
+            href="/"
+            className="btn-primary w-full block text-center"
+          >
+            Continue to your organization &rarr;
+          </a>
+          <button
+            type="button"
+            onClick={handleSignOut}
+            className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            Sign in as a different account
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import PlatformNav from '@/components/platform/PlatformNav';
 import PlatformFooter from '@/components/platform/PlatformFooter';
@@ -13,6 +13,18 @@ export default function SignUpPage() {
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [existingUser, setExistingUser] = useState<string | null>(null);
+  const [checkingSession, setCheckingSession] = useState(true);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user?.email) {
+        setExistingUser(user.email);
+      }
+      setCheckingSession(false);
+    });
+  }, []);
 
   async function handleGoogleSignUp() {
     setError('');
@@ -62,12 +74,45 @@ export default function SignUpPage() {
     setLoading(false);
   }
 
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    setExistingUser(null);
+  }
+
   return (
     <div className="flex min-h-screen flex-col">
       <PlatformNav minimal />
 
       <main className="flex flex-1 items-start justify-center px-4 pt-16 pb-16">
         <div className="w-full max-w-md mx-auto mt-0 p-8 bg-white shadow-lg rounded-xl">
+          {checkingSession ? (
+            <div className="flex justify-center py-8">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+            </div>
+          ) : existingUser ? (
+            <div className="text-center space-y-4">
+              <h1 className="text-2xl font-bold text-gray-900">Welcome back</h1>
+              <p className="text-sm text-gray-600">
+                You&apos;re signed in as
+              </p>
+              <p className="font-medium text-gray-900">{existingUser}</p>
+              <a
+                href="/"
+                className="block w-full rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 transition-colors text-center"
+              >
+                Continue to your organization &rarr;
+              </a>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+              >
+                Sign up with a different account
+              </button>
+            </div>
+          ) : (
+          <>
           <h1 className="text-2xl font-bold text-gray-900 text-center mb-6">
             Start your free trial
           </h1>
@@ -176,6 +221,8 @@ export default function SignUpPage() {
               Sign in
             </Link>
           </p>
+          </>
+          )}
         </div>
       </main>
 

--- a/src/components/platform/PlatformNav.tsx
+++ b/src/components/platform/PlatformNav.tsx
@@ -1,12 +1,31 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { createClient } from '@/lib/supabase/client';
 
 interface PlatformNavProps {
   minimal?: boolean;
 }
 
 export default function PlatformNav({ minimal = false }: PlatformNavProps) {
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user?.email) {
+        setUserEmail(user.email);
+      }
+    });
+  }, []);
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    window.location.href = '/';
+  }
+
   const logo = (
     <Link href="/" className="flex items-center text-xl font-bold tracking-tight">
       <span className="text-indigo-500">Field</span>
@@ -14,17 +33,31 @@ export default function PlatformNav({ minimal = false }: PlatformNavProps) {
     </Link>
   );
 
+  const userIndicator = userEmail ? (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-gray-600 hidden sm:inline">{userEmail}</span>
+      <button
+        onClick={handleSignOut}
+        className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+      >
+        Sign out
+      </button>
+    </div>
+  ) : null;
+
   if (minimal) {
     return (
       <nav className="w-full border-b border-gray-100 bg-white">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           {logo}
-          <Link
-            href="/signin"
-            className="text-sm font-medium text-gray-600 hover:text-indigo-600 transition-colors"
-          >
-            Sign In
-          </Link>
+          {userIndicator || (
+            <Link
+              href="/signin"
+              className="text-sm font-medium text-gray-600 hover:text-indigo-600 transition-colors"
+            >
+              Sign In
+            </Link>
+          )}
         </div>
       </nav>
     );
@@ -34,26 +67,28 @@ export default function PlatformNav({ minimal = false }: PlatformNavProps) {
     <nav className="w-full border-b border-gray-100 bg-white">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
         {logo}
-        <div className="flex items-center gap-6">
-          <a
-            href="#features"
-            className="hidden text-sm font-medium text-gray-600 hover:text-indigo-600 transition-colors sm:block"
-          >
-            Features
-          </a>
-          <Link
-            href="/signin"
-            className="hidden rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:border-indigo-400 hover:text-indigo-600 transition-colors sm:block"
-          >
-            Sign In
-          </Link>
-          <Link
-            href="/signup"
-            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 transition-colors"
-          >
-            Start Free Trial
-          </Link>
-        </div>
+        {userIndicator || (
+          <div className="flex items-center gap-6">
+            <a
+              href="#features"
+              className="hidden text-sm font-medium text-gray-600 hover:text-indigo-600 transition-colors sm:block"
+            >
+              Features
+            </a>
+            <Link
+              href="/signin"
+              className="hidden rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:border-indigo-400 hover:text-indigo-600 transition-colors sm:block"
+            >
+              Sign In
+            </Link>
+            <Link
+              href="/signup"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 transition-colors"
+            >
+              Start Free Trial
+            </Link>
+          </div>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary

- Auth callback clears stale session before code exchange, preventing wrong-user redirects after email verification
- Login and signup pages detect existing sessions and show "You're signed in as X" banner with continue/switch options
- PlatformNav shows authenticated user's email + sign out link instead of sign-in buttons

## Problem

When a user verifies a new account (e.g., `user+test@gmail.com`) while already logged in as another account (e.g., via Google OAuth as `user@gmail.com`), the auth callback's org membership lookup could run against the wrong user, redirecting to an unexpected org/domain. Additionally, there was no indication anywhere of which account was active.

## Test plan

- [ ] Type-check passes, 204 unit tests pass
- [ ] Sign in → visit `/signup` → see "You're signed in as X" banner
- [ ] Click "Sign up with a different account" → session clears, form appears
- [ ] Click "Continue to your organization" → redirects to org
- [ ] Same behavior on `/login` page
- [ ] PlatformNav shows email + "Sign out" when authenticated
- [ ] PlatformNav shows "Sign In" when not authenticated
- [ ] Verify new account while logged in as different user → lands on correct destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)