### PR TITLE
fix: include org_id when creating invite (#101)

### DIFF
--- a/e2e/fixtures/global-setup.ts
+++ b/e2e/fixtures/global-setup.ts
@@ -1,22 +1,9 @@
 import { chromium, type FullConfig } from '@playwright/test';
 import path from 'path';
 import fs from 'fs';
+// test-data loads .env.test.local on import — must be imported before seed
 import { TEST_DATA } from './test-data';
 import { createTestUser, deleteTestUser, createTestClient } from './seed';
-
-// Load .env.test.local if it exists (for local Docker setup)
-const envPath = path.join(__dirname, '..', '..', '.env.test.local');
-if (fs.existsSync(envPath)) {
-  const envContent = fs.readFileSync(envPath, 'utf-8');
-  for (const line of envContent.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const [key, ...rest] = trimmed.split('=');
-    if (key && !process.env[key]) {
-      process.env[key] = rest.join('=');
-    }
-  }
-}
 
 const AUTH_DIR = path.join(__dirname, '..', '.auth');
 

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -1,3 +1,20 @@
+import path from 'path';
+import fs from 'fs';
+
+// Load .env.test.local BEFORE reading process.env so passwords are available.
+const envPath = path.join(__dirname, '..', '..', '.env.test.local');
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf-8');
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [key, ...rest] = trimmed.split('=');
+    if (key && !process.env[key]) {
+      process.env[key] = rest.join('=');
+    }
+  }
+}
+
 /**
  * Constants matching the seed data in the test Supabase project.
  * These values are seeded once during project setup and never change.

--- a/e2e/tests/admin/invites.spec.ts
+++ b/e2e/tests/admin/invites.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { TEST_DATA } from '../../fixtures/test-data';
+import { createTestClient } from '../../fixtures/seed';
+
+const ADMIN_AUTH = path.join(__dirname, '..', '..', '.auth', 'admin.json');
+
+test.describe('Admin Invites', () => {
+  test.use({ storageState: ADMIN_AUTH });
+
+  test.afterAll(async () => {
+    const client = createTestClient();
+    await client
+      .from('invites')
+      .delete()
+      .like('display_name', 'E2E Test Invite%');
+  });
+
+  test('invites page loads and shows create button', async ({ page }) => {
+    await page.goto(
+      `/admin/properties/${TEST_DATA.property.slug}/invites`
+    );
+
+    await expect(page.locator('h1', { hasText: 'Invites' })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(
+      page.locator('button', { hasText: '+ Create Invite' })
+    ).toBeVisible();
+  });
+
+  test('admin can create an invite and see QR code', async ({ page }) => {
+    await page.goto(
+      `/admin/properties/${TEST_DATA.property.slug}/invites`
+    );
+
+    // Wait for the page to load
+    await expect(
+      page.locator('button', { hasText: '+ Create Invite' })
+    ).toBeVisible({ timeout: 15000 });
+
+    // Click "+ Create Invite" to open the form
+    await page.locator('button', { hasText: '+ Create Invite' }).click();
+
+    // Verify the create form is shown
+    await expect(
+      page.locator('h2', { hasText: 'Create New Invite' })
+    ).toBeVisible();
+
+    // Fill in the display name
+    await page.locator('#invite-name').fill('E2E Test Invite');
+
+    // Submit the form
+    await page.locator('button[type="submit"]', { hasText: 'Generate Invite' }).click();
+
+    // Should transition to the share view with QR code (no org_id error)
+    await expect(
+      page.locator('h2', { hasText: 'Invite Ready' })
+    ).toBeVisible({ timeout: 10000 });
+
+    // QR code SVG should be visible
+    await expect(page.locator('svg').first()).toBeVisible();
+
+    // Invite URL input should contain /invite/ path
+    const urlInput = page.locator('input[readonly]');
+    await expect(urlInput).toBeVisible();
+    const urlValue = await urlInput.inputValue();
+    expect(urlValue).toContain('/invite/');
+
+    // No error should be displayed
+    await expect(page.locator('.bg-red-50')).not.toBeVisible();
+  });
+});

--- a/src/app/admin/properties/[slug]/invites/actions.ts
+++ b/src/app/admin/properties/[slug]/invites/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { getTenantContext } from '@/lib/tenant/server';
 import { generateToken, hashToken } from '@/lib/invites/tokens';
 import { INVITE_LINK_TTL_MS, MAX_ACTIVE_INVITES } from '@/lib/invites/constants';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -32,6 +33,8 @@ export async function createInvite(opts: {
 }) {
   const supabase = createClient();
   const service = createServiceClient();
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
 
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
@@ -58,6 +61,7 @@ export async function createInvite(opts: {
   const { error: insertError } = await service
     .from('invites')
     .insert({
+      org_id: tenant.orgId,
       token: tokenHash,
       created_by: user.id,
       display_name: opts.displayName || null,


### PR DESCRIPTION
## Summary

### Issue #101: Invite creation fails with org_id NOT NULL constraint
- **Root cause:** Migration 009 added a NOT NULL `org_id` column to the `invites` table, but `createInvite()` was never updated to include it
- **Fix:** Resolve tenant context via `getTenantContext()` and pass `org_id` in the invite insert

### Issue #104: Invite claim fails with "Failed to create profile"
- **Root cause:** Migration 010 dropped the `role` column from `users`, but `completeInviteClaim()` still inserted `role: invite.role`
- **Fix:** Remove `role` from the users insert (temp user access is controlled by middleware, not the role column)

### E2E infrastructure
- Moved `.env.test.local` loading into `test-data.ts` to fix password resolution order
- Added `dev:e2e` npm script and `.env.e2e.local` for local/CI test parity (no `PLATFORM_DOMAIN`)
- Enabled anonymous sign-ins in `supabase/config.toml` (required for invite claim flow)
- Added E2E tests: invite creation, and full invite create → claim → redirect flow

Closes #101, closes #104

## Test plan

- [x] TypeScript type-check passes
- [x] All 217 unit tests pass
- [x] E2E: invite creation shows QR code (no org_id error)
- [x] E2E: full invite claim flow — admin creates invite, anon user claims, redirects to /manage
- [x] 41/42 full E2E suite passes (1 pre-existing onboarding FK failure)

## Local E2E workflow

```bash
npm run supabase:setup    # one-time setup
npm run dev:e2e           # terminal 1
npm run test:e2e          # terminal 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)