### PR TITLE
fix: site builder DropZone migration, meta tag, and richtext errors

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,7 @@ export default async function RootLayout({
         <link rel="manifest" href="/api/manifest.json" />
         <meta name="theme-color" content="#2563eb" />
         <link rel="icon" type="image/png" sizes="32x32" href="/defaults/logos/favicon-32.png" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
       </head>
       <body className="min-h-screen flex flex-col">

--- a/src/components/puck/PuckChromeEditor.tsx
+++ b/src/components/puck/PuckChromeEditor.tsx
@@ -6,7 +6,8 @@ import { chromeConfig } from '@/lib/puck/chrome-config';
 import { savePuckRootDraft, publishPuckRoot } from '@/app/admin/site-builder/actions';
 import { PuckSuggestionsProvider } from '@/lib/puck/fields';
 import type { Data } from '@puckeditor/core';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { sanitizePuckData } from '@/lib/puck/sanitize-data';
 
 interface PuckChromeEditorProps {
   initialData: Data;
@@ -14,7 +15,8 @@ interface PuckChromeEditorProps {
 
 export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
-  const [puckData, setPuckData] = useState<Data>(initialData);
+  const safeInitialData = useMemo(() => sanitizePuckData(initialData), [initialData]);
+  const [puckData, setPuckData] = useState<Data>(safeInitialData);
 
   const handleChange = useCallback(async (data: Data) => {
     setPuckData(data);
@@ -36,7 +38,7 @@ export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
       <PuckSuggestionsProvider data={puckData}>
         <Puck
           config={chromeConfig}
-          data={initialData}
+          data={safeInitialData}
           onChange={handleChange}
           onPublish={handlePublish}
         />

--- a/src/components/puck/PuckPageEditor.tsx
+++ b/src/components/puck/PuckPageEditor.tsx
@@ -6,7 +6,8 @@ import { pageConfig } from '@/lib/puck/config';
 import { savePuckPageDraft, publishPuckPages } from '@/app/admin/site-builder/actions';
 import { PuckSuggestionsProvider } from '@/lib/puck/fields';
 import type { Data } from '@puckeditor/core';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { sanitizePuckData } from '@/lib/puck/sanitize-data';
 
 interface PuckPageEditorProps {
   initialData: Data;
@@ -15,7 +16,8 @@ interface PuckPageEditorProps {
 
 export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
-  const [puckData, setPuckData] = useState<Data>(initialData);
+  const safeInitialData = useMemo(() => sanitizePuckData(initialData), [initialData]);
+  const [puckData, setPuckData] = useState<Data>(safeInitialData);
 
   const handleChange = useCallback(async (data: Data) => {
     setPuckData(data);
@@ -37,7 +39,7 @@ export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
       <PuckSuggestionsProvider data={puckData}>
         <Puck
           config={pageConfig}
-          data={initialData}
+          data={safeInitialData}
           onChange={handleChange}
           onPublish={handlePublish}
         />

--- a/src/lib/puck/components/page/Columns.tsx
+++ b/src/lib/puck/components/page/Columns.tsx
@@ -1,4 +1,4 @@
-import { DropZone } from '@puckeditor/core';
+import type { SlotComponent } from '@puckeditor/core';
 import type { ColumnsProps } from '../../types';
 
 const gridClasses = {
@@ -7,14 +7,17 @@ const gridClasses = {
   4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
 };
 
-export function Columns({ columnCount }: ColumnsProps) {
+export function Columns({ columnCount, ...slots }: ColumnsProps & Record<`column-${number}`, SlotComponent>) {
   return (
     <div className={`mx-auto max-w-6xl grid gap-6 px-4 py-4 ${gridClasses[columnCount]}`}>
-      {Array.from({ length: columnCount }, (_, i) => (
-        <div key={i} className="min-h-[50px]">
-          <DropZone zone={`column-${i}`} />
-        </div>
-      ))}
+      {Array.from({ length: columnCount }, (_, i) => {
+        const slotRender = slots[`column-${i}`];
+        return (
+          <div key={i} className="min-h-[50px]">
+            {slotRender()}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/lib/puck/components/page/Section.tsx
+++ b/src/lib/puck/components/page/Section.tsx
@@ -1,4 +1,4 @@
-import { DropZone } from '@puckeditor/core';
+import type { SlotComponent } from '@puckeditor/core';
 import type { SectionProps } from '../../types';
 
 const bgClasses = {
@@ -11,13 +11,13 @@ const bgClasses = {
 
 const paddingClasses = { small: 'py-4', medium: 'py-8', large: 'py-16' };
 
-export function Section({ backgroundColor, backgroundImageUrl, paddingY }: SectionProps) {
+export function Section({ backgroundColor, backgroundImageUrl, paddingY, content }: SectionProps & { content: SlotComponent }) {
   return (
     <section
       className={`w-full ${bgClasses[backgroundColor]} ${paddingClasses[paddingY]}`}
       style={backgroundImageUrl ? { backgroundImage: `url(${backgroundImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' } : undefined}
     >
-      <DropZone zone="content" />
+      {content()}
     </section>
   );
 }

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -309,6 +309,10 @@ export const pageConfig: Config<PageComponents> = {
         columnCount: 2,
       },
       fields: {
+        'column-0': { type: 'slot' },
+        'column-1': { type: 'slot' },
+        'column-2': { type: 'slot' },
+        'column-3': { type: 'slot' },
         columnCount: {
           type: 'select',
           label: 'Column Count',
@@ -318,8 +322,8 @@ export const pageConfig: Config<PageComponents> = {
             { label: '4', value: 4 },
           ],
         },
-      },
-      render: Columns,
+      } as any,
+      render: Columns as any,
     },
 
     Section: {
@@ -330,6 +334,7 @@ export const pageConfig: Config<PageComponents> = {
         paddingY: 'medium',
       },
       fields: {
+        content: { type: 'slot' },
         backgroundColor: {
           type: 'select',
           label: 'Background Color',
@@ -345,8 +350,8 @@ export const pageConfig: Config<PageComponents> = {
             { label: 'Large', value: 'large' },
           ],
         },
-      },
-      render: Section,
+      } as any,
+      render: Section as any,
     },
 
     Card: {

--- a/src/lib/puck/sanitize-data.ts
+++ b/src/lib/puck/sanitize-data.ts
@@ -1,0 +1,27 @@
+import type { Data } from '@puckeditor/core';
+
+/**
+ * Sanitize Puck data to remove empty text nodes from richtext (ProseMirror/TipTap) content.
+ *
+ * ProseMirror throws `RangeError: Empty text nodes are not allowed` when deserializing
+ * JSON that contains `{ type: "text", text: "" }`. This walks the entire Puck data tree
+ * and strips those nodes before the editor loads the data.
+ */
+export function sanitizePuckData(data: Data): Data {
+  return JSON.parse(JSON.stringify(data), (_key, value) => {
+    // Look for ProseMirror node content arrays and filter out empty text nodes
+    if (Array.isArray(value)) {
+      const filtered = value.filter(
+        (item) =>
+          !(
+            item &&
+            typeof item === 'object' &&
+            item.type === 'text' &&
+            (item.text === '' || item.text == null)
+          )
+      );
+      return filtered;
+    }
+    return value;
+  });
+}


### PR DESCRIPTION
## Summary
- Replace deprecated `apple-mobile-web-app-capable` meta tag with `mobile-web-app-capable`
- Migrate `Section` and `Columns` components from deprecated `<DropZone>` to Puck slot fields
- Add `sanitizePuckData()` to strip empty ProseMirror text nodes before editor initialization, fixing `RangeError: Empty text nodes are not allowed`

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit` exit 0)
- [x] Production build passes (`npm run build` exit 0)
- [ ] Verify site builder editor loads without console errors
- [ ] Verify Section and Columns components render content correctly with slot-based API
- [ ] Verify richtext fields (RichText, Card text, Testimonial quote) load without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)