### PR TITLE
Fix: enable link autofill for HeaderBar links

### DIFF
--- a/src/lib/puck/chrome-config.ts
+++ b/src/lib/puck/chrome-config.ts
@@ -128,7 +128,7 @@ export const chromeConfig: Config<ChromeComponents> = {
           label: 'Header Links',
           arrayFields: {
             label: { type: 'text', label: 'Label' },
-            href: { type: 'text', label: 'URL' },
+            href: linkField('URL'),
           },
           defaultItemProps: {
             label: 'Link',

--- a/src/lib/puck/components/chrome/HeaderBar.tsx
+++ b/src/lib/puck/components/chrome/HeaderBar.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useConfig } from '@/lib/config/client';
 import type { HeaderBarProps } from '../../types';
+import { resolveLink } from '../../fields/link-utils';
 import { IconRenderer } from '../../icons/IconRenderer';
 
 const bgClasses = {
@@ -97,18 +98,21 @@ export function HeaderBar({
 
           {links && links.length > 0 && (
             <nav className="flex items-center gap-4">
-              {links.map((link, i) => (
-                <Link
-                  key={i}
-                  href={link.href}
-                  target={link.href.startsWith('http') ? '_blank' : undefined}
-                  rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                  className="text-sm hover:underline"
-                  style={linkColor ? { color: linkColor } : undefined}
-                >
-                  {link.label}
-                </Link>
-              ))}
+              {links.map((link, i) => {
+                const resolved = resolveLink(link.href);
+                return (
+                  <Link
+                    key={i}
+                    href={resolved.href}
+                    target={resolved.target}
+                    rel={resolved.target === '_blank' ? 'noopener noreferrer' : undefined}
+                    className="text-sm hover:underline"
+                    style={linkColor ? { color: linkColor } : undefined}
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
             </nav>
           )}
         </div>

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -123,7 +123,7 @@ export interface HeaderBarProps {
   taglineSize?: 'small' | 'medium' | 'large' | 'xl';
   taglineWeight?: 'normal' | 'medium' | 'semibold' | 'bold';
   taglineColor?: string;
-  links?: Array<{ label: string; href: string }>;
+  links?: Array<{ label: string; href: string | LinkValue }>;
   linkColor?: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes the remaining gap from #157 — HeaderBar links used plain `type: 'text'` fields instead of `linkField()`, so the link autofill combobox didn't appear for header navigation links.

- Changed HeaderBar `href` field from `{ type: 'text' }` to `linkField('URL')`
- Updated `HeaderBarProps` type to accept `string | LinkValue` for backward compatibility
- Updated `HeaderBar` component to use `resolveLink()` for rendering

Other chrome components (AnnouncementBar, FooterColumns, SimpleFooter) already used `linkField()` and were working. SocialLinks intentionally stays as plain text (social platform URLs aren't internal routes).

## Test plan

- [x] 155 puck tests pass
- [x] TypeScript type check clean
- [x] Backward compatible — `resolveLink()` handles both string and LinkValue formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)