### PR TITLE
Fix preview 500 error — add 'use client' to Puck renderers

### DIFF
--- a/src/components/puck/PuckPageRenderer.tsx
+++ b/src/components/puck/PuckPageRenderer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Render } from '@puckeditor/core';
 import { pageConfig } from '@/lib/puck/config';
 import type { Data } from '@puckeditor/core';

--- a/src/components/puck/PuckRootRenderer.tsx
+++ b/src/components/puck/PuckRootRenderer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Render } from '@puckeditor/core';
 import { chromeConfig } from '@/lib/puck/chrome-config';
 import type { Data } from '@puckeditor/core';

--- a/src/components/puck/__tests__/renderer-client-directive.test.ts
+++ b/src/components/puck/__tests__/renderer-client-directive.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('Puck renderer client directives', () => {
+  it('PuckPageRenderer has "use client" directive', () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, '..', 'PuckPageRenderer.tsx'),
+      'utf-8'
+    );
+    expect(content.trimStart()).toMatch(/^['"]use client['"]/);
+  });
+
+  it('PuckRootRenderer has "use client" directive', () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, '..', 'PuckRootRenderer.tsx'),
+      'utf-8'
+    );
+    expect(content.trimStart()).toMatch(/^['"]use client['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #141

- `PuckPageRenderer` and `PuckRootRenderer` were missing the `'use client'` directive
- They import `Render` from `@puckeditor/core` which uses React hooks (`useMemo`, `lazy`, `Suspense`)
- On Vercel, the `react-server` export condition resolves to `rsc.js` — hooks crash in RSC context
- Only preview mode (`?preview=true`) was affected because the normal homepage uses the legacy `LandingRenderer`, not Puck

## Test plan

- [x] Unit test verifying both renderers have `'use client'` directive
- [x] All 134 existing Puck tests pass
- [x] TypeScript type check clean
- [x] Production build succeeds
- [ ] Deploy and verify `https://www.fairbankseagle.org/?preview=true` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)