### PR TITLE
fix: replace top-level await with static imports in test files

### DIFF
--- a/src/app/admin/properties/[slug]/invites/__tests__/actions.test.ts
+++ b/src/app/admin/properties/[slug]/invites/__tests__/actions.test.ts
@@ -82,8 +82,8 @@ vi.mock('@/lib/invites/tokens', () => ({
   hashToken: () => 'hashed-token-abc',
 }));
 
-// Must import AFTER mocks are set up
-const { createInvite } = await import('../actions');
+// vi.mock is hoisted by vitest, so regular imports work
+import { createInvite } from '../actions';
 
 const validOpts = {
   displayName: 'Test User',

--- a/src/app/invite/[token]/__tests__/actions.test.ts
+++ b/src/app/invite/[token]/__tests__/actions.test.ts
@@ -94,7 +94,7 @@ vi.mock('@/lib/invites/tokens', () => ({
   hashToken: (token: string) => `hashed-${token}`,
 }));
 
-const { completeInviteClaim, validateInviteToken } = await import('../actions');
+import { completeInviteClaim, validateInviteToken } from '../actions';
 
 describe('completeInviteClaim', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

CI type-check fails because test files use top-level `await import()` which requires `module: 'esnext'` in tsconfig. Replace with static `import` statements — `vi.mock` is hoisted by vitest so mocks are applied before imports.

Fixes CI failure from #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)