### PR TITLE
fix: raise server action body limit and add client-side file size guard for AI context uploads

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,11 @@ const nextConfig = {
       },
     ],
   },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '10mb',
+    },
+  },
 };
 
 module.exports = nextConfig;

--- a/src/app/admin/ai-context/page.tsx
+++ b/src/app/admin/ai-context/page.tsx
@@ -110,8 +110,20 @@ export default function AiContextPage() {
     init();
   }, [loadData]);
 
+  const MAX_FILE_SIZE_MB = 9;
+  const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
   async function handleFilesSelected(files: File[]) {
     if (!orgId || files.length === 0) return;
+
+    // Client-side size guard (server limit is 10 MB including base64 overhead)
+    const oversized = files.filter((f) => f.size > MAX_FILE_SIZE_BYTES);
+    if (oversized.length > 0) {
+      setError(
+        `File${oversized.length > 1 ? 's' : ''} too large (max ${MAX_FILE_SIZE_MB} MB): ${oversized.map((f) => f.name).join(', ')}`
+      );
+      return;
+    }
 
     setUploading(true);
     setSummaryReady(false);


### PR DESCRIPTION
Closes #103

## Problem
Uploading files larger than ~750KB to AI Context caused an unhandled crash:
`Error: Body exceeded 1 MB limit`

This is Next.js's default 1 MB cap on Server Action request bodies. Base64 encoding adds ~33% overhead, so even a 750KB file can exceed 1 MB on the wire.

## Fix

### 1. Raise the server limit (`next.config.js`)
```js
experimental: {
  serverActions: {
    bodySizeLimit: '10mb',
  },
},
```

### 2. Client-side pre-flight guard (`src/app/admin/ai-context/page.tsx`)
Before calling the server action, reject files > 9 MB with a user-friendly error message. The 9 MB client threshold gives headroom for base64 overhead while staying safely under the 10 MB server ceiling.

## Testing
- 245/245 tests pass
- Build clean