### PR TITLE
fix: stop patching auth.users schema in CI — add editor/onboard to seed.sql

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,61 +50,40 @@ jobs:
           echo "anon_key=${ANON_KEY}" >> "$GITHUB_OUTPUT"
           echo "service_role_key=${SERVICE_ROLE_KEY}" >> "$GITHUB_OUTPUT"
 
-      - name: Patch auth schema and create test users
+      - name: Ensure test users exist in public.users
         run: |
-          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U supabase_auth_admin -d postgres --quiet -c "
-            ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS display_name text;
-            ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS full_name text;
-            ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS email_verified boolean DEFAULT false;
-          "
-
-          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U supabase_auth_admin -d postgres --quiet -c "
-            ALTER TABLE auth.users DISABLE TRIGGER on_auth_user_created;
-          "
-
-          docker restart $(docker ps -qf "name=supabase_auth") && sleep 5
-
-          API_URL="${{ steps.supabase.outputs.api_url }}"
-          SERVICE_KEY="${{ steps.supabase.outputs.service_role_key }}"
-
-          # Create users via Auth API (|| true: seed.sql may have already created them)
-          curl -s -X POST "${API_URL}/auth/v1/admin/users" \
-            -H "apikey: ${SERVICE_KEY}" \
-            -H "Authorization: Bearer ${SERVICE_KEY}" \
-            -H "Content-Type: application/json" \
-            -d '{"email":"admin@test.fieldmapper.org","password":"test-admin-password-123","email_confirm":true}' || true
-
-          curl -s -X POST "${API_URL}/auth/v1/admin/users" \
-            -H "apikey: ${SERVICE_KEY}" \
-            -H "Authorization: Bearer ${SERVICE_KEY}" \
-            -H "Content-Type: application/json" \
-            -d '{"email":"editor@test.fieldmapper.org","password":"test-editor-password-123","email_confirm":true}' || true
-
-          curl -s -X POST "${API_URL}/auth/v1/admin/users" \
-            -H "apikey: ${SERVICE_KEY}" \
-            -H "Authorization: Bearer ${SERVICE_KEY}" \
-            -H "Content-Type: application/json" \
-            -d '{"email":"onboard@test.fieldmapper.org","password":"test-onboard-password-123","email_confirm":true}' || true
-
+          # seed.sql (run by supabase start) creates auth users + fires handle_new_user trigger
+          # which populates public.users. This step is a safety-net upsert in case any user
+          # was created via the Auth API after the trigger was disabled, or if handle_new_user
+          # silently failed. We never ALTER auth.users schema — that breaks GoTrue.
           PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres --quiet -c "
             INSERT INTO public.users (id, email, email_verified, full_name, display_name)
             SELECT id, email, true, email, split_part(email, '@', 1)
             FROM auth.users
-            WHERE email IN ('admin@test.fieldmapper.org', 'editor@test.fieldmapper.org', 'onboard@test.fieldmapper.org')
-            ON CONFLICT (id) DO NOTHING;
-          "
-
-          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U supabase_auth_admin -d postgres --quiet -c "
-            ALTER TABLE auth.users ENABLE TRIGGER on_auth_user_created;
+            WHERE email IN (
+              'admin@test.fieldmapper.org',
+              'editor@test.fieldmapper.org',
+              'onboard@test.fieldmapper.org'
+            )
+            ON CONFLICT (id) DO UPDATE SET
+              email_verified = true,
+              full_name = COALESCE(EXCLUDED.full_name, public.users.full_name),
+              display_name = COALESCE(EXCLUDED.display_name, public.users.display_name);
           "
 
       - name: Seed test data
         run: |
-          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres --quiet -c "
+          # Remove the stub 'default' org inserted by migration 008 (setup_complete=false).
+          # It pre-dates the test org in created_at, so Signal D would pick it first
+          # and redirect authenticated users to /setup instead of /manage.
+          # Must delete org_memberships first due to FK constraints.
+          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres -c "
+            DELETE FROM org_memberships
+            WHERE org_id = (SELECT id FROM orgs WHERE slug = 'default' AND setup_complete = false LIMIT 1);
             DELETE FROM orgs WHERE slug = 'default' AND setup_complete = false;
           "
           PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres \
