### PR TITLE
Add E2E test for site builder preview mode

### DIFF
--- a/e2e/tests/site-builder/preview.spec.ts
+++ b/e2e/tests/site-builder/preview.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Site Builder Preview', () => {
+  test('homepage with ?preview=true does not crash (issue #141)', async ({ page }) => {
+    const response = await page.goto('/?preview=true');
+
+    // Must not return a 500 error
+    expect(response?.status()).toBeLessThan(500);
+
+    // Must not show the Next.js error page
+    await expect(
+      page.locator('text=Application error')
+    ).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('preview mode shows preview banner or normal content', async ({ page }) => {
+    await page.goto('/?preview=true');
+    await page.waitForLoadState('networkidle');
+
+    // Page should load — title should not be empty
+    const title = await page.title();
+    expect(title).not.toBe('');
+
+    // Must not show an error page
+    const hasError = await page
+      .locator('text=Application error')
+      .isVisible()
+      .catch(() => false);
+
+    expect(hasError).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the E2E test that was lost during squash merge of #155. Covers the fix for #141.

- Verifies `/?preview=true` does not return a 500 error
- Verifies page renders content without the Next.js error boundary

## Test plan

- [ ] E2E suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)