### PR TITLE
fix: grant org_membership when temp user claims invite

### DIFF
--- a/src/app/invite/[token]/__tests__/actions.test.ts
+++ b/src/app/invite/[token]/__tests__/actions.test.ts
@@ -8,6 +8,7 @@ let deletedAuthUsers: string[] = [];
 
 const validInvite = {
   id: 'invite-1',
+  org_id: 'org-100',
   display_name: 'Volunteer',
   role: 'editor',
   session_expires_at: new Date(Date.now() + 3600_000).toISOString(),
@@ -42,33 +43,50 @@ vi.mock('@/lib/supabase/server', () => ({
         },
       },
     },
-    from: (table: string) => ({
-      select: () => ({
-        eq: () => ({
-          single: () =>
-            Promise.resolve({
-              data: table === 'invites' ? mockInvite : null,
+    from: (table: string) => {
+      // Chainable mock that supports arbitrary .eq/.limit chains
+      const chainable = (): any => {
+        const c: any = {};
+        c.eq = () => c;
+        c.limit = () => c;
+        c.single = () => {
+          if (table === 'invites') {
+            return Promise.resolve({
+              data: mockInvite,
               error: mockInvite ? null : { message: 'not found' },
-            }),
-        }),
-      }),
-      insert: (payload: any) => {
-        inserts[table] = payload;
-        return Promise.resolve({ error: mockInsertError });
-      },
-      update: (payload: any) => {
-        updates[table] = payload;
-        return {
-          eq: () => Promise.resolve({ error: mockUpdateError }),
+            });
+          }
+          if (table === 'roles') {
+            return Promise.resolve({
+              data: { id: 'role-contributor-id' },
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: null, error: null });
         };
-      },
-      delete: () => ({
-        eq: (col: string, val: string) => {
-          if (table === 'users') deletedUsers.push(val);
-          return Promise.resolve({ error: null });
+        return c;
+      };
+
+      return {
+        select: () => chainable(),
+        insert: (payload: any) => {
+          inserts[table] = payload;
+          return Promise.resolve({ error: mockInsertError });
         },
-      }),
-    }),
+        update: (payload: any) => {
+          updates[table] = payload;
+          return {
+            eq: () => Promise.resolve({ error: mockUpdateError }),
+          };
+        },
+        delete: () => ({
+          eq: (col: string, val: string) => {
+            if (table === 'users') deletedUsers.push(val);
+            return Promise.resolve({ error: null });
+          },
+        }),
+      };
+    },
   }),
 }));
 
@@ -130,6 +148,19 @@ describe('completeInviteClaim', () => {
     expect(result).toEqual({ success: true, convertible: true });
     expect(updates.invites.claimed_by).toBe('anon-user-1');
     expect(updates.invites.claimed_at).toBeDefined();
+  });
+
+  it('creates org_membership for the temp user', async () => {
+    await completeInviteClaim('raw-token', 'anon-user-1', 'Test');
+
+    expect(inserts.org_memberships).toBeDefined();
+    expect(inserts.org_memberships).toMatchObject({
+      org_id: 'org-100',
+      user_id: 'anon-user-1',
+      role_id: 'role-contributor-id',
+      status: 'active',
+    });
+    expect(inserts.org_memberships.joined_at).toBeDefined();
   });
 
   it('rejects non-anonymous auth users', async () => {

--- a/src/app/invite/[token]/actions.ts
+++ b/src/app/invite/[token]/actions.ts
@@ -63,7 +63,7 @@ export async function completeInviteClaim(
   // Re-validate token (prevent race conditions)
   const { data: invite, error: inviteError } = await service
     .from('invites')
-    .select('id, display_name, role, session_expires_at, expires_at, claimed_by, convertible')
+    .select('id, org_id, display_name, role, session_expires_at, expires_at, claimed_by, convertible')
     .eq('token', tokenHash)
     .single();
 
@@ -97,6 +97,28 @@ export async function completeInviteClaim(
     // Clean up orphaned anonymous auth user
     await service.auth.admin.deleteUser(userId);
     return { error: `Failed to create profile: ${profileError.message}` };
+  }
+
+  // Grant org membership so RLS policies allow content access.
+  // Map invite role text → org_memberships base_role:
+  //   'editor' → 'contributor', 'admin' → 'org_admin'
+  const baseRole = invite.role === 'admin' ? 'org_admin' : 'contributor';
+  const { data: role } = await service
+    .from('roles')
+    .select('id')
+    .eq('org_id', invite.org_id)
+    .eq('base_role', baseRole)
+    .limit(1)
+    .single();
+
+  if (role) {
+    await service.from('org_memberships').insert({
+      org_id: invite.org_id,
+      user_id: userId,
+      role_id: role.id,
+      status: 'active',
+      joined_at: new Date().toISOString(),
+    });
   }
 
   // Mark invite as claimed


### PR DESCRIPTION
## Summary

Temp users created via invite claim had no `org_membership` row, so RLS policies blocked all content access. The `user_accessible_property_ids()` function returned zero properties → items, updates, and photos were invisible.

**Root cause:** `completeInviteClaim` created the user profile and marked the invite as claimed, but never created an `org_membership` linking the user to the invite's org.

**Fix:** After profile creation, look up the appropriate role (`editor` → `contributor`, `admin` → `org_admin`) in the invite's org and create an `org_membership` with `status: 'active'`.

## Changes

- `src/app/invite/[token]/actions.ts` — add `org_id` to invite select, create `org_membership` after profile insert
- `src/app/invite/[token]/__tests__/actions.test.ts` — add test verifying org_membership creation, update mock for role lookup

## Test plan

- [x] 237 unit tests pass (1 new: org_membership creation)
- [x] 3 invite E2E tests pass (create + claim + invalid token)
- [ ] Production: create invite → scan QR → claim → verify items visible on map

🤖 Generated with [Claude Code](https://claude.com/claude-code)