### PR TITLE
fix: raise fixed submit bar above mobile nav tab bar

### DIFF
--- a/src/components/manage/EditItemForm.tsx
+++ b/src/components/manage/EditItemForm.tsx
@@ -285,7 +285,7 @@ export default function EditItemForm({
   );
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6 pb-24 md:pb-0">
+    <form onSubmit={handleSubmit} className="space-y-6 pb-40 md:pb-0">
       {error && (
         <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
           {error}
@@ -504,7 +504,7 @@ export default function EditItemForm({
         </div>
       ))}
 
-      <div className="fixed bottom-0 left-0 right-0 bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.12)] p-4 pb-safe md:relative md:shadow-none md:p-0 md:bg-transparent">
+      <div className="fixed bottom-16 left-0 right-0 bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.12)] p-4 pb-safe md:bottom-0 md:relative md:shadow-none md:p-0 md:bg-transparent">
         <div className="flex gap-3">
           <button type="submit" disabled={saving} className="btn-primary">
             {saving ? 'Saving...' : 'Save Changes'}

--- a/src/components/manage/ItemForm.tsx
+++ b/src/components/manage/ItemForm.tsx
@@ -160,7 +160,7 @@ export default function ItemForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6 pb-24 md:pb-0">
+    <form onSubmit={handleSubmit} className="space-y-6 pb-40 md:pb-0">
       {error && (
         <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
           {error}
@@ -330,7 +330,7 @@ export default function ItemForm() {
         </div>
       ))}
 
-      <div className="fixed bottom-0 left-0 right-0 bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.12)] p-4 pb-safe md:relative md:shadow-none md:p-0 md:bg-transparent">
+      <div className="fixed bottom-16 left-0 right-0 bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.12)] p-4 pb-safe md:bottom-0 md:relative md:shadow-none md:p-0 md:bg-transparent">
         <div className="flex gap-3">
           <button type="submit" disabled={saving} className="btn-primary">
             {saving ? 'Saving...' : 'Add Item'}

--- a/src/components/manage/UpdateForm.tsx
+++ b/src/components/manage/UpdateForm.tsx
@@ -187,7 +187,7 @@ export default function UpdateForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6 pb-24 md:pb-0">
+    <form onSubmit={handleSubmit} className="space-y-6 pb-40 md:pb-0">
       {error && (
         <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
           {error}
@@ -310,7 +310,7 @@ export default function UpdateForm() {
         </div>
       ))}
 
-      <div className="fixed bottom-0 left-0 right-0 bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.12)] p-4 pb-safe md:relative md:shadow-none md:p-0 md:bg-transparent">
+      <div className="fixed bottom-16 left-0 right-0 bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.12)] p-4 pb-safe md:bottom-0 md:relative md:shadow-none md:p-0 md:bg-transparent">
         <div className="flex gap-3">
           <button type="submit" disabled={saving} className="btn-primary">
             {saving ? 'Saving...' : 'Add Update'}


### PR DESCRIPTION
Closes #109

The fixed submit button bar on form pages (Edit Item, Add Item, Add Update) was positioned at bottom-0, placing it behind the mobile tab nav which is also fixed at bottom-0 with h-16.

Fix: position the submit bar at bottom-16 on mobile so it sits above the nav. md:bottom-0 preserves desktop behavior. Form scroll padding increased from pb-24 to pb-40 to account for combined height.

245/245 tests pass, build clean.