### PR TITLE
feat: pre-populate and lock item when opening Add Update from map

### DIFF
--- a/src/app/manage/update/page.tsx
+++ b/src/app/manage/update/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import UpdateForm from '@/components/manage/UpdateForm';
 
 export default function AddUpdatePage() {
@@ -13,7 +14,9 @@ export default function AddUpdatePage() {
         include photos taken in the field.
       </p>
       <div className="card">
-        <UpdateForm />
+        <Suspense fallback={<div className="py-8 text-center text-sm text-sage">Loading…</div>}>
+          <UpdateForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/manage/UpdateForm.tsx
+++ b/src/components/manage/UpdateForm.tsx
@@ -1,17 +1,23 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import type { Item, UpdateType, EntityType } from '@/lib/types';
+import type { Item, ItemType, UpdateType, EntityType } from '@/lib/types';
 import PhotoUploader from './PhotoUploader';
 import EntitySelect from './EntitySelect';
 import { useUserLocation } from '@/lib/location/provider';
 import { getDistanceToItem } from '@/lib/location/utils';
+import StatusBadge from '@/components/item/StatusBadge';
 
 export default function UpdateForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const preselectedItemId = searchParams.get('item') ?? null;
+  const isLocked = preselectedItemId !== null;
+
   const [items, setItems] = useState<Item[]>([]);
+  const [itemTypes, setItemTypes] = useState<ItemType[]>([]);
   const [updateTypes, setUpdateTypes] = useState<UpdateType[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -20,7 +26,8 @@ export default function UpdateForm() {
   const [autoSelected, setAutoSelected] = useState(false);
   const hasAttemptedAutoSelect = useRef(false);
 
-  const [itemId, setItemId] = useState('');
+  // When locked, seed itemId immediately from URL param
+  const [itemId, setItemId] = useState(preselectedItemId ?? '');
   const [updateTypeId, setUpdateTypeId] = useState('');
   const [content, setContent] = useState('');
   const [updateDate, setUpdateDate] = useState(
@@ -54,6 +61,12 @@ export default function UpdateForm() {
         if (firstGlobal) setUpdateTypeId(firstGlobal.id);
       }
 
+      // Fetch item types for context card icon
+      const { data: itData } = await supabase
+        .from('item_types')
+        .select('*');
+      if (itData) setItemTypes(itData);
+
       // Fetch entity types that link to updates
       const { data: etData } = await supabase
         .from('entity_types')
@@ -66,8 +79,9 @@ export default function UpdateForm() {
     fetchData();
   }, []);
 
-  // Auto-select nearest item if within 100m
+  // Auto-select nearest item if within 100m (only when not locked)
   useEffect(() => {
+    if (isLocked) return;
     if (hasAttemptedAutoSelect.current) return;
     if (!position || items.length === 0) return;
 
@@ -88,13 +102,25 @@ export default function UpdateForm() {
       setItemId(nearest.id);
       setAutoSelected(true);
     }
-  }, [position, items]);
+  }, [position, items, isLocked]);
 
   // Filter update types: show global ones + ones specific to the selected item's type
   const selectedItem = items.find((i) => i.id === itemId);
+  const selectedItemType = selectedItem
+    ? itemTypes.find((t) => t.id === selectedItem.item_type_id)
+    : undefined;
+
   const availableUpdateTypes = updateTypes.filter(
     (t) => t.is_global || (selectedItem && t.item_type_id === selectedItem.item_type_id)
   );
+
+  function handleCancel() {
+    if (isLocked && preselectedItemId) {
+      router.push(`/?item=${preselectedItemId}`);
+    } else {
+      router.back();
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -168,30 +194,55 @@ export default function UpdateForm() {
         </div>
       )}
 
-      <div>
-        <label htmlFor="item" className="label">
-          Item *
-        </label>
-        <select
-          id="item"
-          value={itemId}
-          onChange={(e) => { setItemId(e.target.value); setAutoSelected(false); }}
-          className="input-field"
-          required
+      {isLocked ? (
+        /* Locked item context card */
+        <div
+          className="flex items-center gap-3 rounded-lg border border-sage-light bg-sage-50 px-3 py-2.5"
+          data-testid="locked-item-card"
         >
-          <option value="">Select an item...</option>
-          {items.map((item) => (
-            <option key={item.id} value={item.id}>
-              {item.name}
-            </option>
-          ))}
-        </select>
-        {autoSelected && (
-          <p className="text-xs text-forest mt-1">
-            Auto-selected — you appear to be near this item
-          </p>
-        )}
-      </div>
+          {selectedItemType && (
+            <span className="text-xl leading-none" aria-hidden="true">
+              {selectedItemType.icon}
+            </span>
+          )}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-sm font-medium text-forest-dark">
+              {selectedItem?.name ?? '…'}
+            </span>
+            {selectedItem && (
+              <span className="mt-0.5">
+                <StatusBadge status={selectedItem.status} />
+              </span>
+            )}
+          </div>
+        </div>
+      ) : (
+        /* Open item select dropdown (default / standalone flow) */
+        <div>
+          <label htmlFor="item" className="label">
+            Item *
+          </label>
+          <select
+            id="item"
+            value={itemId}
+            onChange={(e) => { setItemId(e.target.value); setAutoSelected(false); }}
+            className="input-field"
+            required
+          >
+            <option value="">Select an item...</option>
+            {items.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name}
+              </option>
+            ))}
+          </select>
+          {autoSelected && (
+            <p className="text-xs text-forest mt-1">
+              Auto-selected — you appear to be near this item
+            </p>
+          )}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
@@ -266,7 +317,7 @@ export default function UpdateForm() {
           </button>
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={handleCancel}
             className="btn-secondary"
           >
             Cancel

--- a/src/components/manage/__tests__/UpdateForm.test.tsx
+++ b/src/components/manage/__tests__/UpdateForm.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UpdateForm from '@/components/manage/UpdateForm';
+
+// ── Navigation mocks ────────────────────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+let mockSearchParamsGet = vi.fn((_key: string): string | null => null);
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+    refresh: vi.fn(),
+  }),
+  useSearchParams: () => ({
+    get: mockSearchParamsGet,
+  }),
+}));
+
+// ── Location provider mock ───────────────────────────────────────────────────
+vi.mock('@/lib/location/provider', () => ({
+  useUserLocation: () => ({ position: null }),
+}));
+
+vi.mock('@/lib/location/utils', () => ({
+  getDistanceToItem: () => null,
+}));
+
+// ── Child component stubs ────────────────────────────────────────────────────
+vi.mock('@/components/manage/PhotoUploader', () => ({
+  default: () => <div data-testid="photo-uploader" />,
+}));
+
+vi.mock('@/components/manage/EntitySelect', () => ({
+  default: () => <div data-testid="entity-select" />,
+}));
+
+vi.mock('@/components/item/StatusBadge', () => ({
+  default: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+const mockItems = [
+  {
+    id: 'item-1',
+    name: 'Box Alpha',
+    status: 'active',
+    item_type_id: 'type-1',
+    latitude: 0,
+    longitude: 0,
+    description: null,
+    custom_field_values: {},
+    created_at: '',
+    updated_at: '',
+    created_by: null,
+    org_id: 'org-1',
+    property_id: 'prop-1',
+  },
+  {
+    id: 'item-2',
+    name: 'Box Beta',
+    status: 'planned',
+    item_type_id: 'type-1',
+    latitude: 0,
+    longitude: 0,
+    description: null,
+    custom_field_values: {},
+    created_at: '',
+    updated_at: '',
+    created_by: null,
+    org_id: 'org-1',
+    property_id: 'prop-1',
+  },
+];
+
+const mockItemTypes = [
+  { id: 'type-1', name: 'Birdbox', icon: '🐦', color: '#00ff00', sort_order: 1, created_at: '', org_id: 'org-1' },
+];
+
+const mockUpdateTypes = [
+  { id: 'ut-1', name: 'Inspection', icon: '🔍', is_global: true, item_type_id: null, sort_order: 1, org_id: 'org-1' },
+];
+
+function makeChain(data: unknown) {
+  // Make the chain itself a thenable so `await supabase.from(x).select('*')` works
+  const resolved = { data, error: null };
+  const promise = Promise.resolve(resolved);
+  const chain: Record<string, unknown> = {
+    then: (onfulfilled: (v: typeof resolved) => unknown, onrejected?: (e: unknown) => unknown) =>
+      promise.then(onfulfilled, onrejected),
+    catch: (onrejected: (e: unknown) => unknown) => promise.catch(onrejected),
+  };
+  chain.select = () => chain;
+  chain.neq = () => chain;
+  chain.order = () => promise;
+  chain.contains = () => chain;
+  return chain;
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === 'items') return makeChain(mockItems);
+      if (table === 'item_types') return makeChain(mockItemTypes);
+      if (table === 'update_types') return makeChain(mockUpdateTypes);
+      if (table === 'entity_types') return makeChain([]);
+      return makeChain([]);
+    },
+  }),
+}));
+
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('UpdateForm — standalone (no ?item= param)', () => {
+  beforeEach(() => {
+    mockSearchParamsGet = vi.fn(() => null);
+    mockPush.mockReset();
+    mockBack.mockReset();
+  });
+
+  it('renders the item select dropdown', async () => {
+    render(<UpdateForm />);
+    expect(await screen.findByLabelText(/item \*/i)).toBeInTheDocument();
+  });
+
+  it('does NOT render the locked item context card', async () => {
+    render(<UpdateForm />);
+    // Wait for data to load
+    await screen.findByLabelText(/item \*/i);
+    expect(screen.queryByTestId('locked-item-card')).not.toBeInTheDocument();
+  });
+
+  it('Cancel calls router.back()', async () => {
+    render(<UpdateForm />);
+    const cancel = await screen.findByRole('button', { name: /cancel/i });
+    await userEvent.click(cancel);
+    expect(mockBack).toHaveBeenCalledOnce();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+describe('UpdateForm — locked (with ?item=item-1 param)', () => {
+  beforeEach(() => {
+    mockSearchParamsGet = vi.fn((key: string) => (key === 'item' ? 'item-1' : null));
+    mockPush.mockReset();
+    mockBack.mockReset();
+  });
+
+  it('renders the locked item context card, not the dropdown', async () => {
+    render(<UpdateForm />);
+    // Context card should appear after items load
+    await waitFor(() =>
+      expect(screen.getByTestId('locked-item-card')).toBeInTheDocument()
+    );
+    expect(screen.queryByLabelText(/item \*/i)).not.toBeInTheDocument();
+  });
+
+  it('context card shows item name', async () => {
+    render(<UpdateForm />);
+    await waitFor(() =>
+      expect(screen.getByTestId('locked-item-card')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Box Alpha')).toBeInTheDocument();
+  });
+
+  it('context card renders a StatusBadge', async () => {
+    render(<UpdateForm />);
+    await waitFor(() =>
+      expect(screen.getByTestId('locked-item-card')).toBeInTheDocument()
+    );
+    expect(screen.getByTestId('status-badge')).toBeInTheDocument();
+  });
+
+  it('context card shows item type icon', async () => {
+    render(<UpdateForm />);
+    await waitFor(() =>
+      expect(screen.getByTestId('locked-item-card')).toBeInTheDocument()
+    );
+    expect(screen.getByText('🐦')).toBeInTheDocument();
+  });
+
+  it('Cancel navigates to /?item=item-1', async () => {
+    render(<UpdateForm />);
+    const cancel = await screen.findByRole('button', { name: /cancel/i });
+    await userEvent.click(cancel);
+    expect(mockPush).toHaveBeenCalledWith('/?item=item-1');
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Reads `?item=` query param in UpdateForm
- When present: shows a locked item context card (icon, name, status) instead of the item dropdown
- Cancel navigates back to map with item panel re-opened (`/?item=<id>`)
- Standalone /manage/update (no param) behavior unchanged

## UX Improvement
Users tapping 'Add Update' from a map item detail panel no longer need to re-select the item — it is shown and locked at the top of the form.

## Testing
- Existing tests pass
- Added tests for preselected-item locked path