### PR TITLE
Add React Query for faster admin page transitions

### DIFF
--- a/docs/superpowers/plans/2026-04-01-react-query-caching.md
+++ b/docs/superpowers/plans/2026-04-01-react-query-caching.md
@@ -1,0 +1,1303 @@
+# React Query Caching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add React Query as a client-side caching layer for ~14 admin pages, replacing useEffect+useState patterns with useQuery for stale-while-revalidate caching.
+
+**Architecture:** Install @tanstack/react-query, add a QueryProvider client component to the app layout, then mechanically convert each page's useEffect+useState data fetching to inline useQuery calls. Mutations stay imperative with invalidateQueries after success.
+
+**Tech Stack:** @tanstack/react-query, React, Next.js 14, Supabase
+
+---
+
+### Task 1: Install React Query and create QueryProvider
+
+**Files:**
+- Create: `src/components/QueryProvider.tsx`
+- Modify: `src/app/layout.tsx`
+- Modify: `package.json`
+
+- [ ] **Step 1: Install @tanstack/react-query**
+
+```bash
+npm install @tanstack/react-query
+```
+
+- [ ] **Step 2: Create QueryProvider client component**
+
+Create `src/components/QueryProvider.tsx`:
+
+```tsx
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            gcTime: 300_000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+```
+
+- [ ] **Step 3: Add QueryProvider to app layout**
+
+In `src/app/layout.tsx`, add import at top:
+
+```tsx
+import QueryProvider from '@/components/QueryProvider';
+```
+
+Wrap children inside the OfflineProvider with QueryProvider. Change lines 69-79 from:
+
+```tsx
+<OfflineProvider>
+  {puckRoot ? (
+    <PuckRootRenderer data={puckRoot}>
+      <main className="flex-1">{children}</main>
+    </PuckRootRenderer>
+  ) : (
+    <>
+      <Navigation isAuthenticated={!!user} />
+      <main className="flex-1">{children}</main>
+    </>
+  )}
+</OfflineProvider>
+```
+
+to:
+
+```tsx
+<OfflineProvider>
+  <QueryProvider>
+    {puckRoot ? (
+      <PuckRootRenderer data={puckRoot}>
+        <main className="flex-1">{children}</main>
+      </PuckRootRenderer>
+    ) : (
+      <>
+        <Navigation isAuthenticated={!!user} />
+        <main className="flex-1">{children}</main>
+      </>
+    )}
+  </QueryProvider>
+</OfflineProvider>
+```
+
+- [ ] **Step 4: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/QueryProvider.tsx src/app/layout.tsx package.json package-lock.json
+git commit -m "feat: add React Query provider with 30s stale time"
+```
+
+---
+
+### Task 2: Convert /admin/settings page
+
+**Files:**
+- Modify: `src/app/admin/settings/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+In `src/app/admin/settings/page.tsx`:
+
+Add imports — change line 3 from:
+```tsx
+import { useState, useEffect } from 'react';
+```
+to:
+```tsx
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+```
+
+Remove the `loading` state variable (line 48):
+```tsx
+const [loading, setLoading] = useState(true);
+```
+
+Add useQuery and queryClient after the existing useState declarations (after line 58):
+```tsx
+const queryClient = useQueryClient();
+const { data: settings, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'settings'],
+  queryFn: async () => {
+    const result = await getOrgSettings();
+    if (result.error) {
+      setMessage(`Error: ${result.error}`);
+      return null;
+    }
+    return result.data ?? null;
+  },
+});
+```
+
+Remove the existing `settings` useState (line 47):
+```tsx
+const [settings, setSettings] = useState<OrgSettings | null>(null);
+```
+
+- [ ] **Step 2: Populate form fields from query data**
+
+Replace the entire useEffect block (lines 60-77) with a useEffect that syncs form state from query data:
+```tsx
+useEffect(() => {
+  if (settings) {
+    setName(settings.name ?? '');
+    setSlug(settings.slug ?? '');
+    setTagline(settings.tagline ?? '');
+    setLogoUrl(settings.logo_url ?? '');
+    setThemeJson(settings.theme ? JSON.stringify(settings.theme, null, 2) : '');
+  }
+}, [settings]);
+```
+
+Note: We still need `useEffect` imported for this — update the import:
+```tsx
+import { useState, useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+```
+
+- [ ] **Step 3: Update handleSave to invalidate query**
+
+In `handleSave` (around lines 112-117), replace the manual refetch:
+```tsx
+      // Refresh local settings snapshot
+      const fresh = await getOrgSettings();
+      if (fresh.data) setSettings(fresh.data);
+      router.refresh();
+```
+with:
+```tsx
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'settings'] });
+      router.refresh();
+```
+
+- [ ] **Step 4: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/admin/settings/page.tsx
+git commit -m "feat: convert admin settings page to React Query"
+```
+
+---
+
+### Task 3: Convert /admin/members page
+
+**Files:**
+- Modify: `src/app/admin/members/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Change imports (lines 1-8):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabase/client';
+import { StatusBadge } from '@/components/admin/StatusBadge';
+import { EmptyState } from '@/components/admin/EmptyState';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getOrgMembers, inviteMember } from './actions';
+```
+
+Remove state variables for `members`, `roles`, `loading` (lines 39-41), the `loadData` function (lines 52-72), and the useEffect (lines 74-77).
+
+Replace with useQuery:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'members'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const [membersResult, rolesResult] = await Promise.all([
+      getOrgMembers(),
+      supabase.from('roles').select('id, name, base_role').order('name', { ascending: true }),
+    ]);
+    return {
+      members: (membersResult.members ?? []) as Member[],
+      roles: (rolesResult.data ?? []) as Role[],
+    };
+  },
+});
+
+const members = queryData?.members ?? [];
+const roles = queryData?.roles ?? [];
+```
+
+- [ ] **Step 2: Set default invite role from query data**
+
+Add a useEffect to set default inviteRoleId when roles load. Add `useEffect` back to imports:
+```tsx
+import { useState, useEffect } from 'react';
+```
+
+Add after the useQuery:
+```tsx
+useEffect(() => {
+  if (roles.length > 0 && !inviteRoleId) {
+    setInviteRoleId(roles[0].id);
+  }
+}, [roles, inviteRoleId]);
+```
+
+- [ ] **Step 3: Update handleInvite to invalidate**
+
+In `handleInvite` (line 98), replace:
+```tsx
+    await loadData();
+```
+with:
+```tsx
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'members'] });
+```
+
+- [ ] **Step 4: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/admin/members/page.tsx
+git commit -m "feat: convert admin members page to React Query"
+```
+
+---
+
+### Task 4: Convert /admin/properties page
+
+**Files:**
+- Modify: `src/app/admin/properties/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-13):
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabase/client';
+import { StatusBadge, derivePropertyStatus } from '@/components/admin/StatusBadge';
+import { EmptyState } from '@/components/admin/EmptyState';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createProperty,
+  archiveProperty,
+  unarchiveProperty,
+  getProperties,
+} from './actions';
+```
+
+Remove `properties`, `itemCounts`, `memberCounts`, `customDomains`, `loading` useState declarations (lines 40-44), the `loadProperties` function (lines 55-102), and the useEffect (lines 104-106).
+
+Replace with:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'properties'],
+  queryFn: async () => {
+    const result = await getProperties();
+    if (!result.properties) return { properties: [], itemCounts: {}, memberCounts: {}, customDomains: {} };
+
+    const props = result.properties as Property[];
+    const supabase = createClient();
+    const propertyIds = props.map((p) => p.id);
+
+    const [itemsRes, membershipsRes, domainsRes] = await Promise.all([
+      supabase.from('items').select('property_id').in('property_id', propertyIds),
+      supabase.from('property_memberships').select('property_id').in('property_id', propertyIds),
+      supabase.from('custom_domains').select('property_id, domain').in('property_id', propertyIds).eq('status', 'active'),
+    ]);
+
+    const itemCounts: Record<string, number> = {};
+    if (itemsRes.data) {
+      for (const item of itemsRes.data) {
+        itemCounts[item.property_id] = (itemCounts[item.property_id] || 0) + 1;
+      }
+    }
+
+    const memberCounts: Record<string, number> = {};
+    if (membershipsRes.data) {
+      for (const m of membershipsRes.data) {
+        memberCounts[m.property_id] = (memberCounts[m.property_id] || 0) + 1;
+      }
+    }
+
+    const customDomains: Record<string, string> = {};
+    if (domainsRes.data) {
+      for (const d of domainsRes.data) {
+        customDomains[d.property_id] = d.domain;
+      }
+    }
+
+    return { properties: props, itemCounts, memberCounts, customDomains };
+  },
+});
+
+const properties = queryData?.properties ?? [];
+const itemCounts = queryData?.itemCounts ?? {};
+const memberCounts = queryData?.memberCounts ?? {};
+const customDomains = queryData?.customDomains ?? {};
+```
+
+- [ ] **Step 2: Update handleArchiveToggle to invalidate**
+
+In `handleArchiveToggle` (line 141), replace:
+```tsx
+      await loadProperties();
+```
+with:
+```tsx
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'properties'] });
+```
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/properties/page.tsx
+git commit -m "feat: convert admin properties page to React Query"
+```
+
+---
+
+### Task 5: Convert /admin/properties/[slug]/settings page
+
+**Files:**
+- Modify: `src/app/admin/properties/[slug]/settings/page.tsx`
+
+- [ ] **Step 1: Replace useEffect data fetching with useQuery**
+
+Add import:
+```tsx
+import { useQuery } from '@tanstack/react-query';
+```
+
+Remove `propertyId` useState (line 34), `propertyGeoLayers` useState (line 35), `layerAssignments` useState (line 36), and `currentBoundaryId` useState (line 37).
+
+Remove both useEffect blocks (lines 39-49 and 51-60).
+
+Replace with:
+```tsx
+const { data: propertyId } = useQuery({
+  queryKey: ['admin', 'property', slug, 'id'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const { data } = await supabase.from('properties').select('id').eq('slug', slug).single();
+    return data?.id ?? null;
+  },
+});
+
+const { data: geoLayerData } = useQuery({
+  queryKey: ['admin', 'property', slug, 'geo-layers'],
+  queryFn: async () => {
+    if (!propertyId) return { layers: [] as GeoLayerSummary[], assignments: [] as GeoLayerProperty[], boundaryId: null };
+    const result = await getPropertyGeoLayers(propertyId);
+    if ('success' in result) {
+      return { layers: result.layers, assignments: result.assignments, boundaryId: null };
+    }
+    return { layers: [] as GeoLayerSummary[], assignments: [] as GeoLayerProperty[], boundaryId: null };
+  },
+  enabled: activeTab === 'geo-layers' && !!propertyId,
+});
+
+const propertyGeoLayers = geoLayerData?.layers ?? [];
+const layerAssignments = geoLayerData?.assignments ?? [];
+const [currentBoundaryId, setCurrentBoundaryId] = useState<string | null>(null);
+```
+
+Also remove the `useEffect` import if no longer needed — but we don't use useEffect here anymore, so remove it from the import on line 3. Keep `useState`.
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/settings/page.tsx
+git commit -m "feat: convert property settings page to React Query"
+```
+
+---
+
+### Task 6: Convert /admin/properties/[slug]/data page
+
+**Files:**
+- Modify: `src/app/admin/properties/[slug]/data/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-9):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Item, ItemUpdate, UpdateType, Role } from '@/lib/types';
+import { createClient } from '@/lib/supabase/client';
+import StatusBadge from '@/components/item/StatusBadge';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
+import { formatShortDate } from '@/lib/utils';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+```
+
+Remove `users`, `availableRoles`, `items`, `updates`, `updateTypes`, `loading` useState (lines 24-29) and the entire useEffect block (lines 32-76).
+
+Replace with:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'property-data'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const [membershipRes, roleRes, itemRes, updateRes, typeRes] = await Promise.all([
+      supabase.from('org_memberships')
+        .select('id, role_id, users!inner(id, display_name, email, is_temporary, created_at), roles!inner(id, name)')
+        .eq('status', 'active')
+        .order('created_at', { ascending: true }),
+      supabase.from('roles').select('*').order('sort_order', { ascending: true }),
+      supabase.from('items').select('*').order('name', { ascending: true }),
+      supabase.from('item_updates').select('*').order('update_date', { ascending: false }),
+      supabase.from('update_types').select('*').order('sort_order', { ascending: true }),
+    ]);
+
+    const users: UserWithMembership[] = (membershipRes.data ?? []).map((m: any) => ({
+      id: m.users.id,
+      display_name: m.users.display_name,
+      email: m.users.email,
+      is_temporary: m.users.is_temporary,
+      created_at: m.users.created_at,
+      role_name: m.roles.name,
+      role_id: m.role_id,
+      membership_id: m.id,
+    }));
+
+    const availableRoles = (roleRes.data ?? []) as Role[];
+    const items = (itemRes.data ?? []) as Item[];
+    const updateTypes = (typeRes.data ?? []) as UpdateType[];
+
+    const typeMap = new Map(updateTypes.map((t) => [t.id, t]));
+    const updates = (updateRes.data ?? []).map((u: any) => ({
+      ...u,
+      item_name: items.find((b) => b.id === u.item_id)?.name,
+      update_type_name: typeMap.get(u.update_type_id)?.name,
+    }));
+
+    return { users, availableRoles, items, updates, updateTypes };
+  },
+});
+
+const users = queryData?.users ?? [];
+const availableRoles = queryData?.availableRoles ?? [];
+const items = queryData?.items ?? [];
+const updates = queryData?.updates ?? [];
+```
+
+- [ ] **Step 2: Update mutation handlers to invalidate**
+
+Replace the three mutation handlers. For `handleDeleteItem` (lines 78-88):
+```tsx
+async function handleDeleteItem(id: string) {
+  if (!confirm('Delete this item and all its updates? This cannot be undone.')) return;
+  const supabase = createClient();
+  const { error } = await supabase.from('items').delete().eq('id', id);
+  if (!error) {
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
+  }
+}
+```
+
+For `handleDeleteUpdate` (lines 90-99):
+```tsx
+async function handleDeleteUpdate(id: string) {
+  if (!confirm('Delete this update?')) return;
+  const supabase = createClient();
+  const { error } = await supabase.from('item_updates').delete().eq('id', id);
+  if (!error) {
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
+  }
+}
+```
+
+For `handleRoleChange` (lines 101-116):
+```tsx
+async function handleRoleChange(membershipId: string, newRoleId: string) {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('org_memberships')
+    .update({ role_id: newRoleId })
+    .eq('id', membershipId);
+  if (!error) {
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
+  }
+}
+```
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/data/page.tsx
+git commit -m "feat: convert property data page to React Query"
+```
+
+---
+
+### Task 7: Convert /admin/properties/[slug]/types page
+
+**Files:**
+- Modify: `src/app/admin/properties/[slug]/types/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-7):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { ItemType } from '@/lib/types';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
+import ItemTypeEditor from '@/components/admin/ItemTypeEditor';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+```
+
+Remove `itemTypes`, `itemCounts`, `loading` useState (lines 10-12), the useEffect (lines 21-23), and the `fetchData` function (lines 25-44).
+
+Replace with:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'property-types'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const [typeRes, itemRes] = await Promise.all([
+      supabase.from('item_types').select('*').order('sort_order', { ascending: true }),
+      supabase.from('items').select('id, item_type_id'),
+    ]);
+
+    const itemTypes = (typeRes.data ?? []) as ItemType[];
+    const itemCounts: Record<string, number> = {};
+    if (itemRes.data) {
+      for (const item of itemRes.data) {
+        itemCounts[item.item_type_id] = (itemCounts[item.item_type_id] || 0) + 1;
+      }
+    }
+    return { itemTypes, itemCounts };
+  },
+});
+
+const itemTypes = queryData?.itemTypes ?? [];
+const itemCounts = queryData?.itemCounts ?? {};
+```
+
+- [ ] **Step 2: Update mutation handlers to invalidate**
+
+In `handleAddType` (lines 46-76), replace the local state updates:
+```tsx
+      setItemTypes((prev) => [...prev, data]);
+      setItemCounts((prev) => ({ ...prev, [data.id]: 0 }));
+```
+with:
+```tsx
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+```
+
+Keep the form reset and `setExpandedId(data.id)`.
+
+In `handleSaveType` (lines 78-83), replace:
+```tsx
+    setItemTypes((prev) => prev.map((t) => (t.id === id ? { ...t, ...updates } : t)));
+```
+with:
+```tsx
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+```
+
+In `handleDeleteType` (lines 85-92), replace:
+```tsx
+    setItemTypes((prev) => prev.filter((t) => t.id !== id));
+    setItemCounts((prev) => { const c = { ...prev }; delete c[id]; return c; });
+```
+with:
+```tsx
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+```
+
+In `handleReorder` (lines 94-113), replace the local state update block (lines 108-112):
+```tsx
+    const updated = [...itemTypes];
+    updated[index] = { ...current, sort_order: swap.sort_order };
+    updated[swapIndex] = { ...swap, sort_order: current.sort_order };
+    updated.sort((a, b) => a.sort_order - b.sort_order);
+    setItemTypes(updated);
+```
+with:
+```tsx
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+```
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/types/page.tsx
+git commit -m "feat: convert property types page to React Query"
+```
+
+---
+
+### Task 8: Convert /admin/properties/[slug]/members page
+
+**Files:**
+- Modify: `src/app/admin/properties/[slug]/members/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports — replace line 1-14:
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/client';
+import { StatusBadge } from '@/components/admin/StatusBadge';
+import { EmptyState } from '@/components/admin/EmptyState';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getPropertyMembers,
+  addPropertyOverrideForProperty as addPropertyOverride,
+  removePropertyOverrideForProperty as removePropertyOverride,
+  type PropertyMember,
+} from './actions';
+```
+
+Remove `property`, `members`, `availableRoles`, `loading`, `pageError` useState (lines 34-38), the `loadData` function (lines 50-73), and the useEffect (lines 75-78).
+
+Replace with:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'property', slug, 'members'],
+  queryFn: async () => {
+    const [membersResult, rolesResult] = await Promise.all([
+      getPropertyMembers(slug),
+      createClient()
+        .from('roles')
+        .select('id, name, base_role')
+        .neq('base_role', 'platform_admin')
+        .order('sort_order', { ascending: true }),
+    ]);
+
+    if (membersResult.error || !membersResult.property) {
+      return { error: membersResult.error ?? 'Property not found', property: null, members: [], availableRoles: [] };
+    }
+
+    return {
+      error: null,
+      property: membersResult.property as Property,
+      members: (membersResult.members ?? []) as PropertyMember[],
+      availableRoles: (rolesResult.data ?? []) as Role[],
+    };
+  },
+});
+
+const property = queryData?.property ?? null;
+const members = queryData?.members ?? [];
+const availableRoles = queryData?.availableRoles ?? [];
+const pageError = queryData?.error ?? null;
+```
+
+- [ ] **Step 2: Update mutation handlers to invalidate**
+
+In `handleAddOverride` (line 101), replace:
+```tsx
+        await loadData();
+```
+with:
+```tsx
+        await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'members'] });
+```
+
+In `handleRemoveOverride` (line 115), replace:
+```tsx
+        await loadData();
+```
+with:
+```tsx
+        await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'members'] });
+```
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/members/page.tsx
+git commit -m "feat: convert property members page to React Query"
+```
+
+---
+
+### Task 9: Convert /admin/geo-layers page
+
+**Files:**
+- Modify: `src/app/admin/geo-layers/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-5):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { createClient } from '@/lib/supabase/client';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+```
+
+Remove `orgId`, `layers`, `loading`, `properties`, `assignments` useState (lines 24-26, 32-33), the `loadLayers` and `loadAssignments` useCallback functions (lines 52-69), and all three useEffect blocks (lines 36-50, 71-74, 76-90).
+
+Replace with:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: orgId } = useQuery({
+  queryKey: ['admin', 'org-id'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return null;
+    const { data } = await supabase
+      .from('org_memberships')
+      .select('org_id')
+      .eq('user_id', user.id)
+      .limit(1)
+      .single();
+    return data?.org_id ?? null;
+  },
+});
+
+const { data: layersData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'geo-layers', orgId],
+  queryFn: async () => {
+    if (!orgId) return { layers: [], assignments: [], properties: [] };
+
+    const supabase = createClient();
+    const [layersResult, assignmentsResult, propertiesResult] = await Promise.all([
+      listGeoLayers(orgId),
+      getOrgLayerAssignments(orgId),
+      supabase
+        .from('properties')
+        .select('id, name, slug')
+        .eq('org_id', orgId)
+        .is('deleted_at', null)
+        .order('name', { ascending: true }),
+    ]);
+
+    const layers = 'error' in layersResult ? [] : layersResult.layers;
+    const assignments = 'error' in assignmentsResult ? [] : assignmentsResult.assignments;
+    const properties = (propertiesResult.data ?? []).map((p: { id: string; name: string; slug: string }) => ({
+      id: p.id,
+      name: p.name || p.slug,
+    }));
+
+    return { layers, assignments, properties };
+  },
+  enabled: !!orgId,
+});
+
+const layers = layersData?.layers ?? [];
+const assignments = layersData?.assignments ?? [];
+const properties = layersData?.properties ?? [];
+```
+
+- [ ] **Step 2: Update all mutation handlers to invalidate**
+
+Create a helper to invalidate:
+```tsx
+function invalidateLayers() {
+  return queryClient.invalidateQueries({ queryKey: ['admin', 'geo-layers', orgId] });
+}
+```
+
+In `handleToggleProperty` (line 109), replace `loadAssignments()` with `await invalidateLayers()`.
+
+In `handleImport` (lines 151-152), replace `loadLayers()` and `loadAssignments()` with `await invalidateLayers()`.
+
+In `handleDelete` (lines 162-163), replace `loadLayers()` and `loadAssignments()` with `await invalidateLayers()`.
+
+In `handleSaveEdit` (line 175), replace `loadLayers()` with `await invalidateLayers()`.
+
+In `handlePublish` (line 184), replace `loadLayers()` with `await invalidateLayers()`.
+
+In `handleUnpublish` (line 194), replace `loadLayers()` with `await invalidateLayers()`.
+
+Also add error handling for `handleToggleProperty`, `handleImport`, `handleDelete` — keep the existing `setMessage` calls but replace the refetch calls.
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/geo-layers/page.tsx
+git commit -m "feat: convert geo layers page to React Query"
+```
+
+---
+
+### Task 10: Convert /admin/roles/[roleId] page
+
+**Files:**
+- Modify: `src/app/admin/roles/[roleId]/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-7):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import PermissionEditor from '@/components/admin/PermissionEditor';
+import { getRoles, updateRole } from '../actions';
+import { RolePermissions } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+```
+
+Remove `role`, `loading`, `notFound` useState (lines 24-26) and the useEffect (lines 38-62).
+
+Replace with:
+```tsx
+const { data: queryResult, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'roles', roleId],
+  queryFn: async () => {
+    const result = await getRoles();
+    if (!result.roles) return { role: null, notFound: true };
+    const found = (result.roles as Role[]).find((r) => r.id === roleId);
+    if (!found) return { role: null, notFound: true };
+    return { role: found, notFound: false };
+  },
+});
+
+const role = queryResult?.role ?? null;
+const notFound = queryResult?.notFound ?? false;
+```
+
+Add a useEffect to sync editable fields when role loads. Add `useEffect` back to imports:
+```tsx
+import { useState, useEffect } from 'react';
+```
+
+Add after the useQuery:
+```tsx
+useEffect(() => {
+  if (role) {
+    setName(role.name);
+    setDescription(role.description ?? '');
+    setPermissions(role.permissions);
+  }
+}, [role]);
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/admin/roles/[roleId]/page.tsx
+git commit -m "feat: convert role editor page to React Query"
+```
+
+---
+
+### Task 11: Convert /admin/domains page
+
+**Files:**
+- Modify: `src/app/admin/domains/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-11):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import { StatusBadge } from '@/components/admin/StatusBadge';
+import { EmptyState } from '@/components/admin/EmptyState';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  addCustomDomain,
+  removeCustomDomain,
+  checkDomainStatus,
+} from '@/lib/domains/actions';
+```
+
+Remove `orgDomains`, `propertyDomains`, `properties`, `loading`, `orgId` useState (lines 103-107), the `loadData` useCallback (lines 123-186), and the useEffect (lines 188-190).
+
+Replace with:
+```tsx
+const queryClient = useQueryClient();
+
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['admin', 'domains'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { orgDomains: [], propertyDomains: [], properties: [], orgId: null };
+
+    const { data: membership } = await supabase
+      .from('org_memberships')
+      .select('org_id')
+      .eq('user_id', user.id)
+      .limit(1)
+      .single();
+
+    if (!membership) return { orgDomains: [], propertyDomains: [], properties: [], orgId: null };
+    const orgId = membership.org_id;
+
+    const { data: domainsData } = await supabase
+      .from('custom_domains')
+      .select(`
+        id, domain, domain_type, status, ssl_status, is_primary,
+        property_id, verified_at, created_at, verification_token,
+        properties ( name )
+      `)
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: true });
+
+    const rows: OrgDomain[] = (domainsData || []).map((d: Record<string, unknown>) => ({
+      id: d.id as string,
+      domain: d.domain as string,
+      domain_type: (d.domain_type as string) || 'subdomain',
+      status: d.status as string,
+      ssl_status: (d.ssl_status as string) ?? null,
+      is_primary: d.is_primary as boolean,
+      property_id: (d.property_id as string) ?? null,
+      property_name: (d.properties as { name: string } | null)?.name ?? null,
+      verified_at: (d.verified_at as string) ?? null,
+      created_at: d.created_at as string,
+      verification_token: (d.verification_token as string) ?? null,
+    }));
+
+    const { data: propsData } = await supabase
+      .from('properties')
+      .select('id, name, slug, primary_custom_domain_id')
+      .eq('org_id', orgId)
+      .is('deleted_at', null)
+      .order('name', { ascending: true });
+
+    return {
+      orgDomains: rows.filter((r) => r.property_id === null),
+      propertyDomains: rows.filter((r) => r.property_id !== null),
+      properties: (propsData || []) as PropertyInfo[],
+      orgId,
+    };
+  },
+});
+
+const orgDomains = queryData?.orgDomains ?? [];
+const propertyDomains = queryData?.propertyDomains ?? [];
+const properties = queryData?.properties ?? [];
+const orgId = queryData?.orgId ?? null;
+```
+
+- [ ] **Step 2: Update mutation handlers to invalidate**
+
+In each handler, replace `await loadData()` with:
+```tsx
+await queryClient.invalidateQueries({ queryKey: ['admin', 'domains'] });
+```
+
+This applies to:
+- `handleAddDomain` (line 232)
+- `handleRemove` (line 239)
+- `handleCheckStatus` (line 246)
+- `handleAddSubdomain` (line 258)
+
+- [ ] **Step 3: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/domains/page.tsx
+git commit -m "feat: convert domains page to React Query"
+```
+
+---
+
+### Task 12: Convert /manage dashboard page
+
+**Files:**
+- Modify: `src/app/manage/page.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-9):
+```tsx
+'use client';
+
+import Link from 'next/link';
+import type { Item } from '@/lib/types';
+import { createClient } from '@/lib/supabase/client';
+import StatusBadge from '@/components/item/StatusBadge';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
+import { usePermissions } from '@/lib/permissions/hooks';
+import { useQuery } from '@tanstack/react-query';
+```
+
+Remove `items` and `loading` useState (lines 12-13) and the useEffect (lines 16-29).
+
+Replace with:
+```tsx
+const { data: items = [], isLoading: loading } = useQuery({
+  queryKey: ['manage', 'dashboard'],
+  queryFn: async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from('items')
+      .select('*')
+      .order('name', { ascending: true });
+    return (data ?? []) as Item[];
+  },
+});
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/manage/page.tsx
+git commit -m "feat: convert manage dashboard to React Query"
+```
+
+---
+
+### Task 13: Convert EntitySelect component
+
+**Files:**
+- Modify: `src/components/manage/EntitySelect.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-5):
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { Entity } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+```
+
+Remove `entities` and `loading` useState (lines 15-16) and the useEffect (lines 19-31).
+
+Replace with:
+```tsx
+const { data: entities = [], isLoading: loading } = useQuery({
+  queryKey: ['entities', entityTypeId],
+  queryFn: async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from('entities')
+      .select('*')
+      .eq('entity_type_id', entityTypeId)
+      .order('sort_order', { ascending: true });
+    return (data ?? []) as Entity[];
+  },
+});
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/manage/EntitySelect.tsx
+git commit -m "feat: convert EntitySelect to React Query"
+```
+
+---
+
+### Task 14: Convert LocationHistory component
+
+**Files:**
+- Modify: `src/components/manage/LocationHistory.tsx`
+
+- [ ] **Step 1: Replace useEffect+useState with useQuery**
+
+Update imports (lines 1-6):
+```tsx
+'use client';
+
+import { createClient } from '@/lib/supabase/client';
+import type { LocationHistory as LocationHistoryType, Profile } from '@/lib/types';
+import { formatShortDate } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+```
+
+Remove `history`, `profiles`, `loading` useState (lines 14-16) and the useEffect (lines 18-53).
+
+Replace with:
+```tsx
+const { data: queryData, isLoading: loading } = useQuery({
+  queryKey: ['location-history', itemId],
+  queryFn: async () => {
+    const supabase = createClient();
+    const { data: historyData } = await supabase
+      .from('location_history')
+      .select('*')
+      .eq('item_id', itemId)
+      .order('created_at', { ascending: false });
+
+    if (!historyData || historyData.length === 0) {
+      return { history: [], profiles: {} };
+    }
+
+    const creatorIds = Array.from(new Set(historyData.map((h) => h.created_by)));
+    const { data: profileData } = await supabase
+      .from('users')
+      .select('*')
+      .in('id', creatorIds);
+
+    const profiles: Record<string, Profile> = {};
+    if (profileData) {
+      for (const p of profileData) {
+        profiles[p.id] = p;
+      }
+    }
+
+    return { history: historyData as LocationHistoryType[], profiles };
+  },
+});
+
+const history = queryData?.history ?? [];
+const profiles = queryData?.profiles ?? {};
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/manage/LocationHistory.tsx
+git commit -m "feat: convert LocationHistory to React Query"
+```
+
+---
+
+### Task 15: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run type check**
+
+```bash
+npm run type-check
+```
+
+Expected: No type errors.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm run test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Run build**
+
+```bash
+npm run build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Verify no unused imports**
+
+Spot-check a few converted files to ensure no leftover `useEffect` imports where they're no longer needed, and no unused `useState` variables.

--- a/docs/superpowers/specs/2026-04-01-react-query-caching-design.md
+++ b/docs/superpowers/specs/2026-04-01-react-query-caching-design.md
@@ -1,0 +1,116 @@
+# React Query Caching for Admin Pages
+
+**Issue:** [#145](https://github.com/patjackson52/birdhouse-mapper/issues/145)
+**Date:** 2026-04-01
+
+## Summary
+
+Add React Query (TanStack Query) as a client-side data caching layer for admin pages and non-offline components. This provides stale-while-revalidate caching so repeated navigation to admin pages shows cached data instantly while revalidating in the background.
+
+## Motivation
+
+The offline capabilities PR (#144) converted 6 core components to use IndexedDB, making those pages load instantly. However, ~15 admin pages and utility components still call Supabase directly on every navigation, causing visible loading spinners on repeat visits. React Query with a 30-second stale time eliminates this latency.
+
+## Approach
+
+**Inline `useQuery` per page** — no shared hooks or abstraction layer. Each page defines its own `useQuery` calls. Query keys follow a convention but are not centralized.
+
+This was chosen over shared custom hooks or a query key factory because most queries are used in exactly one place, making abstraction premature.
+
+## Setup
+
+### Dependencies
+
+- `@tanstack/react-query` (latest stable)
+
+### QueryProvider
+
+New client component at `src/components/QueryProvider.tsx`:
+- Wraps `QueryClientProvider` from `@tanstack/react-query`
+- Default config: `staleTime: 30_000` (30s), `gcTime: 300_000` (5 min)
+
+Added to `src/app/layout.tsx` alongside existing `OfflineProvider` and `ConfigProvider`.
+
+## Query Key Convention
+
+All admin queries follow: `['admin', '<resource>', ...params]`
+
+Examples:
+- `['admin', 'settings']`
+- `['admin', 'members']`
+- `['admin', 'properties']`
+- `['admin', 'property', slug, 'settings']`
+- `['admin', 'property', slug, 'data']`
+- `['admin', 'property', slug, 'types']`
+- `['admin', 'property', slug, 'entities']`
+- `['admin', 'property', slug, 'members']`
+- `['admin', 'geo-layers']`
+- `['admin', 'roles', roleId]`
+- `['admin', 'domains']`
+- `['manage', 'dashboard']`
+- `['entities', entityTypeId]` (for EntitySelect)
+- `['location-history', ...params]` (for LocationHistory)
+
+## Conversion Pattern
+
+### Before (current pattern)
+```tsx
+const [data, setData] = useState([]);
+const [loading, setLoading] = useState(true);
+
+useEffect(() => {
+  async function load() {
+    const result = await getServerAction();
+    // or: const { data } = await supabase.from('table').select('*');
+    if (result.data) setData(result.data);
+    setLoading(false);
+  }
+  load();
+}, []);
+```
+
+### After
+```tsx
+const { data, isLoading } = useQuery({
+  queryKey: ['admin', 'resource'],
+  queryFn: async () => {
+    const result = await getServerAction();
+    return result.data;
+    // or: const { data } = await supabase.from('table').select('*');
+    // return data;
+  },
+});
+```
+
+### Mutations
+
+Existing imperative mutation logic (server action calls for saves/deletes) stays as-is. After a successful mutation, call `queryClient.invalidateQueries({ queryKey: [...] })` to trigger a refetch of affected queries.
+
+## Pages In Scope
+
+### Admin pages
+1. `/admin/settings` — org settings (server action fetch)
+2. `/admin/members` — member management (server action + supabase)
+3. `/admin/properties` — property list (server action + supabase)
+4. `/admin/properties/[slug]/settings` — property settings (supabase)
+5. `/admin/properties/[slug]/data` — item data management (supabase)
+6. `/admin/properties/[slug]/types` — item type definitions
+7. `/admin/properties/[slug]/entities` — entity management
+8. `/admin/properties/[slug]/members` — property members
+9. `/admin/geo-layers` — geo layer management
+10. `/admin/roles/[roleId]` — role editor
+11. `/admin/domains` — custom domains
+
+### Other pages/components
+12. `/manage` — dashboard stats
+13. `EntitySelect.tsx` — entity picker in forms
+14. `LocationHistory.tsx` — location history display
+
+## Exclusions
+
+- **Navigation.tsx** — uses `onAuthStateChange` subscription, not a fetch-on-mount pattern. Not a fit for `useQuery`.
+- **Map page, list page, item forms** — already use IndexedDB offline store via OfflineProvider.
+- **Map tiles** — cached by service worker (Cache-First).
+- **No prefetching** — stale-while-revalidate handles the main latency issue; prefetching can be added later if needed.
+- **No shared hook abstractions** — inline `useQuery` per page to keep it simple.
+- **No query key factory** — convention-based keys are sufficient at this scale.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@serwist/next": "^9.5.7",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.47.0",
+        "@tanstack/react-query": "^5.96.1",
         "@tmcw/togeojson": "^7.1.2",
         "@turf/bbox": "^7.3.4",
         "@turf/boolean-point-in-polygon": "^7.3.4",
@@ -2239,6 +2240,32 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.1.tgz",
+      "integrity": "sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.1.tgz",
+      "integrity": "sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@serwist/next": "^9.5.7",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.0",
+    "@tanstack/react-query": "^5.96.1",
     "@tmcw/togeojson": "^7.1.2",
     "@turf/bbox": "^7.3.4",
     "@turf/boolean-point-in-polygon": "^7.3.4",

--- a/src/app/admin/domains/page.tsx
+++ b/src/app/admin/domains/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import { StatusBadge } from '@/components/admin/StatusBadge';
 import { EmptyState } from '@/components/admin/EmptyState';
@@ -100,11 +101,7 @@ function DnsInfoPanel({ domain }: { domain: OrgDomain }) {
 }
 
 export default function DomainsPage() {
-  const [orgDomains, setOrgDomains] = useState<OrgDomain[]>([]);
-  const [propertyDomains, setPropertyDomains] = useState<OrgDomain[]>([]);
-  const [properties, setProperties] = useState<PropertyInfo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [orgId, setOrgId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   // Add domain form state
   const [showAddForm, setShowAddForm] = useState(false);
@@ -120,74 +117,80 @@ export default function DomainsPage() {
   const [checkingDomain, setCheckingDomain] = useState<string | null>(null);
   const [addingSubdomain, setAddingSubdomain] = useState<string | null>(null);
 
-  const loadData = useCallback(async () => {
-    const supabase = createClient();
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'domains'],
+    queryFn: async () => {
+      const supabase = createClient();
 
-    // Get org context from the current user's membership
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
+      // Get org context from the current user's membership
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return { orgDomains: [], propertyDomains: [], properties: [], orgId: null };
 
-    const { data: membership } = await supabase
-      .from('org_memberships')
-      .select('org_id')
-      .eq('user_id', user.id)
-      .limit(1)
-      .single();
+      const { data: membership } = await supabase
+        .from('org_memberships')
+        .select('org_id')
+        .eq('user_id', user.id)
+        .limit(1)
+        .single();
 
-    if (!membership) return;
-    setOrgId(membership.org_id);
+      if (!membership) return { orgDomains: [], propertyDomains: [], properties: [], orgId: null };
 
-    // Fetch domains with property join
-    const { data: domainsData } = await supabase
-      .from('custom_domains')
-      .select(`
-        id,
-        domain,
-        domain_type,
-        status,
-        ssl_status,
-        is_primary,
-        property_id,
-        verified_at,
-        created_at,
-        verification_token,
-        properties ( name )
-      `)
-      .eq('org_id', membership.org_id)
-      .order('created_at', { ascending: true });
+      const orgId = membership.org_id;
 
-    const rows: OrgDomain[] = (domainsData || []).map((d: Record<string, unknown>) => ({
-      id: d.id as string,
-      domain: d.domain as string,
-      domain_type: (d.domain_type as string) || 'subdomain',
-      status: d.status as string,
-      ssl_status: (d.ssl_status as string) ?? null,
-      is_primary: d.is_primary as boolean,
-      property_id: (d.property_id as string) ?? null,
-      property_name: (d.properties as { name: string } | null)?.name ?? null,
-      verified_at: (d.verified_at as string) ?? null,
-      created_at: d.created_at as string,
-      verification_token: (d.verification_token as string) ?? null,
-    }));
+      // Fetch domains with property join
+      const { data: domainsData } = await supabase
+        .from('custom_domains')
+        .select(`
+          id,
+          domain,
+          domain_type,
+          status,
+          ssl_status,
+          is_primary,
+          property_id,
+          verified_at,
+          created_at,
+          verification_token,
+          properties ( name )
+        `)
+        .eq('org_id', orgId)
+        .order('created_at', { ascending: true });
 
-    setOrgDomains(rows.filter((r) => r.property_id === null));
-    setPropertyDomains(rows.filter((r) => r.property_id !== null));
+      const rows: OrgDomain[] = (domainsData || []).map((d: Record<string, unknown>) => ({
+        id: d.id as string,
+        domain: d.domain as string,
+        domain_type: (d.domain_type as string) || 'subdomain',
+        status: d.status as string,
+        ssl_status: (d.ssl_status as string) ?? null,
+        is_primary: d.is_primary as boolean,
+        property_id: (d.property_id as string) ?? null,
+        property_name: (d.properties as { name: string } | null)?.name ?? null,
+        verified_at: (d.verified_at as string) ?? null,
+        created_at: d.created_at as string,
+        verification_token: (d.verification_token as string) ?? null,
+      }));
 
-    // Fetch properties
-    const { data: propsData } = await supabase
-      .from('properties')
-      .select('id, name, slug, primary_custom_domain_id')
-      .eq('org_id', membership.org_id)
-      .is('deleted_at', null)
-      .order('name', { ascending: true });
+      const orgDomains = rows.filter((r) => r.property_id === null);
+      const propertyDomains = rows.filter((r) => r.property_id !== null);
 
-    setProperties((propsData || []) as PropertyInfo[]);
-    setLoading(false);
-  }, []);
+      // Fetch properties
+      const { data: propsData } = await supabase
+        .from('properties')
+        .select('id, name, slug, primary_custom_domain_id')
+        .eq('org_id', orgId)
+        .is('deleted_at', null)
+        .order('name', { ascending: true });
 
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
+      const properties = (propsData || []) as PropertyInfo[];
+
+      return { orgDomains, propertyDomains, properties, orgId };
+    },
+  });
+
+  const orgDomains = data?.orgDomains ?? [];
+  const propertyDomains = data?.propertyDomains ?? [];
+  const properties = data?.properties ?? [];
+  const orgId = data?.orgId ?? null;
 
   const primaryOrgDomain = orgDomains.find((d) => d.is_primary && d.property_id === null);
 
@@ -229,21 +232,21 @@ export default function DomainsPage() {
       setFormScope('org');
     }
 
-    await loadData();
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'domains'] });
   }
 
   async function handleRemove(domainId: string) {
     const result = await removeCustomDomain(domainId);
     setConfirmRemove(null);
     if (result.success) {
-      await loadData();
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'domains'] });
     }
   }
 
   async function handleCheckStatus(domainId: string) {
     setCheckingDomain(domainId);
     await checkDomainStatus(domainId);
-    await loadData();
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'domains'] });
     setCheckingDomain(null);
   }
 
@@ -255,7 +258,7 @@ export default function DomainsPage() {
     const result = await addCustomDomain(orgId, subdomain, property.id);
 
     if (result.success) {
-      await loadData();
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'domains'] });
     }
     setAddingSubdomain(null);
   }

--- a/src/app/admin/geo-layers/page.tsx
+++ b/src/app/admin/geo-layers/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { createClient } from '@/lib/supabase/client';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 const ImportFlow = dynamic(() => import('@/components/geo/ImportFlow'), {
   ssr: false,
@@ -21,73 +22,51 @@ import {
 import type { GeoLayerSummary, GeoLayerProperty } from '@/lib/geo/types';
 
 export default function GeoLayersAdminPage() {
-  const [orgId, setOrgId] = useState<string | null>(null);
-  const [layers, setLayers] = useState<GeoLayerSummary[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [showImport, setShowImport] = useState(false);
   const [showAiImport, setShowAiImport] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
-  const [properties, setProperties] = useState<Array<{ id: string; name: string }>>([]);
-  const [assignments, setAssignments] = useState<GeoLayerProperty[]>([]);
   const [expandedLayerId, setExpandedLayerId] = useState<string | null>(null);
 
-  useEffect(() => {
-    const supabase = createClient();
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      if (!user) return;
-      supabase
-        .from('org_memberships')
-        .select('org_id')
-        .eq('user_id', user.id)
-        .limit(1)
-        .single()
-        .then(({ data }) => {
-          if (data?.org_id) setOrgId(data.org_id);
-        });
-    });
-  }, []);
+  const { data: orgId } = useQuery({
+    queryKey: ['admin', 'org-id'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return null;
+      const { data } = await supabase.from('org_memberships').select('org_id').eq('user_id', user.id).limit(1).single();
+      return data?.org_id ?? null;
+    },
+  });
 
-  const loadLayers = useCallback(async () => {
-    if (!orgId) return;
-    const result = await listGeoLayers(orgId);
-    if ('error' in result) {
-      setMessage({ type: 'error', text: result.error });
-    } else {
-      setLayers(result.layers);
-    }
-    setLoading(false);
-  }, [orgId]);
+  const { data: layersData, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'geo-layers', orgId],
+    queryFn: async () => {
+      if (!orgId) return { layers: [], assignments: [], properties: [] };
+      const supabase = createClient();
+      const [layersResult, assignmentsResult, propertiesResult] = await Promise.all([
+        listGeoLayers(orgId),
+        getOrgLayerAssignments(orgId),
+        supabase.from('properties').select('id, name, slug').eq('org_id', orgId).is('deleted_at', null).order('name', { ascending: true }),
+      ]);
+      return {
+        layers: 'error' in layersResult ? [] : layersResult.layers,
+        assignments: 'error' in assignmentsResult ? [] : assignmentsResult.assignments,
+        properties: (propertiesResult.data ?? []).map((p: { id: string; name: string; slug: string }) => ({ id: p.id, name: p.name || p.slug })),
+      };
+    },
+    enabled: !!orgId,
+  });
 
-  const loadAssignments = useCallback(async () => {
-    if (!orgId) return;
-    const result = await getOrgLayerAssignments(orgId);
-    if (!('error' in result)) {
-      setAssignments(result.assignments);
-    }
-  }, [orgId]);
+  const layers: GeoLayerSummary[] = layersData?.layers ?? [];
+  const assignments: GeoLayerProperty[] = layersData?.assignments ?? [];
+  const properties: Array<{ id: string; name: string }> = layersData?.properties ?? [];
 
-  useEffect(() => {
-    loadLayers();
-    loadAssignments();
-  }, [loadLayers, loadAssignments]);
-
-  useEffect(() => {
-    if (!orgId) return;
-    const supabase = createClient();
-    supabase
-      .from('properties')
-      .select('id, name, slug')
-      .eq('org_id', orgId)
-      .is('deleted_at', null)
-      .order('name', { ascending: true })
-      .then(({ data }) => {
-        if (data) {
-          setProperties(data.map((p: { id: string; name: string; slug: string }) => ({ id: p.id, name: p.name || p.slug })));
-        }
-      });
-  }, [orgId]);
+  function invalidateLayers() {
+    return queryClient.invalidateQueries({ queryKey: ['admin', 'geo-layers', orgId] });
+  }
 
   function getAssignedPropertyIds(layerId: string): Set<string> {
     return new Set(
@@ -106,7 +85,7 @@ export default function GeoLayersAdminPage() {
     if ('error' in result) {
       setMessage({ type: 'error', text: result.error });
     } else {
-      loadAssignments();
+      await invalidateLayers();
     }
   }
 
@@ -148,8 +127,7 @@ export default function GeoLayersAdminPage() {
 
     setMessage({ type: 'success', text: `Layer "${data.name}" imported successfully` });
     setShowImport(false);
-    loadLayers();
-    loadAssignments();
+    await invalidateLayers();
   };
 
   const handleDelete = async (layer: GeoLayerSummary) => {
@@ -159,8 +137,7 @@ export default function GeoLayersAdminPage() {
       setMessage({ type: 'error', text: result.error });
     } else {
       setMessage({ type: 'success', text: `Layer "${layer.name}" deleted` });
-      loadLayers();
-      loadAssignments();
+      await invalidateLayers();
     }
   };
 
@@ -171,7 +148,7 @@ export default function GeoLayersAdminPage() {
       setMessage({ type: 'error', text: result.error });
     } else {
       setEditingId(null);
-      loadLayers();
+      await invalidateLayers();
     }
   };
 
@@ -181,7 +158,7 @@ export default function GeoLayersAdminPage() {
       setMessage({ type: 'error', text: result.error });
     } else {
       setMessage({ type: 'success', text: 'Layer published — now visible on maps' });
-      loadLayers();
+      await invalidateLayers();
     }
   };
 
@@ -191,7 +168,7 @@ export default function GeoLayersAdminPage() {
       setMessage({ type: 'error', text: result.error });
     } else {
       setMessage({ type: 'success', text: 'Layer unpublished — hidden from maps' });
-      loadLayers();
+      await invalidateLayers();
     }
   };
 

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { StatusBadge } from '@/components/admin/StatusBadge';
@@ -35,10 +36,8 @@ function formatDate(dateStr: string | null): string {
 
 export default function MembersPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
-  const [members, setMembers] = useState<Member[]>([]);
-  const [roles, setRoles] = useState<Role[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
 
   // Invite form state
@@ -49,32 +48,29 @@ export default function MembersPage() {
   const [inviteLoading, setInviteLoading] = useState(false);
   const [inviteSuccess, setInviteSuccess] = useState(false);
 
-  async function loadData() {
-    const supabase = createClient();
+  const { data: queryData, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'members'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const [membersResult, rolesResult] = await Promise.all([
+        getOrgMembers(),
+        supabase.from('roles').select('id, name, base_role').order('name', { ascending: true }),
+      ]);
+      return {
+        members: (membersResult.members ?? []) as Member[],
+        roles: (rolesResult.data ?? []) as Role[],
+      };
+    },
+  });
 
-    const [membersResult, rolesResult] = await Promise.all([
-      getOrgMembers(),
-      supabase.from('roles').select('id, name, base_role').order('name', { ascending: true }),
-    ]);
-
-    if (membersResult.members) {
-      setMembers(membersResult.members as Member[]);
-    }
-
-    if (rolesResult.data) {
-      setRoles(rolesResult.data);
-      if (rolesResult.data.length > 0 && !inviteRoleId) {
-        setInviteRoleId(rolesResult.data[0].id);
-      }
-    }
-
-    setLoading(false);
-  }
+  const members = queryData?.members ?? [];
+  const roles = queryData?.roles ?? [];
 
   useEffect(() => {
-    loadData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (roles.length > 0 && !inviteRoleId) {
+      setInviteRoleId(roles[0].id);
+    }
+  }, [roles, inviteRoleId]);
 
   async function handleInvite(e: React.FormEvent) {
     e.preventDefault();
@@ -95,7 +91,7 @@ export default function MembersPage() {
 
     setInviteSuccess(true);
     setInviteEmail('');
-    await loadData();
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'members'] });
   }
 
   function handleCancelInvite() {

--- a/src/app/admin/properties/[slug]/data/page.tsx
+++ b/src/app/admin/properties/[slug]/data/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import type { Item, ItemUpdate, UpdateType, Role } from '@/lib/types';
 import { createClient } from '@/lib/supabase/client';
@@ -21,16 +22,12 @@ type UserWithMembership = {
 
 export default function PropertyDataPage() {
   const router = useRouter();
-  const [users, setUsers] = useState<UserWithMembership[]>([]);
-  const [availableRoles, setAvailableRoles] = useState<Role[]>([]);
-  const [items, setItems] = useState<Item[]>([]);
-  const [updates, setUpdates] = useState<(ItemUpdate & { item_name?: string; update_type_name?: string })[]>([]);
-  const [updateTypes, setUpdateTypes] = useState<UpdateType[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<'users' | 'items' | 'updates'>('items');
 
-  useEffect(() => {
-    async function fetchData() {
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'property-data'],
+    queryFn: async () => {
       const supabase = createClient();
 
       const [membershipRes, roleRes, itemRes, updateRes, typeRes] = await Promise.all([
@@ -44,36 +41,41 @@ export default function PropertyDataPage() {
         supabase.from('update_types').select('*').order('sort_order', { ascending: true }),
       ]);
 
-      if (membershipRes.data) {
-        setUsers(membershipRes.data.map((m: any) => ({
-          id: m.users.id,
-          display_name: m.users.display_name,
-          email: m.users.email,
-          is_temporary: m.users.is_temporary,
-          created_at: m.users.created_at,
-          role_name: m.roles.name,
-          role_id: m.role_id,
-          membership_id: m.id,
-        })));
-      }
-      if (roleRes.data) setAvailableRoles(roleRes.data);
-      if (itemRes.data) setItems(itemRes.data);
-      if (typeRes.data) setUpdateTypes(typeRes.data);
-      if (updateRes.data) {
-        const typeMap = new Map((typeRes.data || []).map((t) => [t.id, t]));
-        const enriched = updateRes.data.map((u) => ({
-          ...u,
-          item_name: itemRes.data?.find((b) => b.id === u.item_id)?.name,
-          update_type_name: typeMap.get(u.update_type_id)?.name,
-        }));
-        setUpdates(enriched);
-      }
+      const users: UserWithMembership[] = membershipRes.data
+        ? membershipRes.data.map((m: any) => ({
+            id: m.users.id,
+            display_name: m.users.display_name,
+            email: m.users.email,
+            is_temporary: m.users.is_temporary,
+            created_at: m.users.created_at,
+            role_name: m.roles.name,
+            role_id: m.role_id,
+            membership_id: m.id,
+          }))
+        : [];
 
-      setLoading(false);
-    }
+      const availableRoles: Role[] = roleRes.data ?? [];
+      const items: Item[] = itemRes.data ?? [];
+      const updateTypes: UpdateType[] = typeRes.data ?? [];
 
-    fetchData();
-  }, []);
+      const typeMap = new Map((typeRes.data || []).map((t) => [t.id, t]));
+      const updates: (ItemUpdate & { item_name?: string; update_type_name?: string })[] = updateRes.data
+        ? updateRes.data.map((u) => ({
+            ...u,
+            item_name: itemRes.data?.find((b) => b.id === u.item_id)?.name,
+            update_type_name: typeMap.get(u.update_type_id)?.name,
+          }))
+        : [];
+
+      return { users, availableRoles, items, updates, updateTypes };
+    },
+  });
+
+  const users = data?.users ?? [];
+  const availableRoles = data?.availableRoles ?? [];
+  const items = data?.items ?? [];
+  const updates = data?.updates ?? [];
+  const updateTypes = data?.updateTypes ?? [];
 
   async function handleDeleteItem(id: string) {
     if (!confirm('Delete this item and all its updates? This cannot be undone.')) return;
@@ -82,8 +84,7 @@ export default function PropertyDataPage() {
     const { error } = await supabase.from('items').delete().eq('id', id);
 
     if (!error) {
-      setItems((prev) => prev.filter((b) => b.id !== id));
-      setUpdates((prev) => prev.filter((u) => u.item_id !== id));
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
     }
   }
 
@@ -94,7 +95,7 @@ export default function PropertyDataPage() {
     const { error } = await supabase.from('item_updates').delete().eq('id', id);
 
     if (!error) {
-      setUpdates((prev) => prev.filter((u) => u.id !== id));
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
     }
   }
 
@@ -106,12 +107,7 @@ export default function PropertyDataPage() {
       .eq('id', membershipId);
 
     if (!error) {
-      const roleName = availableRoles.find(r => r.id === newRoleId)?.name ?? '';
-      setUsers((prev) =>
-        prev.map((u) => u.membership_id === membershipId
-          ? { ...u, role_id: newRoleId, role_name: roleName }
-          : u)
-      );
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
     }
   }
 

--- a/src/app/admin/properties/[slug]/data/page.tsx
+++ b/src/app/admin/properties/[slug]/data/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import type { Item, ItemUpdate, UpdateType, Role } from '@/lib/types';
 import { createClient } from '@/lib/supabase/client';
 import StatusBadge from '@/components/item/StatusBadge';
@@ -22,11 +22,13 @@ type UserWithMembership = {
 
 export default function PropertyDataPage() {
   const router = useRouter();
+  const params = useParams();
+  const slug = params.slug as string;
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<'users' | 'items' | 'updates'>('items');
 
   const { data, isLoading: loading } = useQuery({
-    queryKey: ['admin', 'property-data'],
+    queryKey: ['admin', 'property', slug, 'data'],
     queryFn: async () => {
       const supabase = createClient();
 
@@ -84,7 +86,7 @@ export default function PropertyDataPage() {
     const { error } = await supabase.from('items').delete().eq('id', id);
 
     if (!error) {
-      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'data'] });
     }
   }
 
@@ -95,7 +97,7 @@ export default function PropertyDataPage() {
     const { error } = await supabase.from('item_updates').delete().eq('id', id);
 
     if (!error) {
-      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'data'] });
     }
   }
 
@@ -107,7 +109,7 @@ export default function PropertyDataPage() {
       .eq('id', membershipId);
 
     if (!error) {
-      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-data'] });
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'data'] });
     }
   }
 

--- a/src/app/admin/properties/[slug]/entities/[entityTypeId]/page.tsx
+++ b/src/app/admin/properties/[slug]/entities/[entityTypeId]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type { Entity, EntityType, EntityTypeField } from '@/lib/types';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
@@ -11,55 +12,50 @@ import EntityCard from '@/components/admin/EntityCard';
 export default function EntitiesPage() {
   const params = useParams();
   const entityTypeId = params.entityTypeId as string;
+  const queryClient = useQueryClient();
 
-  const [entityType, setEntityType] = useState<EntityType | null>(null);
-  const [fields, setFields] = useState<EntityTypeField[]>([]);
-  const [entities, setEntities] = useState<Entity[]>([]);
-  const [loading, setLoading] = useState(true);
   const [editingEntity, setEditingEntity] = useState<Entity | undefined>(undefined);
   const [showAdd, setShowAdd] = useState(false);
   const [search, setSearch] = useState('');
   const [error, setError] = useState('');
 
-  useEffect(() => {
-    fetchData();
-  }, [entityTypeId]);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'property', 'entities', entityTypeId],
+    queryFn: async () => {
+      const supabase = createClient();
 
-  async function fetchData() {
-    const supabase = createClient();
+      const [etRes, entitiesRes] = await Promise.all([
+        supabase
+          .from('entity_types')
+          .select('*, entity_type_fields(*)')
+          .eq('id', entityTypeId)
+          .single(),
+        supabase
+          .from('entities')
+          .select('*')
+          .eq('entity_type_id', entityTypeId)
+          .order('sort_order', { ascending: true }),
+      ]);
 
-    const [etRes, entitiesRes] = await Promise.all([
-      supabase
-        .from('entity_types')
-        .select('*, entity_type_fields(*)')
-        .eq('id', entityTypeId)
-        .single(),
-      supabase
-        .from('entities')
-        .select('*')
-        .eq('entity_type_id', entityTypeId)
-        .order('sort_order', { ascending: true }),
-    ]);
+      const entityType = etRes.data ? (etRes.data as EntityType) : null;
+      const fields = etRes.data
+        ? ((etRes.data as EntityType & { entity_type_fields: EntityTypeField[] }).entity_type_fields || [])
+            .sort((a: EntityTypeField, b: EntityTypeField) => a.sort_order - b.sort_order)
+        : [];
+      const entities: Entity[] = entitiesRes.data ?? [];
 
-    if (etRes.data) {
-      setEntityType(etRes.data as EntityType);
-      setFields(
-        ((etRes.data as EntityType & { entity_type_fields: EntityTypeField[] }).entity_type_fields || [])
-          .sort((a: EntityTypeField, b: EntityTypeField) => a.sort_order - b.sort_order)
-      );
-    }
-    if (entitiesRes.data) setEntities(entitiesRes.data);
-    setLoading(false);
-  }
+      return { entityType, fields, entities };
+    },
+  });
 
-  function handleSaved(saved: Entity) {
-    if (editingEntity) {
-      setEntities((prev) => prev.map((e) => (e.id === saved.id ? saved : e)));
-    } else {
-      setEntities((prev) => [...prev, saved]);
-    }
+  const entityType = data?.entityType ?? null;
+  const fields = data?.fields ?? [];
+  const entities = data?.entities ?? [];
+
+  async function handleSaved(_saved: Entity) {
     setEditingEntity(undefined);
     setShowAdd(false);
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property', 'entities', entityTypeId] });
   }
 
   async function handleDelete(entity: Entity) {
@@ -85,7 +81,7 @@ export default function EntitiesPage() {
     if (err) {
       setError(err.message);
     } else {
-      setEntities((prev) => prev.filter((e) => e.id !== entity.id));
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property', 'entities', entityTypeId] });
     }
   }
 

--- a/src/app/admin/properties/[slug]/members/page.tsx
+++ b/src/app/admin/properties/[slug]/members/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import { StatusBadge } from '@/components/admin/StatusBadge';
 import { EmptyState } from '@/components/admin/EmptyState';
@@ -30,12 +31,8 @@ export default function PropertyMembersPage() {
   const slug = params.slug as string;
 
   const [isPending, startTransition] = useTransition();
+  const queryClient = useQueryClient();
 
-  const [property, setProperty] = useState<Property | null>(null);
-  const [members, setMembers] = useState<PropertyMember[]>([]);
-  const [availableRoles, setAvailableRoles] = useState<Role[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [pageError, setPageError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   // Per-member "add override" dropdown state: userId → selected roleId
@@ -47,35 +44,41 @@ export default function PropertyMembersPage() {
   // Data loading
   // ---------------------------------------------------------------------------
 
-  async function loadData() {
-    setLoading(true);
-    setPageError(null);
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin', 'property', slug, 'members'],
+    queryFn: async () => {
+      const [membersResult, rolesResult] = await Promise.all([
+        getPropertyMembers(slug),
+        createClient()
+          .from('roles')
+          .select('id, name, base_role')
+          .neq('base_role', 'platform_admin')
+          .order('sort_order', { ascending: true }),
+      ]);
 
-    const [membersResult, rolesResult] = await Promise.all([
-      getPropertyMembers(slug),
-      createClient()
-        .from('roles')
-        .select('id, name, base_role')
-        .neq('base_role', 'platform_admin')
-        .order('sort_order', { ascending: true }),
-    ]);
+      if (membersResult.error || !membersResult.property) {
+        return {
+          error: membersResult.error ?? 'Property not found',
+          property: null,
+          members: [] as PropertyMember[],
+          availableRoles: [] as Role[],
+        };
+      }
 
-    if (membersResult.error || !membersResult.property) {
-      setPageError(membersResult.error ?? 'Property not found');
-      setLoading(false);
-      return;
-    }
+      return {
+        error: null,
+        property: membersResult.property,
+        members: membersResult.members ?? [],
+        availableRoles: (rolesResult.data ?? []) as Role[],
+      };
+    },
+  });
 
-    setProperty(membersResult.property);
-    setMembers(membersResult.members ?? []);
-    setAvailableRoles((rolesResult.data ?? []) as Role[]);
-    setLoading(false);
-  }
-
-  useEffect(() => {
-    loadData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slug]);
+  const loading = isLoading;
+  const property = data?.property ?? null;
+  const members = data?.members ?? [];
+  const availableRoles = data?.availableRoles ?? [];
+  const pageError = data?.error ?? null;
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -98,7 +101,7 @@ export default function PropertyMembersPage() {
           delete next[userId];
           return next;
         });
-        await loadData();
+        await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'members'] });
       }
     });
   }
@@ -112,7 +115,7 @@ export default function PropertyMembersPage() {
       if (result.error) {
         setActionError(result.error);
       } else {
-        await loadData();
+        await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'members'] });
       }
     });
   }

--- a/src/app/admin/properties/[slug]/settings/page.tsx
+++ b/src/app/admin/properties/[slug]/settings/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useConfig } from '@/lib/config/client';
 import { useRouter, useParams } from 'next/navigation';
@@ -31,33 +32,32 @@ export default function SettingsPage() {
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
-  const [propertyId, setPropertyId] = useState<string | null>(null);
-  const [propertyGeoLayers, setPropertyGeoLayers] = useState<GeoLayerSummary[]>([]);
-  const [layerAssignments, setLayerAssignments] = useState<GeoLayerProperty[]>([]);
   const [currentBoundaryId, setCurrentBoundaryId] = useState<string | null>(null);
 
-  useEffect(() => {
-    const supabase = createClient();
-    supabase
-      .from('properties')
-      .select('id')
-      .eq('slug', slug)
-      .single()
-      .then(({ data }) => {
-        if (data) setPropertyId(data.id);
-      });
-  }, [slug]);
+  const { data: propertyId } = useQuery({
+    queryKey: ['admin', 'property', slug, 'id'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data } = await supabase.from('properties').select('id').eq('slug', slug).single();
+      return data?.id ?? null;
+    },
+  });
 
-  useEffect(() => {
-    if (activeTab === 'geo-layers' && propertyId) {
-      getPropertyGeoLayers(propertyId).then((result) => {
-        if ('success' in result) {
-          setPropertyGeoLayers(result.layers);
-          setLayerAssignments(result.assignments);
-        }
-      });
-    }
-  }, [activeTab, propertyId]);
+  const { data: geoLayerData } = useQuery({
+    queryKey: ['admin', 'property', slug, 'geo-layers'],
+    queryFn: async () => {
+      if (!propertyId) return { layers: [], assignments: [] };
+      const result = await getPropertyGeoLayers(propertyId);
+      if ('success' in result) {
+        return { layers: result.layers, assignments: result.assignments };
+      }
+      return { layers: [], assignments: [] };
+    },
+    enabled: activeTab === 'geo-layers' && !!propertyId,
+  });
+
+  const propertyGeoLayers: GeoLayerSummary[] = geoLayerData?.layers ?? [];
+  const layerAssignments: GeoLayerProperty[] = geoLayerData?.assignments ?? [];
 
   const tabs: { id: SettingsTab; label: string }[] = [
     { id: 'general', label: 'General' },

--- a/src/app/admin/properties/[slug]/types/page.tsx
+++ b/src/app/admin/properties/[slug]/types/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import type { ItemType } from '@/lib/types';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
@@ -9,6 +10,8 @@ import ItemTypeEditor from '@/components/admin/ItemTypeEditor';
 
 export default function TypesPage() {
   const queryClient = useQueryClient();
+  const params = useParams();
+  const slug = params.slug as string;
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const [newName, setNewName] = useState('');
@@ -18,7 +21,7 @@ export default function TypesPage() {
   const [adding, setAdding] = useState(false);
 
   const { data, isLoading: loading } = useQuery({
-    queryKey: ['admin', 'property-types'],
+    queryKey: ['admin', 'property', slug, 'types'],
     queryFn: async () => {
       const supabase = createClient();
 
@@ -63,7 +66,7 @@ export default function TypesPage() {
 
       if (error) throw error;
 
-      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'types'] });
       setNewName('');
       setNewIcon('📍');
       setNewColor('#5D7F3A');
@@ -79,14 +82,14 @@ export default function TypesPage() {
     const supabase = createClient();
     const { error } = await supabase.from('item_types').update(updates).eq('id', id);
     if (error) throw error;
-    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'types'] });
   }
 
   async function handleDeleteType(id: string) {
     const supabase = createClient();
     const { error } = await supabase.from('item_types').delete().eq('id', id);
     if (error) throw error;
-    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'types'] });
     if (expandedId === id) setExpandedId(null);
   }
 
@@ -104,7 +107,7 @@ export default function TypesPage() {
       supabase.from('item_types').update({ sort_order: current.sort_order }).eq('id', swap.id),
     ]);
 
-    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'types'] });
   }
 
   if (loading) return <LoadingSpinner className="py-12" />;

--- a/src/app/admin/properties/[slug]/types/page.tsx
+++ b/src/app/admin/properties/[slug]/types/page.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type { ItemType } from '@/lib/types';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import ItemTypeEditor from '@/components/admin/ItemTypeEditor';
 
 export default function TypesPage() {
-  const [itemTypes, setItemTypes] = useState<ItemType[]>([]);
-  const [itemCounts, setItemCounts] = useState<Record<string, number>>({});
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const [newName, setNewName] = useState('');
@@ -18,30 +17,32 @@ export default function TypesPage() {
   const [addError, setAddError] = useState('');
   const [adding, setAdding] = useState(false);
 
-  useEffect(() => {
-    fetchData();
-  }, []);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'property-types'],
+    queryFn: async () => {
+      const supabase = createClient();
 
-  async function fetchData() {
-    const supabase = createClient();
+      const [typeRes, itemRes] = await Promise.all([
+        supabase.from('item_types').select('*').order('sort_order', { ascending: true }),
+        supabase.from('items').select('id, item_type_id'),
+      ]);
 
-    const [typeRes, itemRes] = await Promise.all([
-      supabase.from('item_types').select('*').order('sort_order', { ascending: true }),
-      supabase.from('items').select('id, item_type_id'),
-    ]);
+      const itemTypes: ItemType[] = typeRes.data ?? [];
 
-    if (typeRes.data) setItemTypes(typeRes.data);
-
-    // Count items per type
-    const counts: Record<string, number> = {};
-    if (itemRes.data) {
-      for (const item of itemRes.data) {
-        counts[item.item_type_id] = (counts[item.item_type_id] || 0) + 1;
+      // Count items per type
+      const itemCounts: Record<string, number> = {};
+      if (itemRes.data) {
+        for (const item of itemRes.data) {
+          itemCounts[item.item_type_id] = (itemCounts[item.item_type_id] || 0) + 1;
+        }
       }
-    }
-    setItemCounts(counts);
-    setLoading(false);
-  }
+
+      return { itemTypes, itemCounts };
+    },
+  });
+
+  const itemTypes = data?.itemTypes ?? [];
+  const itemCounts = data?.itemCounts ?? {};
 
   async function handleAddType(e: React.FormEvent) {
     e.preventDefault();
@@ -62,8 +63,7 @@ export default function TypesPage() {
 
       if (error) throw error;
 
-      setItemTypes((prev) => [...prev, data]);
-      setItemCounts((prev) => ({ ...prev, [data.id]: 0 }));
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
       setNewName('');
       setNewIcon('📍');
       setNewColor('#5D7F3A');
@@ -79,15 +79,14 @@ export default function TypesPage() {
     const supabase = createClient();
     const { error } = await supabase.from('item_types').update(updates).eq('id', id);
     if (error) throw error;
-    setItemTypes((prev) => prev.map((t) => (t.id === id ? { ...t, ...updates } : t)));
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
   }
 
   async function handleDeleteType(id: string) {
     const supabase = createClient();
     const { error } = await supabase.from('item_types').delete().eq('id', id);
     if (error) throw error;
-    setItemTypes((prev) => prev.filter((t) => t.id !== id));
-    setItemCounts((prev) => { const c = { ...prev }; delete c[id]; return c; });
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
     if (expandedId === id) setExpandedId(null);
   }
 
@@ -105,11 +104,7 @@ export default function TypesPage() {
       supabase.from('item_types').update({ sort_order: current.sort_order }).eq('id', swap.id),
     ]);
 
-    const updated = [...itemTypes];
-    updated[index] = { ...current, sort_order: swap.sort_order };
-    updated[swapIndex] = { ...swap, sort_order: current.sort_order };
-    updated.sort((a, b) => a.sort_order - b.sort_order);
-    setItemTypes(updated);
+    await queryClient.invalidateQueries({ queryKey: ['admin', 'property-types'] });
   }
 
   if (loading) return <LoadingSpinner className="py-12" />;

--- a/src/app/admin/properties/page.tsx
+++ b/src/app/admin/properties/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import { StatusBadge, derivePropertyStatus } from '@/components/admin/StatusBadge';
 import { EmptyState } from '@/components/admin/EmptyState';
@@ -36,12 +37,8 @@ function toSlug(name: string): string {
 export default function PropertiesPage() {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const queryClient = useQueryClient();
 
-  const [properties, setProperties] = useState<Property[]>([]);
-  const [itemCounts, setItemCounts] = useState<Record<string, number>>({});
-  const [memberCounts, setMemberCounts] = useState<Record<string, number>>({});
-  const [customDomains, setCustomDomains] = useState<Record<string, string>>({});
-  const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<FilterTab>('all');
   const [showCreateForm, setShowCreateForm] = useState(false);
 
@@ -52,12 +49,15 @@ export default function PropertiesPage() {
   const [formError, setFormError] = useState<string | null>(null);
   const [formLoading, setFormLoading] = useState(false);
 
-  async function loadProperties() {
-    const result = await getProperties();
-    if (result.properties) {
-      const props = result.properties as Property[];
-      setProperties(props);
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin', 'properties'],
+    queryFn: async () => {
+      const result = await getProperties();
+      if (!result.properties) {
+        return { properties: [], itemCounts: {}, memberCounts: {}, customDomains: {} };
+      }
 
+      const props = result.properties as Property[];
       const supabase = createClient();
       const propertyIds = props.map((p) => p.id);
 
@@ -74,36 +74,36 @@ export default function PropertiesPage() {
           .eq('status', 'active'),
       ]);
 
+      const itemCounts: Record<string, number> = {};
       if (itemsRes.data) {
-        const counts: Record<string, number> = {};
         for (const item of itemsRes.data) {
-          counts[item.property_id] = (counts[item.property_id] || 0) + 1;
+          itemCounts[item.property_id] = (itemCounts[item.property_id] || 0) + 1;
         }
-        setItemCounts(counts);
       }
 
+      const memberCounts: Record<string, number> = {};
       if (membershipsRes.data) {
-        const counts: Record<string, number> = {};
         for (const m of membershipsRes.data) {
-          counts[m.property_id] = (counts[m.property_id] || 0) + 1;
+          memberCounts[m.property_id] = (memberCounts[m.property_id] || 0) + 1;
         }
-        setMemberCounts(counts);
       }
 
+      const customDomains: Record<string, string> = {};
       if (domainsRes.data) {
-        const domains: Record<string, string> = {};
         for (const d of domainsRes.data) {
-          domains[d.property_id] = d.domain;
+          customDomains[d.property_id] = d.domain;
         }
-        setCustomDomains(domains);
       }
-    }
-    setLoading(false);
-  }
 
-  useEffect(() => {
-    loadProperties();
-  }, []);
+      return { properties: props, itemCounts, memberCounts, customDomains };
+    },
+  });
+
+  const properties = data?.properties ?? [];
+  const itemCounts = data?.itemCounts ?? {};
+  const memberCounts = data?.memberCounts ?? {};
+  const customDomains = data?.customDomains ?? {};
+  const loading = isLoading;
 
   function handleNameChange(name: string) {
     setFormName(name);
@@ -138,7 +138,7 @@ export default function PropertiesPage() {
     const action = property.deleted_at !== null ? unarchiveProperty : archiveProperty;
     startTransition(async () => {
       await action(property.id);
-      await loadProperties();
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'properties'] });
     });
   }
 

--- a/src/app/admin/roles/[roleId]/page.tsx
+++ b/src/app/admin/roles/[roleId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useRouter, useParams } from 'next/navigation';
 import PermissionEditor from '@/components/admin/PermissionEditor';
 import { getRoles, updateRole } from '../actions';
@@ -21,10 +22,6 @@ export default function RoleEditorPage() {
   const params = useParams();
   const roleId = params.roleId as string;
 
-  const [role, setRole] = useState<Role | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [notFound, setNotFound] = useState(false);
-
   // Editable fields
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -35,31 +32,28 @@ export default function RoleEditorPage() {
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [saveMessage, setSaveMessage] = useState('');
 
-  useEffect(() => {
-    async function load() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin', 'roles', roleId],
+    queryFn: async () => {
       const result = await getRoles();
-      if (!result.roles) {
-        setNotFound(true);
-        setLoading(false);
-        return;
-      }
-
+      if (!result.roles) return { role: null, notFound: true };
       const found = (result.roles as Role[]).find((r) => r.id === roleId);
-      if (!found) {
-        setNotFound(true);
-        setLoading(false);
-        return;
-      }
+      if (!found) return { role: null, notFound: true };
+      return { role: found, notFound: false };
+    },
+  });
 
-      setRole(found);
-      setName(found.name);
-      setDescription(found.description ?? '');
-      setPermissions(found.permissions);
-      setLoading(false);
+  const role = data?.role ?? null;
+  const notFound = data?.notFound ?? false;
+  const loading = isLoading;
+
+  useEffect(() => {
+    if (role) {
+      setName(role.name);
+      setDescription(role.description ?? '');
+      setPermissions(role.permissions);
     }
-
-    load();
-  }, [roleId]);
+  }, [role]);
 
   async function handleSave() {
     if (!role || !permissions) return;
@@ -82,8 +76,6 @@ export default function RoleEditorPage() {
     } else {
       setSaveStatus('success');
       setSaveMessage('Role saved successfully.');
-      // Refresh role data
-      setRole((prev) => prev ? { ...prev, name: name.trim(), description: description.trim() || null, permissions } : prev);
     }
   }
 

--- a/src/app/admin/roles/[roleId]/page.tsx
+++ b/src/app/admin/roles/[roleId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter, useParams } from 'next/navigation';
 import PermissionEditor from '@/components/admin/PermissionEditor';
 import { getRoles, updateRole } from '../actions';
@@ -21,6 +21,8 @@ export default function RoleEditorPage() {
   const router = useRouter();
   const params = useParams();
   const roleId = params.roleId as string;
+  const queryClient = useQueryClient();
+  const initialized = useRef(false);
 
   // Editable fields
   const [name, setName] = useState('');
@@ -48,7 +50,8 @@ export default function RoleEditorPage() {
   const loading = isLoading;
 
   useEffect(() => {
-    if (role) {
+    if (role && !initialized.current) {
+      initialized.current = true;
       setName(role.name);
       setDescription(role.description ?? '');
       setPermissions(role.permissions);
@@ -76,6 +79,7 @@ export default function RoleEditorPage() {
     } else {
       setSaveStatus('success');
       setSaveMessage('Role saved successfully.');
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'roles', roleId] });
     }
   }
 

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getOrgSettings, updateOrgSettings } from './actions';
-import type { OrgSettings, OrgSettingsUpdates } from './actions';
+import type { OrgSettingsUpdates } from './actions';
 import type { SubscriptionTier, SubscriptionStatus } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -44,8 +45,7 @@ const STATUS_COLORS: Record<SubscriptionStatus, string> = {
 
 export default function OrgSettingsPage() {
   const router = useRouter();
-  const [settings, setSettings] = useState<OrgSettings | null>(null);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
 
@@ -57,24 +57,27 @@ export default function OrgSettingsPage() {
   const [themeJson, setThemeJson] = useState('');
   const [themeJsonError, setThemeJsonError] = useState('');
 
-  useEffect(() => {
-    async function load() {
+  const { data: settings, isLoading: loading } = useQuery({
+    queryKey: ['admin', 'settings'],
+    queryFn: async () => {
       const result = await getOrgSettings();
       if (result.error) {
         setMessage(`Error: ${result.error}`);
-      } else if (result.data) {
-        const s = result.data;
-        setSettings(s);
-        setName(s.name ?? '');
-        setSlug(s.slug ?? '');
-        setTagline(s.tagline ?? '');
-        setLogoUrl(s.logo_url ?? '');
-        setThemeJson(s.theme ? JSON.stringify(s.theme, null, 2) : '');
+        return null;
       }
-      setLoading(false);
+      return result.data ?? null;
+    },
+  });
+
+  useEffect(() => {
+    if (settings) {
+      setName(settings.name ?? '');
+      setSlug(settings.slug ?? '');
+      setTagline(settings.tagline ?? '');
+      setLogoUrl(settings.logo_url ?? '');
+      setThemeJson(settings.theme ? JSON.stringify(settings.theme, null, 2) : '');
     }
-    load();
-  }, []);
+  }, [settings]);
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -111,9 +114,7 @@ export default function OrgSettingsPage() {
       setMessage(`Error: ${result.error}`);
     } else {
       setMessage('Settings saved!');
-      // Refresh local settings snapshot
-      const fresh = await getOrgSettings();
-      if (fresh.data) setSettings(fresh.data);
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'settings'] });
       router.refresh();
       setTimeout(() => setMessage(''), 3000);
     }

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getOrgSettings, updateOrgSettings } from './actions';
@@ -46,6 +46,7 @@ const STATUS_COLORS: Record<SubscriptionStatus, string> = {
 export default function OrgSettingsPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const initialized = useRef(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
 
@@ -70,7 +71,8 @@ export default function OrgSettingsPage() {
   });
 
   useEffect(() => {
-    if (settings) {
+    if (settings && !initialized.current) {
+      initialized.current = true;
       setName(settings.name ?? '');
       setSlug(settings.slug ?? '');
       setTagline(settings.tagline ?? '');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ConfigProvider } from '@/lib/config/client';
 import { getConfig } from '@/lib/config/server';
 import { resolveTheme, themeToCssVars } from '@/lib/config/themes';
 import { UserLocationProvider } from '@/lib/location/provider';
+import QueryProvider from '@/components/QueryProvider';
 import { OfflineProvider } from '@/lib/offline/provider';
 import { createClient } from '@/lib/supabase/server';
 import type { Data } from '@puckeditor/core';
@@ -67,16 +68,18 @@ export default async function RootLayout({
         <ConfigProvider config={config} theme={theme}>
           <UserLocationProvider>
             <OfflineProvider>
-              {puckRoot ? (
-                <PuckRootRenderer data={puckRoot}>
-                  <main className="flex-1">{children}</main>
-                </PuckRootRenderer>
-              ) : (
-                <>
-                  <Navigation isAuthenticated={!!user} />
-                  <main className="flex-1">{children}</main>
-                </>
-              )}
+              <QueryProvider>
+                {puckRoot ? (
+                  <PuckRootRenderer data={puckRoot}>
+                    <main className="flex-1">{children}</main>
+                  </PuckRootRenderer>
+                ) : (
+                  <>
+                    <Navigation isAuthenticated={!!user} />
+                    <main className="flex-1">{children}</main>
+                  </>
+                )}
+              </QueryProvider>
             </OfflineProvider>
           </UserLocationProvider>
         </ConfigProvider>

--- a/src/app/manage/page.tsx
+++ b/src/app/manage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import type { Item } from '@/lib/types';
 import { createClient } from '@/lib/supabase/client';
@@ -9,24 +9,15 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { usePermissions } from '@/lib/permissions/hooks';
 
 export default function ManageDashboard() {
-  const [items, setItems] = useState<Item[]>([]);
-  const [loading, setLoading] = useState(true);
   const { permissions } = usePermissions();
-
-  useEffect(() => {
-    async function fetchData() {
+  const { data: items = [], isLoading: loading } = useQuery({
+    queryKey: ['manage', 'dashboard'],
+    queryFn: async () => {
       const supabase = createClient();
-      const { data } = await supabase
-        .from('items')
-        .select('*')
-        .order('name', { ascending: true });
-
-      if (data) setItems(data);
-      setLoading(false);
-    }
-
-    fetchData();
-  }, []);
+      const { data } = await supabase.from('items').select('*').order('name', { ascending: true });
+      return (data ?? []) as Item[];
+    },
+  });
 
   const stats = {
     total: items.length,

--- a/src/components/QueryProvider.tsx
+++ b/src/components/QueryProvider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            gcTime: 300_000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/components/manage/EntitySelect.tsx
+++ b/src/components/manage/EntitySelect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type { Entity } from '@/lib/types';
 
@@ -12,23 +13,16 @@ interface EntitySelectProps {
 }
 
 export default function EntitySelect({ entityTypeId, entityTypeName, selectedIds, onChange }: EntitySelectProps) {
-  const [entities, setEntities] = useState<Entity[]>([]);
-  const [loading, setLoading] = useState(true);
   const [showDropdown, setShowDropdown] = useState(false);
 
-  useEffect(() => {
-    async function fetch() {
+  const { data: entities = [], isLoading: loading } = useQuery({
+    queryKey: ['entities', entityTypeId],
+    queryFn: async () => {
       const supabase = createClient();
-      const { data } = await supabase
-        .from('entities')
-        .select('*')
-        .eq('entity_type_id', entityTypeId)
-        .order('sort_order', { ascending: true });
-      if (data) setEntities(data);
-      setLoading(false);
-    }
-    fetch();
-  }, [entityTypeId]);
+      const { data } = await supabase.from('entities').select('*').eq('entity_type_id', entityTypeId).order('sort_order', { ascending: true });
+      return (data ?? []) as Entity[];
+    },
+  });
 
   function toggleEntity(id: string) {
     if (selectedIds.includes(id)) {

--- a/src/components/manage/LocationHistory.tsx
+++ b/src/components/manage/LocationHistory.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import type { LocationHistory as LocationHistoryType, Profile } from '@/lib/types';
 import { formatShortDate } from '@/lib/utils';
@@ -11,46 +11,21 @@ interface LocationHistoryProps {
 }
 
 export default function LocationHistory({ itemId, onRevert }: LocationHistoryProps) {
-  const [history, setHistory] = useState<LocationHistoryType[]>([]);
-  const [profiles, setProfiles] = useState<Record<string, Profile>>({});
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    async function fetchData() {
+  const { data: queryData, isLoading: loading } = useQuery({
+    queryKey: ['location-history', itemId],
+    queryFn: async () => {
       const supabase = createClient();
-
-      const { data: historyData } = await supabase
-        .from('location_history')
-        .select('*')
-        .eq('item_id', itemId)
-        .order('created_at', { ascending: false });
-
-      if (!historyData || historyData.length === 0) {
-        setLoading(false);
-        return;
-      }
-
-      setHistory(historyData);
-
+      const { data: historyData } = await supabase.from('location_history').select('*').eq('item_id', itemId).order('created_at', { ascending: false });
+      if (!historyData || historyData.length === 0) return { history: [], profiles: {} };
       const creatorIds = Array.from(new Set(historyData.map((h) => h.created_by)));
-      const { data: profileData } = await supabase
-        .from('users')
-        .select('*')
-        .in('id', creatorIds);
-
-      if (profileData) {
-        const profileMap: Record<string, Profile> = {};
-        for (const p of profileData) {
-          profileMap[p.id] = p;
-        }
-        setProfiles(profileMap);
-      }
-
-      setLoading(false);
-    }
-
-    fetchData();
-  }, [itemId]);
+      const { data: profileData } = await supabase.from('users').select('*').in('id', creatorIds);
+      const profiles: Record<string, Profile> = {};
+      if (profileData) { for (const p of profileData) { profiles[p.id] = p; } }
+      return { history: historyData as LocationHistoryType[], profiles };
+    },
+  });
+  const history = queryData?.history ?? [];
+  const profiles = queryData?.profiles ?? {};
 
   if (loading) return null;
 


### PR DESCRIPTION
## Summary

- Adds `@tanstack/react-query` with a 30s stale time / 5min GC time `QueryProvider` to the app layout
- Converts 14 admin pages and components from `useEffect` + `useState` + `createClient()` patterns to `useQuery()` hooks for stale-while-revalidate caching
- All mutations use `queryClient.invalidateQueries()` after success to trigger refetch
- Form-based pages (settings, role editor) use `useRef` guards to prevent background revalidation from overwriting unsaved edits

**Pages converted:** admin settings, members, properties, property settings, property data, property types, property entities, property members, geo-layers, roles, domains, manage dashboard, EntitySelect, LocationHistory

**Not converted (by design):** Navigation.tsx (uses auth subscription), map/list/item pages (already use IndexedDB offline store)

Closes #145

## Test plan
- [ ] Navigate between admin pages — second visit should show cached data instantly
- [ ] Edit and save on settings/roles pages — form fields should not reset during editing
- [ ] Archive/unarchive a property — list should refresh after action
- [ ] Type check, unit tests (501), and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)