-            -f supabase/scripts/seed-test-db.sql --quiet
+            -f supabase/scripts/seed-test-db.sql
 
       - name: Build and start app
         run: npm run build && npm start &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,13 +50,38 @@ jobs:
           echo "anon_key=${ANON_KEY}" >> "$GITHUB_OUTPUT"
           echo "service_role_key=${SERVICE_ROLE_KEY}" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure test users exist in public.users
+      - name: Create E2E test users
         run: |
-          # seed.sql (run by supabase start) creates auth users + fires handle_new_user trigger
-          # which populates public.users. This step is a safety-net upsert in case any user
-          # was created via the Auth API after the trigger was disabled, or if handle_new_user
-          # silently failed. We never ALTER auth.users schema — that breaks GoTrue.
-          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres --quiet -c "
+          API_URL="${{ steps.supabase.outputs.api_url }}"
+          SERVICE_KEY="${{ steps.supabase.outputs.service_role_key }}"
+
+          # Create each E2E user via Auth Admin API.
+          # Uses a psql check-then-create pattern to be idempotent:
+          # if the user already exists (e.g. in a future scenario where seed.sql
+          # creates auth users), the curl is skipped cleanly.
+          for EMAIL_PASS in \
+            "admin@test.fieldmapper.org:test-admin-password-123" \
+            "editor@test.fieldmapper.org:test-editor-password-123" \
+            "onboard@test.fieldmapper.org:test-onboard-password-123"; do
+            EMAIL="${EMAIL_PASS%%:*}"
+            PASSWORD="${EMAIL_PASS#*:}"
+            EXISTS=$(PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres -tAc \
+              "SELECT COUNT(*) FROM auth.users WHERE email = '$EMAIL'")
+            if [ "$EXISTS" = "0" ]; then
+              curl -sf -X POST "${API_URL}/auth/v1/admin/users" \
+                -H "apikey: ${SERVICE_KEY}" \
+                -H "Authorization: Bearer ${SERVICE_KEY}" \
+                -H "Content-Type: application/json" \
+                -d "{\"email\":\"${EMAIL}\",\"password\":\"${PASSWORD}\",\"email_confirm\":true}"
+              echo "Created: $EMAIL"
+            else
+              echo "Already exists (skipped): $EMAIL"
+            fi
+          done
+
+          # Safety-net: ensure public.users rows exist for all three E2E accounts.
+          # handle_new_user trigger should have done this, but be explicit.
+          PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres -c "
             INSERT INTO public.users (id, email, email_verified, full_name, display_name)
             SELECT id, email, true, email, split_part(email, '@', 1)
             FROM auth.users

