### PR TITLE
fix: auto-populate lat/lng from location name via Nominatim geocoding (#98)

### DIFF
--- a/src/app/onboard/page.tsx
+++ b/src/app/onboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import PlatformNav from '@/components/platform/PlatformNav';
 import { createClient } from '@/lib/supabase/client';
 import { onboardCreateOrg, generateEntityTypeSuggestions } from './actions';
+import { geocodeLocation } from '@/lib/location/geocoding';
 import type { EntityTypeSuggestion } from './actions';
 import { THEME_PRESETS } from '@/lib/config/themes';
 import FileDropZone from '@/components/ai-context/FileDropZone';
@@ -76,6 +77,9 @@ export default function OnboardPage() {
   const [aboutContent, setAboutContent] = useState(
     '# About\n\nDescribe your project here.'
   );
+  const [geocoding, setGeocoding] = useState(false);
+  const [geocodeSuccess, setGeocodeSuccess] = useState('');
+
   const [entityTypeSuggestions, setEntityTypeSuggestions] = useState<
     EntityTypeSuggestion[]
   >([]);
@@ -131,6 +135,27 @@ export default function OnboardPage() {
         });
     });
   }, []);
+
+  useEffect(() => {
+    if (locationName.length < 3) return;
+    setGeocoding(true);
+    setGeocodeSuccess('');
+    const timer = setTimeout(async () => {
+      const result = await geocodeLocation(locationName);
+      setGeocoding(false);
+      if (result) {
+        setLat(result.lat);
+        setLng(result.lng);
+        setZoom(10);
+        setGeocodeSuccess(locationName);
+        setTimeout(() => setGeocodeSuccess(''), 3000);
+      }
+    }, 500);
+    return () => {
+      clearTimeout(timer);
+      setGeocoding(false);
+    };
+  }, [locationName]);
 
   const steps = onboardPath === 'ai' ? AI_STEPS : MANUAL_STEPS;
   const stepIndex = steps.indexOf(step);
@@ -686,6 +711,12 @@ export default function OnboardPage() {
                         placeholder="e.g., Fairbanks, AK"
                       />
                     </div>
+                    {geocoding && (
+                      <p className="text-xs text-indigo-500">📍 Auto-filling coordinates...</p>
+                    )}
+                    {!geocoding && geocodeSuccess && (
+                      <p className="text-xs text-green-600">📍 Coordinates updated for {geocodeSuccess}</p>
+                    )}
                     <div className="grid grid-cols-3 gap-4">
                       <div>
                         <label
@@ -1084,6 +1115,12 @@ export default function OnboardPage() {
                   placeholder="e.g., Fairbanks, AK"
                 />
               </div>
+              {geocoding && (
+                <p className="text-xs text-indigo-500">📍 Auto-filling coordinates...</p>
+              )}
+              {!geocoding && geocodeSuccess && (
+                <p className="text-xs text-green-600">📍 Coordinates updated for {geocodeSuccess}</p>
+              )}
               <div className="grid grid-cols-3 gap-4">
                 <div>
                   <label

--- a/src/lib/location/__tests__/geocoding.test.ts
+++ b/src/lib/location/__tests__/geocoding.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { geocodeLocation } from '../geocoding';
+
+describe('geocodeLocation', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns lat/lng for a valid city query', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ lat: '64.8378', lon: '-147.7164', display_name: 'Fairbanks, AK' }],
+    } as Response);
+
+    const result = await geocodeLocation('Fairbanks, AK');
+
+    expect(result).toEqual({ lat: 64.8378, lng: -147.7164 });
+  });
+
+  it('calls Nominatim with correct URL and headers', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ lat: '51.5074', lon: '-0.1278', display_name: 'London' }],
+    } as Response);
+
+    await geocodeLocation('London');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://nominatim.openstreetmap.org/search?q=London&format=json&limit=1',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'birdhouse-mapper/1.0' }),
+      })
+    );
+  });
+
+  it('returns null when no results found', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    const result = await geocodeLocation('zzznotacityzzzz');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on network error', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await geocodeLocation('London');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on non-ok response', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => [],
+    } as Response);
+
+    const result = await geocodeLocation('London');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/location/geocoding.ts
+++ b/src/lib/location/geocoding.ts
@@ -1,0 +1,21 @@
+export interface GeocodeResult {
+  lat: number;
+  lng: number;
+}
+
+export async function geocodeLocation(
+  query: string
+): Promise<GeocodeResult | null> {
+  try {
+    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1`;
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'birdhouse-mapper/1.0' },
+    });
+    if (!response.ok) return null;
+    const results = await response.json();
+    if (!results.length) return null;
+    return { lat: parseFloat(results[0].lat), lng: parseFloat(results[0].lon) };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #98

Adds debounced Nominatim (OpenStreetMap) geocoding to the onboarding Name & Location step. When the user types a city/location name (3+ chars), lat/lng auto-populate after 500ms. Also applied to the AI-review step location input. No new dependencies — uses native fetch.