### PR TITLE
Add link autofill to site builder

### DIFF
--- a/src/components/puck/PuckChromeEditor.tsx
+++ b/src/components/puck/PuckChromeEditor.tsx
@@ -4,6 +4,7 @@ import { Puck } from '@puckeditor/core';
 import '@puckeditor/core/dist/index.css';
 import { chromeConfig } from '@/lib/puck/chrome-config';
 import { savePuckRootDraft, publishPuckRoot } from '@/app/admin/site-builder/actions';
+import { PuckSuggestionsProvider } from '@/lib/puck/fields';
 import type { Data } from '@puckeditor/core';
 import { useState, useCallback } from 'react';
 
@@ -13,8 +14,10 @@ interface PuckChromeEditorProps {
 
 export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
+  const [puckData, setPuckData] = useState<Data>(initialData);
 
   const handleChange = useCallback(async (data: Data) => {
+    setPuckData(data);
     setIsSaving(true);
     await savePuckRootDraft(data);
     setIsSaving(false);
@@ -30,12 +33,14 @@ export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
 
   return (
     <div className="h-screen">
-      <Puck
-        config={chromeConfig}
-        data={initialData}
-        onChange={handleChange}
-        onPublish={handlePublish}
-      />
+      <PuckSuggestionsProvider data={puckData}>
+        <Puck
+          config={chromeConfig}
+          data={initialData}
+          onChange={handleChange}
+          onPublish={handlePublish}
+        />
+      </PuckSuggestionsProvider>
     </div>
   );
 }

--- a/src/components/puck/PuckPageEditor.tsx
+++ b/src/components/puck/PuckPageEditor.tsx
@@ -4,6 +4,7 @@ import { Puck } from '@puckeditor/core';
 import '@puckeditor/core/dist/index.css';
 import { pageConfig } from '@/lib/puck/config';
 import { savePuckPageDraft, publishPuckPages } from '@/app/admin/site-builder/actions';
+import { PuckSuggestionsProvider } from '@/lib/puck/fields';
 import type { Data } from '@puckeditor/core';
 import { useState, useCallback } from 'react';
 
@@ -14,8 +15,10 @@ interface PuckPageEditorProps {
 
 export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
+  const [puckData, setPuckData] = useState<Data>(initialData);
 
   const handleChange = useCallback(async (data: Data) => {
+    setPuckData(data);
     setIsSaving(true);
     await savePuckPageDraft(pagePath, data);
     setIsSaving(false);
@@ -31,12 +34,14 @@ export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
 
   return (
     <div className="h-screen">
-      <Puck
-        config={pageConfig}
-        data={initialData}
-        onChange={handleChange}
-        onPublish={handlePublish}
-      />
+      <PuckSuggestionsProvider data={puckData}>
+        <Puck
+          config={pageConfig}
+          data={initialData}
+          onChange={handleChange}
+          onPublish={handlePublish}
+        />
+      </PuckSuggestionsProvider>
     </div>
   );
 }

--- a/src/lib/puck/fields/LinkField.tsx
+++ b/src/lib/puck/fields/LinkField.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { LinkValue } from './link-utils';
 import { resolveLink } from './link-utils';
 import { ColorPickerField } from './ColorPickerField';
+import { PUBLIC_ROUTES, type LinkSuggestion } from './link-suggestions';
+import { useLinkSuggestions } from './PuckSuggestionsProvider';
 
 interface LinkFieldProps {
   value: string | LinkValue | undefined;
@@ -15,6 +17,12 @@ export function LinkField({ value, onChange }: LinkFieldProps) {
   const [href, setHref] = useState(resolved.href);
   const [target, setTarget] = useState<'_blank' | undefined>(resolved.target);
   const [color, setColor] = useState<string | undefined>(resolved.color);
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listboxId = useRef(`linkfield-listbox-${Math.random().toString(36).slice(2, 8)}`).current;
+
+  const { externalLinks } = useLinkSuggestions();
 
   useEffect(() => {
     const r = resolveLink(value);
@@ -22,6 +30,22 @@ export function LinkField({ value, onChange }: LinkFieldProps) {
     setTarget(r.target);
     setColor(r.color);
   }, [value]);
+
+  const filteredPages = PUBLIC_ROUTES.filter(
+    (r) =>
+      !href ||
+      r.label.toLowerCase().includes(href.toLowerCase()) ||
+      r.href.toLowerCase().includes(href.toLowerCase())
+  );
+
+  const filteredExternal = externalLinks.filter(
+    (r) =>
+      !href ||
+      r.label.toLowerCase().includes(href.toLowerCase()) ||
+      r.href.toLowerCase().includes(href.toLowerCase())
+  );
+
+  const allSuggestions: LinkSuggestion[] = [...filteredPages, ...filteredExternal];
 
   function emitChange(updates: Partial<LinkValue>) {
     const next: LinkValue = {
@@ -32,8 +56,65 @@ export function LinkField({ value, onChange }: LinkFieldProps) {
     onChange(next);
   }
 
-  function handleHrefBlur() {
+  function selectSuggestion(suggestion: LinkSuggestion) {
+    const isExternal = suggestion.href.startsWith('http');
+    const newTarget = isExternal ? '_blank' : target;
+    setHref(suggestion.href);
+    setTarget(newTarget);
+    setIsOpen(false);
+    setActiveIndex(-1);
+    onChange({
+      href: suggestion.href,
+      target: newTarget,
+      color,
+    });
+  }
+
+  function handleFocus() {
+    setIsOpen(true);
+    setActiveIndex(-1);
+  }
+
+  function handleBlur(e: React.FocusEvent) {
+    if (containerRef.current?.contains(e.relatedTarget as Node)) return;
+    setIsOpen(false);
+    setActiveIndex(-1);
     emitChange({ href });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        setIsOpen(true);
+        setActiveIndex(0);
+        e.preventDefault();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          prev < allSuggestions.length - 1 ? prev + 1 : prev
+        );
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((prev) => (prev > 0 ? prev - 1 : prev));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (activeIndex >= 0 && activeIndex < allSuggestions.length) {
+          selectSuggestion(allSuggestions[activeIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setIsOpen(false);
+        setActiveIndex(-1);
+        break;
+    }
   }
 
   function handleTargetToggle() {
@@ -47,16 +128,103 @@ export function LinkField({ value, onChange }: LinkFieldProps) {
     emitChange({ color: c });
   }
 
+  const showExternal = filteredExternal.length > 0;
+  const activeId =
+    activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined;
+
   return (
-    <div className="space-y-2">
-      <input
-        type="text"
-        value={href}
-        onChange={(e) => setHref(e.target.value)}
-        onBlur={handleHrefBlur}
-        placeholder="URL (e.g. /about or https://...)"
-        className="w-full rounded border border-gray-300 px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-300"
-      />
+    <div className="space-y-2" ref={containerRef}>
+      <div className="relative">
+        <input
+          type="text"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={activeId}
+          aria-autocomplete="list"
+          value={href}
+          onChange={(e) => {
+            setHref(e.target.value);
+            setIsOpen(true);
+            setActiveIndex(-1);
+          }}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder="Search pages or type URL..."
+          className="w-full rounded border border-gray-300 px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-300"
+        />
+
+        {isOpen && allSuggestions.length > 0 && (
+          <ul
+            id={listboxId}
+            role="listbox"
+            className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded border border-gray-200 bg-white shadow-lg"
+          >
+            {filteredPages.length > 0 && (
+              <>
+                <li className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500 bg-gray-50">
+                  Pages
+                </li>
+                {filteredPages.map((suggestion, i) => {
+                  const globalIndex = i;
+                  return (
+                    <li
+                      key={suggestion.href}
+                      id={`${listboxId}-option-${globalIndex}`}
+                      role="option"
+                      aria-selected={activeIndex === globalIndex}
+                      className={`flex cursor-pointer items-center justify-between px-2 py-1.5 text-xs ${
+                        activeIndex === globalIndex
+                          ? 'bg-blue-50 text-blue-700'
+                          : 'hover:bg-gray-50'
+                      }`}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => selectSuggestion(suggestion)}
+                    >
+                      <span>{suggestion.label}</span>
+                      <span className="text-[10px] text-gray-400">
+                        {suggestion.href}
+                      </span>
+                    </li>
+                  );
+                })}
+              </>
+            )}
+
+            {showExternal && (
+              <>
+                <li className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500 bg-gray-50">
+                  Previously Used
+                </li>
+                {filteredExternal.map((suggestion, i) => {
+                  const globalIndex = filteredPages.length + i;
+                  return (
+                    <li
+                      key={suggestion.href}
+                      id={`${listboxId}-option-${globalIndex}`}
+                      role="option"
+                      aria-selected={activeIndex === globalIndex}
+                      className={`flex cursor-pointer items-center justify-between px-2 py-1.5 text-xs ${
+                        activeIndex === globalIndex
+                          ? 'bg-blue-50 text-blue-700'
+                          : 'hover:bg-gray-50'
+                      }`}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => selectSuggestion(suggestion)}
+                    >
+                      <span><span aria-hidden="true">🔗 </span>{suggestion.label}</span>
+                      <span className="max-w-[120px] truncate text-[10px] text-gray-400">
+                        {suggestion.href}
+                      </span>
+                    </li>
+                  );
+                })}
+              </>
+            )}
+          </ul>
+        )}
+      </div>
 
       <div className="flex items-center gap-3">
         <label className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer">

--- a/src/lib/puck/fields/PuckSuggestionsProvider.tsx
+++ b/src/lib/puck/fields/PuckSuggestionsProvider.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { extractExternalLinks, type LinkSuggestion } from './link-suggestions';
+
+interface SuggestionsContextValue {
+  externalLinks: LinkSuggestion[];
+}
+
+const SuggestionsContext = createContext<SuggestionsContextValue>({
+  externalLinks: [],
+});
+
+interface PuckSuggestionsProviderProps {
+  data: any;
+  children: ReactNode;
+}
+
+export function PuckSuggestionsProvider({ data, children }: PuckSuggestionsProviderProps) {
+  const externalLinks = useMemo(() => extractExternalLinks(data), [data]);
+  const value = useMemo(() => ({ externalLinks }), [externalLinks]);
+
+  return (
+    <SuggestionsContext.Provider value={value}>
+      {children}
+    </SuggestionsContext.Provider>
+  );
+}
+
+export function useLinkSuggestions(): SuggestionsContextValue {
+  return useContext(SuggestionsContext);
+}

--- a/src/lib/puck/fields/__tests__/LinkField.test.tsx
+++ b/src/lib/puck/fields/__tests__/LinkField.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LinkField } from '../LinkField';
+import { PuckSuggestionsProvider } from '../PuckSuggestionsProvider';
 
 // Mock ColorPickerField
 vi.mock('../ColorPickerField', () => ({
@@ -11,6 +13,18 @@ vi.mock('../ColorPickerField', () => ({
     </div>
   ),
 }));
+
+vi.mock('../link-suggestions', async () => {
+  const actual = await vi.importActual('../link-suggestions');
+  return {
+    ...actual,
+    PUBLIC_ROUTES: [
+      { href: '/', label: 'Home' },
+      { href: '/map', label: 'Map' },
+      { href: '/about', label: 'About' },
+    ],
+  };
+});
 
 describe('LinkField', () => {
   it('renders href when value is a string', () => {
@@ -49,5 +63,112 @@ describe('LinkField', () => {
   it('shows color picker', () => {
     render(<LinkField value={{ href: '/about' }} onChange={vi.fn()} />);
     expect(screen.getByTestId('color-picker')).toBeDefined();
+  });
+});
+
+describe('combobox', () => {
+  it('opens dropdown on focus showing page suggestions', async () => {
+    render(<LinkField value="" onChange={vi.fn()} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeDefined();
+    expect(screen.getByText('Home')).toBeDefined();
+    expect(screen.getByText('Map')).toBeDefined();
+    expect(screen.getByText('About')).toBeDefined();
+  });
+
+  it('closes dropdown on Escape', async () => {
+    render(<LinkField value="" onChange={vi.fn()} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeDefined();
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('filters suggestions by typing', async () => {
+    render(<LinkField value="" onChange={vi.fn()} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'ma' } });
+    expect(screen.getByText('Map')).toBeDefined();
+    expect(screen.queryByText('About')).toBeNull();
+  });
+
+  it('selects a suggestion on click and closes dropdown', async () => {
+    const onChange = vi.fn();
+    render(<LinkField value="" onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByText('Map'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ href: '/map' })
+    );
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('selects suggestion with Enter key', async () => {
+    const onChange = vi.fn();
+    render(<LinkField value="" onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ href: '/' })
+    );
+  });
+
+  it('auto-sets target _blank for external URL suggestions', async () => {
+    const puckData = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Card',
+          props: { id: 'c1', linkHref: 'https://example.com' },
+        },
+      ],
+    };
+    const onChange = vi.fn();
+    render(
+      <PuckSuggestionsProvider data={puckData}>
+        <LinkField value="" onChange={onChange} />
+      </PuckSuggestionsProvider>
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.click(screen.getByText('example.com'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ href: 'https://example.com', target: '_blank' })
+    );
+  });
+
+  it('shows only pages group when no provider', async () => {
+    render(<LinkField value="" onChange={vi.fn()} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByText('Pages')).toBeDefined();
+    expect(screen.queryByText('Previously Used')).toBeNull();
+  });
+
+  it('shows Previously Used group when provider has external links', async () => {
+    const puckData = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Card',
+          props: { id: 'c1', linkHref: 'https://example.com' },
+        },
+      ],
+    };
+    render(
+      <PuckSuggestionsProvider data={puckData}>
+        <LinkField value="" onChange={vi.fn()} />
+      </PuckSuggestionsProvider>
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    expect(screen.getByText('Pages')).toBeDefined();
+    expect(screen.getByText('Previously Used')).toBeDefined();
   });
 });

--- a/src/lib/puck/fields/__tests__/PuckSuggestionsProvider.test.tsx
+++ b/src/lib/puck/fields/__tests__/PuckSuggestionsProvider.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { PuckSuggestionsProvider, useLinkSuggestions } from '../PuckSuggestionsProvider';
+
+function Consumer() {
+  const { externalLinks } = useLinkSuggestions();
+  return (
+    <ul>
+      {externalLinks.map((link) => (
+        <li key={link.href}>{link.label}</li>
+      ))}
+    </ul>
+  );
+}
+
+describe('PuckSuggestionsProvider', () => {
+  it('provides empty external links initially', () => {
+    const data = { root: { props: {} }, content: [] };
+    render(
+      <PuckSuggestionsProvider data={data}>
+        <Consumer />
+      </PuckSuggestionsProvider>
+    );
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+
+  it('extracts external links from data', () => {
+    const data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Hero',
+          props: { id: 'h1', ctaHref: { href: 'https://example.com' } },
+        },
+      ],
+    };
+    render(
+      <PuckSuggestionsProvider data={data}>
+        <Consumer />
+      </PuckSuggestionsProvider>
+    );
+    expect(screen.getByText('example.com')).toBeDefined();
+  });
+
+  it('useLinkSuggestions returns empty when used outside provider', () => {
+    render(<Consumer />);
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+});

--- a/src/lib/puck/fields/__tests__/link-suggestions.test.ts
+++ b/src/lib/puck/fields/__tests__/link-suggestions.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { extractExternalLinks, PUBLIC_ROUTES, type LinkSuggestion } from '../link-suggestions';
+
+describe('PUBLIC_ROUTES', () => {
+  it('contains the four public-facing routes', () => {
+    const paths = PUBLIC_ROUTES.map((r) => r.href);
+    expect(paths).toEqual(['/', '/map', '/about', '/list']);
+  });
+
+  it('each route has a label', () => {
+    for (const route of PUBLIC_ROUTES) {
+      expect(route.label).toBeTruthy();
+    }
+  });
+});
+
+describe('extractExternalLinks', () => {
+  it('returns empty array for empty content', () => {
+    const data = { root: { props: {} }, content: [] };
+    expect(extractExternalLinks(data)).toEqual([]);
+  });
+
+  it('extracts href from LinkValue objects', () => {
+    const data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Hero',
+          props: {
+            id: 'hero-1',
+            title: 'Test',
+            ctaHref: { href: 'https://example.com', target: '_blank' },
+          },
+        },
+      ],
+    };
+    const result = extractExternalLinks(data);
+    expect(result).toEqual([{ href: 'https://example.com', label: 'example.com' }]);
+  });
+
+  it('extracts plain string URLs starting with http', () => {
+    const data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Card',
+          props: { id: 'card-1', linkHref: 'https://troop1564.org/info' },
+        },
+      ],
+    };
+    const result = extractExternalLinks(data);
+    expect(result).toEqual([{ href: 'https://troop1564.org/info', label: 'troop1564.org' }]);
+  });
+
+  it('ignores internal URLs', () => {
+    const data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Hero',
+          props: { id: 'hero-1', ctaHref: { href: '/map' } },
+        },
+        {
+          type: 'Card',
+          props: { id: 'card-1', linkHref: '/about' },
+        },
+      ],
+    };
+    expect(extractExternalLinks(data)).toEqual([]);
+  });
+
+  it('deduplicates by URL', () => {
+    const data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Hero',
+          props: { id: 'hero-1', ctaHref: { href: 'https://example.com' } },
+        },
+        {
+          type: 'Card',
+          props: { id: 'card-1', linkHref: 'https://example.com' },
+        },
+      ],
+    };
+    const result = extractExternalLinks(data);
+    expect(result).toHaveLength(1);
+  });
+
+  it('extracts links from nested array props (buttons, items)', () => {
+    const data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'ButtonGroup',
+          props: {
+            id: 'bg-1',
+            buttons: [
+              { label: 'Visit', href: { href: 'https://a.com' } },
+              { label: 'More', href: { href: 'https://b.com' } },
+            ],
+          },
+        },
+      ],
+    };
+    const result = extractExternalLinks(data);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.href)).toContain('https://a.com');
+    expect(result.map((r) => r.href)).toContain('https://b.com');
+  });
+
+  it('extracts links from zones', () => {
+    const data = {
+      root: { props: {} },
+      content: [],
+      zones: {
+        'Section-1:content': [
+          {
+            type: 'Card',
+            props: { id: 'card-z', linkHref: 'https://zone-link.com' },
+          },
+        ],
+      },
+    };
+    const result = extractExternalLinks(data);
+    expect(result).toEqual([{ href: 'https://zone-link.com', label: 'zone-link.com' }]);
+  });
+
+  it('handles malformed data gracefully', () => {
+    expect(extractExternalLinks({ root: { props: {} }, content: [] })).toEqual([]);
+    expect(extractExternalLinks(null as any)).toEqual([]);
+    expect(extractExternalLinks(undefined as any)).toEqual([]);
+  });
+});

