### PR TITLE
fix: E2E CI build timeout and localhost redirect loop

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,8 +110,8 @@ jobs:
           PGPASSWORD=postgres psql -h 127.0.0.1 -p 54322 -U postgres -d postgres \
             -f supabase/scripts/seed-test-db.sql
 
-      - name: Build and start app
-        run: npm run build && npm start &
+      - name: Build app
+        run: npm run build
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ steps.supabase.outputs.api_url }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ steps.supabase.outputs.anon_key }}
@@ -119,6 +119,13 @@ jobs:
           # PLATFORM_DOMAIN intentionally NOT set — tenant resolution uses
           # Signal D (default org fallback) to pick the seeded test org.
           # Local dev:e2e uses the same approach.
+
+      - name: Start app
+        run: npm start &
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ steps.supabase.outputs.api_url }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ steps.supabase.outputs.anon_key }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ steps.supabase.outputs.service_role_key }}
 
       - name: Wait for app to be ready
         run: |

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -50,6 +50,11 @@ export async function GET(request: Request) {
 
           const org = (membership?.orgs as any);
           if (org?.slug) {
+            const requestHost = new URL(request.url).hostname;
+            // On localhost, stay on the same origin — subdomain URLs don't work
+            if (requestHost === 'localhost') {
+              return NextResponse.redirect(new URL('/manage', origin));
+            }
             // Prefer primary custom domain, fall back to platform subdomain
             const primaryDomain = org.custom_domains?.find((d: any) => d.is_primary)?.domain;
             if (primaryDomain) {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -170,9 +170,10 @@ export async function updateSession(request: NextRequest) {
   // --- Setup complete check ---
   const isSetupRoute = pathname === '/setup' || pathname.startsWith('/setup/');
   const isAuthCallback = pathname.startsWith('/api/auth/');
-  const isStaticAsset = pathname.startsWith('/_next/');
+  const isStaticAsset = pathname.startsWith('/_next/') || pathname.startsWith('/favicon');
+  const isAuthPage = ['/login', '/signup', '/signin'].includes(pathname);
 
-  if (!isSetupRoute && !isAuthCallback && !isStaticAsset) {
+  if (!isSetupRoute && !isAuthCallback && !isStaticAsset && !isAuthPage) {
     const setupDoneCookie = request.cookies.get('setup_done');
 
     if (!setupDoneCookie) {

--- a/src/lib/tenant/__tests__/resolve.test.ts
+++ b/src/lib/tenant/__tests__/resolve.test.ts
@@ -438,13 +438,17 @@ describe('resolveTenant', () => {
       expect(result?.source).toBe('default');
     });
 
-    it('platform domain with port in hostname matches Signal 0', async () => {
+    it('localhost skips Signal 0 even when PLATFORM_DOMAIN=localhost', async () => {
       process.env.PLATFORM_DOMAIN = 'localhost';
-      const client = createMockClient({});
+      const client = createMockClient({
+        orgs: { id: 'org-1', slug: 'test-org', default_property_id: 'prop-1' },
+      });
 
+      // localhost should fall through to Signal D (default org) because
+      // platform context with subdomain-based routing doesn't work on localhost
       const result = await resolveTenant('localhost:3000', '/', client);
 
-      expect(result?.source).toBe('platform');
+      expect(result?.source).toBe('default');
     });
   });
 });

--- a/src/lib/tenant/resolve.ts
+++ b/src/lib/tenant/resolve.ts
@@ -34,7 +34,9 @@ export async function resolveTenant(
   const hostnameWithoutPort = hostname.replace(/:\d+$/, '');
 
   // Signal 0: Platform root — exact match on PLATFORM_DOMAIN with no subdomain
-  if (platformDomain && hostnameWithoutPort === platformDomain) {
+  // Skip on localhost — platform context doesn't make sense for local development
+  // where subdomain-based org routing isn't available
+  if (platformDomain && hostnameWithoutPort === platformDomain && hostnameWithoutPort !== 'localhost') {
     return {
       orgId: null,
       orgSlug: null,


### PR DESCRIPTION
## Summary

- **E2E CI fix:** Separate `npm run build` and `npm start` into distinct workflow steps so the build completes before readiness polling begins. Previously `npm run build && npm start &` backgrounded both, causing the 60s wait to timeout.
- **Localhost routing fix:** Skip platform context (Signal 0) on localhost since subdomain-based org routing doesn't work locally. Exclude `/login`, `/signup`, `/signin` from the setup_complete redirect so users can authenticate. Add localhost guard in auth callback to prevent broken subdomain URL construction.

## Test plan

- [ ] 467 unit tests pass
- [ ] E2E tests pass on CI (was failing every run before this fix)
- [ ] `npm run dev` on localhost: `/login` renders (no redirect loop)
- [ ] `npm run dev` on localhost: `/` redirects to `/setup` or renders landing (no loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)