### PR TITLE
fix: reliably remove stub default org before E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -100,11 +100,29 @@ jobs:
 
       - name: Seed test data
         run: |
-          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres --quiet -c "
-            DELETE FROM orgs WHERE slug = 'default' AND setup_complete = false;
+          # Remove the stub 'default' org created by migrations (setup_complete=false).
+          # It has no setup_complete=true so it would cause middleware to redirect to /setup.
+          # We must also clear its roles/memberships first to avoid FK RESTRICT violations,
+          # then delete the org itself. Cascade handles role deletion from org side,
+          # but org_memberships.role_id -> roles is RESTRICT so delete memberships first.
+          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres -c "
+            DO \$\$
+            DECLARE
+              stub_org_id uuid;
+            BEGIN
+              SELECT id INTO stub_org_id FROM orgs WHERE slug = 'default' AND setup_complete = false LIMIT 1;
+              IF stub_org_id IS NOT NULL THEN
+                DELETE FROM org_memberships WHERE org_id = stub_org_id;
+                DELETE FROM orgs WHERE id = stub_org_id;
+                RAISE NOTICE 'Deleted stub default org %', stub_org_id;
+              ELSE
+                RAISE NOTICE 'No stub default org found (already cleaned or not present)';
+              END IF;
+            END;
+            \$\$;
           "
           PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres \
-            -f supabase/scripts/seed-test-db.sql --quiet
+            -f supabase/scripts/seed-test-db.sql
 
       - name: Build and start app
         run: npm run build && npm start &

--- a/e2e/fixtures/global-setup.ts
+++ b/e2e/fixtures/global-setup.ts
@@ -15,27 +15,32 @@ async function globalSetup(config: FullConfig) {
 
   const browser = await chromium.launch();
 
+  // Helper: log in via form and save storage state
+  async function loginAndSave(email: string, password: string, storageStatePath: string): Promise<void> {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(`${baseURL}/login`);
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(password);
+    await page.locator('button[type="submit"]').click();
+    try {
+      await page.waitForURL(/\/(map|manage|admin)/, { timeout: 30000 });
+    } catch (err) {
+      // Log current URL to help diagnose failures
+      console.error(`[global-setup] Login failed for ${email}. Current URL: ${page.url()}`);
+      const bodyText = await page.locator('body').innerText().catch(() => '');
+      if (bodyText) console.error('[global-setup] Page body:', bodyText.slice(0, 500));
+      throw err;
+    }
+    await ctx.storageState({ path: storageStatePath });
+    await ctx.close();
+  }
+
   // Log in as admin via the actual login form (sets cookies properly)
-  const adminContext = await browser.newContext();
-  const adminPage = await adminContext.newPage();
-  await adminPage.goto(`${baseURL}/login`);
-  await adminPage.locator('#email').fill(TEST_DATA.admin.email);
-  await adminPage.locator('#password').fill(TEST_DATA.admin.password);
-  await adminPage.locator('button[type="submit"]').click();
-  await adminPage.waitForURL(/\/(map|manage|admin)/, { timeout: 15000 });
-  await adminContext.storageState({ path: path.join(AUTH_DIR, 'admin.json') });
-  await adminContext.close();
+  await loginAndSave(TEST_DATA.admin.email, TEST_DATA.admin.password, path.join(AUTH_DIR, 'admin.json'));
 
   // Log in as editor via the actual login form
-  const editorContext = await browser.newContext();
-  const editorPage = await editorContext.newPage();
-  await editorPage.goto(`${baseURL}/login`);
-  await editorPage.locator('#email').fill(TEST_DATA.editor.email);
-  await editorPage.locator('#password').fill(TEST_DATA.editor.password);
-  await editorPage.locator('button[type="submit"]').click();
-  await editorPage.waitForURL(/\/(map|manage|admin)/, { timeout: 15000 });
-  await editorContext.storageState({ path: path.join(AUTH_DIR, 'editor.json') });
-  await editorContext.close();
+  await loginAndSave(TEST_DATA.editor.email, TEST_DATA.editor.password, path.join(AUTH_DIR, 'editor.json'));
 
   // Onboard user: ensure clean state by removing any org memberships from prior runs.
   // We do NOT delete/recreate the user — the CI workflow pre-creates them via psql


### PR DESCRIPTION
## Root cause

Migration `008` creates a stub `default` org with `setup_complete=false`. Since `seed.sql` now creates auth users directly (added in `32a4bfa`), `supabase start` seeds this stub org *before* the test org is inserted. Tenant resolution (Signal D) picks the **oldest** org first, so after login the middleware sees `setup_complete=false` and redirects `/manage` → `/setup` instead of letting the authenticated user through.

The E2E global setup then times out at `waitForURL(/\/(map|manage|admin)/)` because the browser is stuck at `/setup`.

## Changes

### `.github/workflows/e2e.yml`
- Replace the simple `DELETE FROM orgs WHERE slug='default'` with a `DO` block that explicitly deletes `org_memberships` first, then the org. This avoids any FK RESTRICT violation (`org_memberships.role_id → roles` is RESTRICT by default) that could silently prevent the delete even with `--quiet`.
- Removes `--quiet` from the `seed-test-db.sql` run so errors surface visibly.

### `e2e/fixtures/global-setup.ts`
- Extracts login into a `loginAndSave` helper that logs the current URL and page body on timeout, making future failures immediately diagnosable.
- Increases `waitForURL` timeout from 15s → 30s.