--- a/src/lib/puck/fields/index.tsx
+++ b/src/lib/puck/fields/index.tsx
@@ -9,6 +9,7 @@ export { ImagePickerField } from './ImagePickerField';
 export { IconPickerField } from './IconPickerField';
 export { LinkField } from './LinkField';
 export { ColorPickerField } from './ColorPickerField';
+export { PuckSuggestionsProvider, useLinkSuggestions } from './PuckSuggestionsProvider';
 
 /**
  * Creates a Puck custom field config for an image picker.

--- a/src/lib/puck/fields/link-suggestions.ts
+++ b/src/lib/puck/fields/link-suggestions.ts
@@ -1,0 +1,80 @@
+export interface LinkSuggestion {
+  href: string;
+  label: string;
+}
+
+export const PUBLIC_ROUTES: LinkSuggestion[] = [
+  { href: '/', label: 'Home' },
+  { href: '/map', label: 'Map' },
+  { href: '/about', label: 'About' },
+  { href: '/list', label: 'List' },
+];
+
+/**
+ * Extract deduplicated external URLs from puck data.
+ * Walks content and zones, inspects all props for LinkValue objects
+ * or plain strings starting with "http".
+ */
+export function extractExternalLinks(data: any): LinkSuggestion[] {
+  if (!data) return [];
+
+  const seen = new Set<string>();
+  const results: LinkSuggestion[] = [];
+
+  function addIfExternal(value: unknown) {
+    let href: string | undefined;
+    if (typeof value === 'string' && value.startsWith('http')) {
+      href = value;
+    } else if (
+      value &&
+      typeof value === 'object' &&
+      'href' in value &&
+      typeof (value as any).href === 'string' &&
+      (value as any).href.startsWith('http')
+    ) {
+      href = (value as any).href;
+    }
+    if (href && !seen.has(href)) {
+      seen.add(href);
+      try {
+        const hostname = new URL(href).hostname;
+        results.push({ href, label: hostname });
+      } catch {
+        results.push({ href, label: href });
+      }
+    }
+  }
+
+  function walkProps(props: Record<string, unknown>) {
+    for (const value of Object.values(props)) {
+      if (value === null || value === undefined) continue;
+      addIfExternal(value);
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (item && typeof item === 'object') {
+            walkProps(item as Record<string, unknown>);
+          }
+        }
+      }
+    }
+  }
+
+  function walkComponents(components: any[]) {
+    if (!Array.isArray(components)) return;
+    for (const component of components) {
+      if (component?.props) {
+        walkProps(component.props);
+      }
+    }
+  }
+
+  walkComponents(data.content);
+
+  if (data.zones && typeof data.zones === 'object') {
+    for (const zoneComponents of Object.values(data.zones)) {
+      walkComponents(zoneComponents as any[]);
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

Closes #157

- Upgrades `LinkField` from a plain text input to a combobox with grouped suggestions
- **Pages** group shows public routes (Home, Map, About, List) — swappable to DB query when custom pages land
- **Previously Used** group shows deduplicated external URLs from the current puck draft, updated live as users edit
- Keyboard navigation (arrow keys + Enter), Escape to close, click to select
- External URL suggestions auto-set "Open in new tab"
- Gracefully works without the provider (pages-only mode)

## Test plan

- [x] 14 LinkField tests (6 existing + 8 new combobox tests)
- [x] 10 extraction logic tests (dedup, nested arrays, zones, malformed data)
- [x] 3 PuckSuggestionsProvider context tests
- [x] All 542 project tests pass
- [x] TypeScript type check clean
- [x] Production build succeeds
- [ ] Manual smoke test in site builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)