### PR TITLE
feat: upgrade Puck text fields to richtext (TipTap)

### DIFF
--- a/src/lib/puck/components/page/Card.tsx
+++ b/src/lib/puck/components/page/Card.tsx
@@ -14,7 +14,11 @@ export function Card({ imageUrl, title, text, linkHref, linkLabel, icon }: CardP
           </div>
         )}
         {title && <h3 className="text-lg font-semibold text-[var(--color-primary-dark)]">{title}</h3>}
-        {text && <p className="mt-2 text-sm text-gray-600">{text}</p>}
+        {text && (
+          typeof text === 'string'
+            ? <div className="mt-2 text-sm text-gray-600 prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: text }} />
+            : <div className="mt-2 text-sm text-gray-600 prose prose-sm max-w-none">{text}</div>
+        )}
         {link.href && linkLabel && (
           <a
             href={link.href}

--- a/src/lib/puck/components/page/RichText.tsx
+++ b/src/lib/puck/components/page/RichText.tsx
@@ -4,22 +4,37 @@ export function RichText({ content, alignment, columns }: RichTextProps) {
   const alignClass = alignment === 'center' ? 'text-center' : 'text-left';
   const colClass = columns === 2 ? 'md:columns-2 md:gap-8' : '';
 
-  const isHtml = content.startsWith('<') || content.includes('<p>') || content.includes('<h');
-
   return (
     <div className={`mx-auto max-w-4xl px-4 py-8 ${alignClass} ${colClass}`}>
       <div className="prose prose-lg max-w-none prose-headings:text-[var(--color-primary-dark)] prose-a:text-[var(--color-primary)]">
-        {isHtml ? (
-          <div dangerouslySetInnerHTML={{ __html: content }} />
-        ) : (
-          <MarkdownContent content={content} />
-        )}
+        <RichTextContent content={content} />
       </div>
     </div>
   );
 }
 
-function MarkdownContent({ content }: { content: string }) {
+/**
+ * Renders rich text content. Handles three formats:
+ * - ReactNode (from Puck richtext field at edit time)
+ * - HTML string (from Puck richtext field when saved)
+ * - Plain text / markdown (legacy textarea content)
+ */
+function RichTextContent({ content }: { content: any }) {
+  // ReactNode from Puck richtext field (not a string)
+  if (typeof content !== 'string') {
+    return <>{content}</>;
+  }
+
+  // Empty content
+  if (!content) return null;
+
+  // HTML string (from saved richtext data)
+  const isHtml = content.startsWith('<') || content.includes('<p>') || content.includes('<h');
+  if (isHtml) {
+    return <div dangerouslySetInnerHTML={{ __html: content }} />;
+  }
+
+  // Legacy plain text / markdown
   const ReactMarkdown = require('react-markdown').default;
   const remarkGfm = require('remark-gfm').default;
   return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;

--- a/src/lib/puck/components/page/Testimonial.tsx
+++ b/src/lib/puck/components/page/Testimonial.tsx
@@ -4,7 +4,12 @@ export function Testimonial({ quote, attribution, photoUrl, style }: Testimonial
   const borderColor = style === 'accent' ? 'border-[var(--color-accent)]' : 'border-[var(--color-primary)]';
   return (
     <blockquote className={`mx-auto max-w-2xl border-l-4 ${borderColor} px-4 py-8 pl-6`}>
-      <p className="text-lg italic text-gray-700">&ldquo;{quote}&rdquo;</p>
+      <div className="text-lg italic text-gray-700 prose prose-lg max-w-none">
+        &ldquo;{typeof quote === 'string'
+          ? <span dangerouslySetInnerHTML={{ __html: quote }} />
+          : <span>{quote}</span>
+        }&rdquo;
+      </div>
       <footer className="mt-4 flex items-center gap-3">
         {photoUrl && <img src={photoUrl} alt={attribution} className="h-10 w-10 rounded-full object-cover" />}
         <cite className="text-sm font-medium not-italic text-gray-600">{attribution}</cite>

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -98,7 +98,7 @@ export const pageConfig: Config<PageComponents> = {
         columns: 1,
       },
       fields: {
-        content: { type: 'textarea', label: 'Content' },
+        content: { type: 'richtext', label: 'Content', contentEditable: true },
         alignment: {
           type: 'radio',
           label: 'Alignment',
@@ -361,7 +361,7 @@ export const pageConfig: Config<PageComponents> = {
       fields: {
         imageUrl: imagePickerField('Image', fetchLandingAssets),
         title: { type: 'text', label: 'Title' },
-        text: { type: 'textarea', label: 'Text' },
+        text: { type: 'richtext', label: 'Text' },
         linkHref: linkField('Link URL'),
         linkLabel: { type: 'text', label: 'Link Label' },
         icon: iconPickerField('Icon'),
@@ -413,7 +413,7 @@ export const pageConfig: Config<PageComponents> = {
         style: 'default',
       },
       fields: {
-        quote: { type: 'textarea', label: 'Quote' },
+        quote: { type: 'richtext', label: 'Quote' },
         attribution: { type: 'text', label: 'Attribution' },
         photoUrl: imagePickerField('Photo', fetchLandingAssets),
         style: {


### PR DESCRIPTION
## Summary

- Switch RichText `content`, Card `text`, and Testimonial `quote` fields from `textarea` to Puck's built-in `richtext` field (TipTap WYSIWYG editor)
- RichText component gets `contentEditable: true` for inline canvas editing
- Component render functions handle three content formats: ReactNode (editor preview), HTML string (saved data), and plain text/markdown (legacy)

## Test plan

- [ ] 467 tests pass
- [ ] RichText component shows TipTap toolbar in Puck editor
- [ ] Card text field shows rich text editor
- [ ] Testimonial quote field shows rich text editor
- [ ] Existing plain text content renders correctly (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)