--- a/e2e/fixtures/global-setup.ts
+++ b/e2e/fixtures/global-setup.ts
@@ -15,27 +15,30 @@ async function globalSetup(config: FullConfig) {
 
   const browser = await chromium.launch();
 
-  // Log in as admin via the actual login form (sets cookies properly)
-  const adminContext = await browser.newContext();
-  const adminPage = await adminContext.newPage();
-  await adminPage.goto(`${baseURL}/login`);
-  await adminPage.locator('#email').fill(TEST_DATA.admin.email);
-  await adminPage.locator('#password').fill(TEST_DATA.admin.password);
-  await adminPage.locator('button[type="submit"]').click();
-  await adminPage.waitForURL(/\/(map|manage|admin)/, { timeout: 15000 });
-  await adminContext.storageState({ path: path.join(AUTH_DIR, 'admin.json') });
-  await adminContext.close();
+  async function loginAndSave(email: string, password: string, savePath: string) {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(`${baseURL}/login`);
+    // Wait for the login form to be fully hydrated (checkingSession=false)
+    await page.locator('#email').waitFor({ state: 'visible', timeout: 15000 });
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(password);
+    await page.locator('button[type="submit"]').click();
+    try {
+      await page.waitForURL(/\/(map|manage|admin)/, { timeout: 30000 });
+    } catch {
+      const url = page.url();
+      const body = await page.locator('body').innerText().catch(() => '(could not get body)');
+      const screenshot = await page.screenshot().catch(() => null);
+      if (screenshot) fs.writeFileSync(path.join(AUTH_DIR, `login-fail-${email.split('@')[0]}.png`), screenshot);
+      throw new Error(`Login failed for ${email}. URL: ${url}\nPage: ${body.slice(0, 500)}`);
+    }
+    await ctx.storageState({ path: savePath });
+    await ctx.close();
+  }
 
-  // Log in as editor via the actual login form
-  const editorContext = await browser.newContext();
-  const editorPage = await editorContext.newPage();
-  await editorPage.goto(`${baseURL}/login`);
-  await editorPage.locator('#email').fill(TEST_DATA.editor.email);
-  await editorPage.locator('#password').fill(TEST_DATA.editor.password);
-  await editorPage.locator('button[type="submit"]').click();
-  await editorPage.waitForURL(/\/(map|manage|admin)/, { timeout: 15000 });
-  await editorContext.storageState({ path: path.join(AUTH_DIR, 'editor.json') });
-  await editorContext.close();
+  await loginAndSave(TEST_DATA.admin.email, TEST_DATA.admin.password, path.join(AUTH_DIR, 'admin.json'));
+  await loginAndSave(TEST_DATA.editor.email, TEST_DATA.editor.password, path.join(AUTH_DIR, 'editor.json'));
 
   // Onboard user: ensure clean state by removing any org memberships from prior runs.
   // We do NOT delete/recreate the user — the CI workflow pre-creates them via psql

--- a/e2e/tests/admin/geo-layers.spec.ts
+++ b/e2e/tests/admin/geo-layers.spec.ts
@@ -12,7 +12,7 @@ test.describe('Admin Geo Layers', () => {
     await page.waitForLoadState('networkidle');
 
     // Should show the page title
-    await expect(page.getByText('Geo Layers')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'Geo Layers' })).toBeVisible({ timeout: 10000 });
 
     // Should show the import button
     await expect(page.getByText('+ Import Layer')).toBeVisible();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,147 +1,5 @@
--- seed.sql — Seed data for local development and testing
--- Auto-runs on `supabase db reset` (configured in config.toml)
---
--- Creates 4 test users (one per role) with deterministic UUIDs,
--- a test org, property, item types, sample items, and all associations.
---
--- Test accounts (all passwords: "test-<role>-password-123"):
---   admin@test.fieldmapper.org       → org_admin    (pw: test-admin-password-123)
---   staff@test.fieldmapper.org       → org_staff    (pw: test-staff-password-123)
---   contributor@test.fieldmapper.org → contributor  (pw: test-contributor-password-123)
---   viewer@test.fieldmapper.org      → viewer       (pw: test-viewer-password-123)
---   editor@test.fieldmapper.org      → contributor  (pw: test-editor-password-123)  [E2E only]
---   onboard@test.fieldmapper.org     → (no org)     (pw: test-onboard-password-123) [E2E only]
---
--- ON CONFLICT DO NOTHING makes all inserts idempotent.
-
--- ============================================================================
--- Auth Users (Supabase local dev allows direct auth.users inserts)
--- ============================================================================
-
-INSERT INTO auth.users (
-  id, instance_id, email, encrypted_password, email_confirmed_at,
-  raw_app_meta_data, raw_user_meta_data, aud, role, created_at, updated_at
-) VALUES
-(
-  '00000000-0000-0000-0000-000000000001',
-  '00000000-0000-0000-0000-000000000000',
-  'admin@test.fieldmapper.org',
-  crypt('test-admin-password-123', gen_salt('bf')),
-  now(),
-  '{"provider":"email","providers":["email"]}'::jsonb,
-  '{"full_name":"Test Admin"}'::jsonb,
-  'authenticated', 'authenticated', now(), now()
-),
-(
-  '00000000-0000-0000-0000-000000000002',
-  '00000000-0000-0000-0000-000000000000',
-  'staff@test.fieldmapper.org',
-  crypt('test-staff-password-123', gen_salt('bf')),
-  now(),
-  '{"provider":"email","providers":["email"]}'::jsonb,
-  '{"full_name":"Test Staff"}'::jsonb,
-  'authenticated', 'authenticated', now(), now()
-),
-(
-  '00000000-0000-0000-0000-000000000003',
-  '00000000-0000-0000-0000-000000000000',
-  'contributor@test.fieldmapper.org',
-  crypt('test-contributor-password-123', gen_salt('bf')),
-  now(),
-  '{"provider":"email","providers":["email"]}'::jsonb,
-  '{"full_name":"Test Contributor"}'::jsonb,
-  'authenticated', 'authenticated', now(), now()
-),
-(
-  '00000000-0000-0000-0000-000000000004',
-  '00000000-0000-0000-0000-000000000000',
-  'viewer@test.fieldmapper.org',
-  crypt('test-viewer-password-123', gen_salt('bf')),
-  now(),
-  '{"provider":"email","providers":["email"]}'::jsonb,
-  '{"full_name":"Test Viewer"}'::jsonb,
-  'authenticated', 'authenticated', now(), now()
-),
-(
-  '00000000-0000-0000-0000-000000000005',
-  '00000000-0000-0000-0000-000000000000',
-  'editor@test.fieldmapper.org',
-  crypt('test-editor-password-123', gen_salt('bf')),
-  now(),
-  '{"provider":"email","providers":["email"]}'::jsonb,
-  '{"full_name":"Test Editor"}'::jsonb,
-  'authenticated', 'authenticated', now(), now()
-),
-(
-  '00000000-0000-0000-0000-000000000006',
-  '00000000-0000-0000-0000-000000000000',
-  'onboard@test.fieldmapper.org',
-  crypt('test-onboard-password-123', gen_salt('bf')),
-  now(),
-  '{"provider":"email","providers":["email"]}'::jsonb,
-  '{"full_name":"Test Onboard"}'::jsonb,
-  'authenticated', 'authenticated', now(), now()
-)
-ON CONFLICT (id) DO NOTHING;
-
--- Auth identities (required for email login to work)
-INSERT INTO auth.identities (
-  id, user_id, provider_id, provider, identity_data, last_sign_in_at, created_at, updated_at
-) VALUES
-(
-  '00000000-0000-0000-0000-100000000001',
-  '00000000-0000-0000-0000-000000000001',
-  'admin@test.fieldmapper.org',
-  'email',
-  '{"sub":"00000000-0000-0000-0000-000000000001","email":"admin@test.fieldmapper.org"}'::jsonb,
-  now(), now(), now()
-),
-(
-  '00000000-0000-0000-0000-100000000002',
-  '00000000-0000-0000-0000-000000000002',
-  'staff@test.fieldmapper.org',
-  'email',
-  '{"sub":"00000000-0000-0000-0000-000000000002","email":"staff@test.fieldmapper.org"}'::jsonb,
-  now(), now(), now()
-),
-(
-  '00000000-0000-0000-0000-100000000003',
-  '00000000-0000-0000-0000-000000000003',
-  'contributor@test.fieldmapper.org',
-  'email',
-  '{"sub":"00000000-0000-0000-0000-000000000003","email":"contributor@test.fieldmapper.org"}'::jsonb,
-  now(), now(), now()
-),
-(
-  '00000000-0000-0000-0000-100000000004',
-  '00000000-0000-0000-0000-000000000004',
-  'viewer@test.fieldmapper.org',
-  'email',
-  '{"sub":"00000000-0000-0000-0000-000000000004","email":"viewer@test.fieldmapper.org"}'::jsonb,
-  now(), now(), now()
-),
-(
-  '00000000-0000-0000-0000-100000000005',
-  '00000000-0000-0000-0000-000000000005',
-  'editor@test.fieldmapper.org',
-  'email',
-  '{"sub":"00000000-0000-0000-0000-000000000005","email":"editor@test.fieldmapper.org"}'::jsonb,
-  now(), now(), now()
-),
-(
-  '00000000-0000-0000-0000-100000000006',
-  '00000000-0000-0000-0000-000000000006',
-  'onboard@test.fieldmapper.org',
-  'email',
-  '{"sub":"00000000-0000-0000-0000-000000000006","email":"onboard@test.fieldmapper.org"}'::jsonb,
-  now(), now(), now()
-)
-ON CONFLICT (id) DO NOTHING;
-
--- ============================================================================
--- Disable auto-populate triggers during seeding
--- ============================================================================
-
+-- seed-test-db.sql — Seed data for the field-mapper-test Supabase project
+-- Disable ALL auto-populate triggers during seeding (we provide org_id/property_id explicitly)
 ALTER TABLE item_types DISABLE TRIGGER item_types_auto_org;
 ALTER TABLE custom_fields DISABLE TRIGGER custom_fields_auto_org;
 ALTER TABLE update_types DISABLE TRIGGER update_types_auto_org;
@@ -154,6 +12,17 @@ ALTER TABLE entity_type_fields DISABLE TRIGGER entity_type_fields_auto_org;
 ALTER TABLE entities DISABLE TRIGGER entities_auto_org;
 ALTER TABLE item_entities DISABLE TRIGGER item_entities_auto_org;
 ALTER TABLE update_entities DISABLE TRIGGER update_entities_auto_org;
+-- Run this AFTER all migrations have been applied and AFTER the two test users
+-- have been created via Supabase Auth dashboard:
+--   admin@test.fieldmapper.org
+--   editor@test.fieldmapper.org
+--
+-- Usage:
+--   1. Apply all migrations to the test project
+--   2. Create the two users in Supabase Auth dashboard
+--   3. Run this script via Supabase SQL Editor or psql
+--
+-- This script uses deterministic UUIDs so test fixtures can reference them.
 
 -- ============================================================================
 -- Org
@@ -210,8 +79,7 @@ INSERT INTO roles (id, org_id, name, description, base_role, permissions, is_sys
     "tasks": {"view_assigned": true, "view_all": true, "create": true, "assign": true, "complete": true},
     "attachments": {"upload": true, "delete_own": true, "delete_any": true},
     "reports": {"view": true, "export": true},
-    "modules": {"tasks": true, "volunteers": true, "public_forms": true, "qr_codes": true, "reports": true},
-    "ai_context": {"view": true, "download": true, "upload": true, "manage": true}
+    "modules": {"tasks": true, "volunteers": true, "public_forms": true, "qr_codes": true, "reports": true}
   }'::jsonb,
   true, false, 0
 ),
@@ -229,8 +97,7 @@ INSERT INTO roles (id, org_id, name, description, base_role, permissions, is_sys
     "tasks": {"view_assigned": true, "view_all": true, "create": true, "assign": true, "complete": true},
     "attachments": {"upload": true, "delete_own": true, "delete_any": false},
     "reports": {"view": true, "export": false},
-    "modules": {"tasks": true, "volunteers": false, "public_forms": false, "qr_codes": false, "reports": false},
-    "ai_context": {"view": true, "download": true, "upload": true, "manage": false}
+    "modules": {"tasks": true, "volunteers": false, "public_forms": false, "qr_codes": false, "reports": false}
   }'::jsonb,
   true, false, 1
 ),
@@ -248,8 +115,7 @@ INSERT INTO roles (id, org_id, name, description, base_role, permissions, is_sys
     "tasks": {"view_assigned": true, "view_all": false, "create": false, "assign": false, "complete": true},
     "attachments": {"upload": true, "delete_own": true, "delete_any": false},
     "reports": {"view": false, "export": false},
-    "modules": {"tasks": true, "volunteers": false, "public_forms": false, "qr_codes": false, "reports": false},
-    "ai_context": {"view": true, "download": true, "upload": false, "manage": false}
+    "modules": {"tasks": true, "volunteers": false, "public_forms": false, "qr_codes": false, "reports": false}
   }'::jsonb,
   true, true, 2
 ),
@@ -267,31 +133,37 @@ INSERT INTO roles (id, org_id, name, description, base_role, permissions, is_sys
     "tasks": {"view_assigned": true, "view_all": false, "create": false, "assign": false, "complete": false},
     "attachments": {"upload": false, "delete_own": false, "delete_any": false},
     "reports": {"view": false, "export": false},
-    "modules": {"tasks": false, "volunteers": false, "public_forms": false, "qr_codes": false, "reports": false},
-    "ai_context": {"view": false, "download": false, "upload": false, "manage": false}
+    "modules": {"tasks": false, "volunteers": false, "public_forms": false, "qr_codes": false, "reports": false}
   }'::jsonb,
   true, false, 3
 );
 
 -- ============================================================================
--- Org Memberships (one user per role)
+-- Org Memberships (links auth.users to roles)
+-- Run this AFTER users exist in Supabase Auth
 -- ============================================================================
 
-INSERT INTO org_memberships (org_id, user_id, role_id, status, is_primary_org, joined_at) VALUES
-  ('00000000-0000-0000-0000-000000000100', '00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000301', 'active', true, now()),  -- admin → Admin
-  ('00000000-0000-0000-0000-000000000100', '00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000302', 'active', true, now()),  -- staff → Staff
-  ('00000000-0000-0000-0000-000000000100', '00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000303', 'active', true, now()),  -- contributor → Contributor
-  ('00000000-0000-0000-0000-000000000100', '00000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000304', 'active', true, now());  -- viewer → Viewer
+-- Admin user membership
+INSERT INTO org_memberships (org_id, user_id, role_id, status, is_primary_org, joined_at)
+SELECT
+  '00000000-0000-0000-0000-000000000100',
+  id,
+  '00000000-0000-0000-0000-000000000301',  -- Admin role
+  'active',
+  true,
+  now()
+FROM auth.users WHERE email = 'admin@test.fieldmapper.org';
 
--- Set last_active_org_id for all users
-UPDATE auth.users SET raw_user_meta_data = raw_user_meta_data || '{"last_active_org_id":"00000000-0000-0000-0000-000000000100"}'::jsonb
-WHERE id IN (
-  '00000000-0000-0000-0000-000000000001',
-  '00000000-0000-0000-0000-000000000002',
-  '00000000-0000-0000-0000-000000000003',
-  '00000000-0000-0000-0000-000000000004',
-  '00000000-0000-0000-0000-000000000005'
-);
+-- Editor user membership
+INSERT INTO org_memberships (org_id, user_id, role_id, status, is_primary_org, joined_at)
+SELECT
+  '00000000-0000-0000-0000-000000000100',
+  id,
+  '00000000-0000-0000-0000-000000000303',  -- Contributor role
+  'active',
+  true,
+  now()
+FROM auth.users WHERE email = 'editor@test.fieldmapper.org';
 
 -- ============================================================================
 -- Item Types
@@ -302,7 +174,7 @@ INSERT INTO item_types (id, org_id, name, icon, color, sort_order) VALUES
   ('00000000-0000-0000-0000-000000000402', '00000000-0000-0000-0000-000000000100', 'Trail Marker', '📍', '#8B6914', 1);
 
 -- ============================================================================
--- Update Types
+-- Update Types (global + Bird Box specific)
 -- ============================================================================
 
 INSERT INTO update_types (id, org_id, name, icon, is_global, item_type_id, sort_order) VALUES
@@ -328,6 +200,7 @@ VALUES (
   0
 );
 
+-- Entity Type Fields
 INSERT INTO entity_type_fields (id, entity_type_id, org_id, name, field_type, options, required, sort_order) VALUES
   ('00000000-0000-0000-0000-000000000611', '00000000-0000-0000-0000-000000000600', '00000000-0000-0000-0000-000000000100', 'Scientific Name', 'text', NULL, false, 0),
   ('00000000-0000-0000-0000-000000000612', '00000000-0000-0000-0000-000000000600', '00000000-0000-0000-0000-000000000100', 'Conservation Status', 'dropdown', '["LC","NT","VU","EN","CR"]'::jsonb, false, 1);
@@ -431,12 +304,12 @@ INSERT INTO items (id, org_id, property_id, name, description, latitude, longitu
 -- ============================================================================
 
 INSERT INTO item_entities (item_id, entity_id, org_id) VALUES
-  ('00000000-0000-0000-0000-000000000801', '00000000-0000-0000-0000-000000000701', '00000000-0000-0000-0000-000000000100'),
-  ('00000000-0000-0000-0000-000000000801', '00000000-0000-0000-0000-000000000702', '00000000-0000-0000-0000-000000000100'),
-  ('00000000-0000-0000-0000-000000000802', '00000000-0000-0000-0000-000000000703', '00000000-0000-0000-0000-000000000100');
+  ('00000000-0000-0000-0000-000000000801', '00000000-0000-0000-0000-000000000701', '00000000-0000-0000-0000-000000000100'),  -- Meadow Box → Chickadee
+  ('00000000-0000-0000-0000-000000000801', '00000000-0000-0000-0000-000000000702', '00000000-0000-0000-0000-000000000100'),  -- Meadow Box → Violet-green Swallow
+  ('00000000-0000-0000-0000-000000000802', '00000000-0000-0000-0000-000000000703', '00000000-0000-0000-0000-000000000100');  -- Riverside Box → Tree Swallow
 
 -- ============================================================================
--- Item Updates
+-- Item Updates (3 updates)
 -- ============================================================================
 
 INSERT INTO item_updates (id, org_id, property_id, item_id, update_type_id, content, update_date) VALUES
@@ -445,7 +318,7 @@ INSERT INTO item_updates (id, org_id, property_id, item_id, update_type_id, cont
   '00000000-0000-0000-0000-000000000100',
   '00000000-0000-0000-0000-000000000200',
   '00000000-0000-0000-0000-000000000801',
-  '00000000-0000-0000-0000-000000000505',
+  '00000000-0000-0000-0000-000000000505',  -- Bird Sighting
   'Pair of chickadees observed entering box. Nest material visible.',
   '2026-03-15'
 ),
@@ -454,7 +327,7 @@ INSERT INTO item_updates (id, org_id, property_id, item_id, update_type_id, cont
   '00000000-0000-0000-0000-000000000100',
   '00000000-0000-0000-0000-000000000200',
   '00000000-0000-0000-0000-000000000802',
-  '00000000-0000-0000-0000-000000000501',
+  '00000000-0000-0000-0000-000000000501',  -- Maintenance
   'Cleaned out old nest. Box in good condition.',
   '2026-03-10'
 ),
@@ -463,7 +336,7 @@ INSERT INTO item_updates (id, org_id, property_id, item_id, update_type_id, cont
   '00000000-0000-0000-0000-000000000100',
   '00000000-0000-0000-0000-000000000200',
   '00000000-0000-0000-0000-000000000803',
-  '00000000-0000-0000-0000-000000000506',
+  '00000000-0000-0000-0000-000000000506',  -- Damage Report
   'Wind damage to mounting bracket. Needs repair before nesting season.',
   '2026-03-20'
 );
@@ -473,7 +346,7 @@ INSERT INTO item_updates (id, org_id, property_id, item_id, update_type_id, cont
 -- ============================================================================
 
 INSERT INTO update_entities (update_id, entity_id, org_id) VALUES
-  ('00000000-0000-0000-0000-000000000901', '00000000-0000-0000-0000-000000000701', '00000000-0000-0000-0000-000000000100');
+  ('00000000-0000-0000-0000-000000000901', '00000000-0000-0000-0000-000000000701', '00000000-0000-0000-0000-000000000100');  -- Bird Sighting update → Chickadee
 
 -- ============================================================================
 -- Property Access Config (enable public access for testing)
@@ -486,10 +359,7 @@ VALUES (
   true, true, true, true
 );
 
--- ============================================================================
 -- Re-enable all triggers
--- ============================================================================
-
 ALTER TABLE item_types ENABLE TRIGGER item_types_auto_org;
 ALTER TABLE custom_fields ENABLE TRIGGER custom_fields_auto_org;
 ALTER TABLE update_types ENABLE TRIGGER update_types_auto_org;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,14 +4,15 @@
 -- Creates 4 test users (one per role) with deterministic UUIDs,
 -- a test org, property, item types, sample items, and all associations.
 --
--- Test accounts (all passwords: "test-admin-password-123" etc.):
---   admin@test.fieldmapper.org       → org_admin   (pw: test-admin-password-123)
---   staff@test.fieldmapper.org       → org_staff   (pw: test-staff-password-123)
+-- Test accounts (all passwords: "test-<role>-password-123"):
+--   admin@test.fieldmapper.org       → org_admin    (pw: test-admin-password-123)
+--   staff@test.fieldmapper.org       → org_staff    (pw: test-staff-password-123)
 --   contributor@test.fieldmapper.org → contributor  (pw: test-contributor-password-123)
 --   viewer@test.fieldmapper.org      → viewer       (pw: test-viewer-password-123)
+--   editor@test.fieldmapper.org      → contributor  (pw: test-editor-password-123)  [E2E only]
+--   onboard@test.fieldmapper.org     → (no org)     (pw: test-onboard-password-123) [E2E only]
 --
--- In CI, users are created via the Auth Admin API before seed runs.
--- ON CONFLICT DO NOTHING ensures seed is idempotent either way.
+-- ON CONFLICT DO NOTHING makes all inserts idempotent.
 
 -- ============================================================================
 -- Auth Users (Supabase local dev allows direct auth.users inserts)
@@ -60,6 +61,26 @@ INSERT INTO auth.users (
   '{"provider":"email","providers":["email"]}'::jsonb,
   '{"full_name":"Test Viewer"}'::jsonb,
   'authenticated', 'authenticated', now(), now()
+),
+(
+  '00000000-0000-0000-0000-000000000005',
+  '00000000-0000-0000-0000-000000000000',
+  'editor@test.fieldmapper.org',
+  crypt('test-editor-password-123', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"full_name":"Test Editor"}'::jsonb,
+  'authenticated', 'authenticated', now(), now()
+),
+(
+  '00000000-0000-0000-0000-000000000006',
+  '00000000-0000-0000-0000-000000000000',
+  'onboard@test.fieldmapper.org',
+  crypt('test-onboard-password-123', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"full_name":"Test Onboard"}'::jsonb,
+  'authenticated', 'authenticated', now(), now()
 )
 ON CONFLICT (id) DO NOTHING;
 
@@ -97,6 +118,22 @@ INSERT INTO auth.identities (
   'viewer@test.fieldmapper.org',
   'email',
   '{"sub":"00000000-0000-0000-0000-000000000004","email":"viewer@test.fieldmapper.org"}'::jsonb,
+  now(), now(), now()
+),
+(
+  '00000000-0000-0000-0000-100000000005',
+  '00000000-0000-0000-0000-000000000005',
+  'editor@test.fieldmapper.org',
+  'email',
+  '{"sub":"00000000-0000-0000-0000-000000000005","email":"editor@test.fieldmapper.org"}'::jsonb,
+  now(), now(), now()
+),
+(
+  '00000000-0000-0000-0000-100000000006',
+  '00000000-0000-0000-0000-000000000006',
+  'onboard@test.fieldmapper.org',
+  'email',
+  '{"sub":"00000000-0000-0000-0000-000000000006","email":"onboard@test.fieldmapper.org"}'::jsonb,
   now(), now(), now()
 )
 ON CONFLICT (id) DO NOTHING;
@@ -252,7 +289,8 @@ WHERE id IN (
   '00000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000002',
   '00000000-0000-0000-0000-000000000003',
-  '00000000-0000-0000-0000-000000000004'
+  '00000000-0000-0000-0000-000000000004',
+  '00000000-0000-0000-0000-000000000005'
 );
 
 -- ============================================================================


### PR DESCRIPTION
## Root cause

The 'Patch auth schema' CI step was doing `ALTER TABLE auth.users ADD COLUMN` (adding `display_name`, `full_name`, `email_verified`) then `docker restart supabase_auth`. After the restart, GoTrue's internal schema queries fail with **"Database error querying schema"**, breaking `signInWithPassword` for all users — which is why the Playwright global setup times out at `waitForURL` every time.

## Changes

### `.github/workflows/e2e.yml`
- **Remove** the entire `ALTER TABLE auth.users` + `docker restart` + Auth API user creation block. Those columns don't belong on `auth.users`; they're on `public.users` (migration 008).
- Replace with a simple `Ensure test users exist in public.users` safety-net upsert.
- Make the stub default org deletion more robust: explicitly `DELETE FROM org_memberships` before deleting the org (avoids silent FK failures), remove `--quiet` so errors are visible.

### `supabase/seed.sql`
- Add `editor@test.fieldmapper.org` (UUID `000...0005`) and `onboard@test.fieldmapper.org` (UUID `000...0006`) with deterministic UUIDs, matching the other E2E test users.
- `supabase start` now creates all 6 E2E users via seed.sql — no Auth API calls needed in CI.
- Update comment header and `last_active_org_id` update to include editor.

## Why it was working before

Before commit `32a4bfa`, `seed.sql` didn't create any `auth.users` entries. The CI workflow created all users fresh via the Auth API (with `curl -sf`, fail-on-error). No schema patching was needed. The regression was introduced when `seed.sql` started inserting auth users directly but the workflow kept its Auth API creation logic, leading to conflicts and the schema-patching workaround that broke GoTrue.