### PR TITLE
feat: add text size controls and fix editor crashes

### DIFF
--- a/docs/superpowers/plans/2026-04-01-text-size-controls.md
+++ b/docs/superpowers/plans/2026-04-01-text-size-controls.md
@@ -1,0 +1,1110 @@
+# Text Size Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a configurable text size field (Small/Medium/Large/XL) to all text-rendering Puck page components via a shared text styles module.
+
+**Architecture:** A new `text-styles.ts` module provides the `TextSize` type, per-component-type Tailwind class maps, and a `textSizeField()` factory. Each of the 6 affected components gets an optional `textSize` prop with a backward-compatible default. Types, configs, and render functions are updated together per component.
+
+**Tech Stack:** TypeScript, Tailwind CSS (prose plugin), Puck editor, Vitest + React Testing Library
+
+---
+
+### Task 1: Create Shared Text Styles Module
+
+**Files:**
+- Create: `src/lib/puck/text-styles.ts`
+- Create: `src/lib/puck/__tests__/text-styles.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/puck/__tests__/text-styles.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  proseSizeClasses,
+  heroTitleClasses,
+  heroSubtitleClasses,
+  statValueClasses,
+  linkLabelClasses,
+  textSizeField,
+} from '../text-styles';
+import type { TextSize } from '../text-styles';
+
+const allSizes: TextSize[] = ['small', 'medium', 'large', 'xl'];
+
+describe('text-styles', () => {
+  it('proseSizeClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(proseSizeClasses[size]).toBeDefined();
+      expect(proseSizeClasses[size]).toContain('prose-');
+    }
+  });
+
+  it('heroTitleClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(heroTitleClasses[size]).toBeDefined();
+      expect(heroTitleClasses[size]).toContain('text-');
+    }
+  });
+
+  it('heroSubtitleClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(heroSubtitleClasses[size]).toBeDefined();
+      expect(heroSubtitleClasses[size]).toContain('text-');
+    }
+  });
+
+  it('statValueClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(statValueClasses[size]).toBeDefined();
+      expect(statValueClasses[size]).toContain('text-');
+    }
+  });
+
+  it('linkLabelClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(linkLabelClasses[size]).toBeDefined();
+      expect(linkLabelClasses[size]).toContain('text-');
+    }
+  });
+
+  it('textSizeField returns a valid Puck select field', () => {
+    const field = textSizeField();
+    expect(field.type).toBe('select');
+    expect(field.label).toBe('Text Size');
+    expect(field.options).toHaveLength(4);
+    expect(field.options.map((o: { value: string }) => o.value)).toEqual(allSizes);
+  });
+
+  it('textSizeField accepts a custom label', () => {
+    const field = textSizeField('Quote Size');
+    expect(field.label).toBe('Quote Size');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/__tests__/text-styles.test.ts`
+Expected: FAIL — module `../text-styles` does not exist
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/lib/puck/text-styles.ts
+export type TextSize = 'small' | 'medium' | 'large' | 'xl';
+
+/** Prose-based components: RichText, Card body, Testimonial quote */
+export const proseSizeClasses: Record<TextSize, string> = {
+  small: 'prose-sm',
+  medium: 'prose-base',
+  large: 'prose-lg',
+  xl: 'prose-xl',
+};
+
+/** Hero title */
+export const heroTitleClasses: Record<TextSize, string> = {
+  small: 'text-2xl md:text-3xl',
+  medium: 'text-3xl md:text-4xl',
+  large: 'text-4xl md:text-5xl',
+  xl: 'text-5xl md:text-6xl',
+};
+
+/** Hero subtitle */
+export const heroSubtitleClasses: Record<TextSize, string> = {
+  small: 'text-base',
+  medium: 'text-lg md:text-xl',
+  large: 'text-xl md:text-2xl',
+  xl: 'text-2xl md:text-3xl',
+};
+
+/** Stats value number */
+export const statValueClasses: Record<TextSize, string> = {
+  small: 'text-xl',
+  medium: 'text-2xl',
+  large: 'text-3xl',
+  xl: 'text-4xl',
+};
+
+/** LinkList label text */
+export const linkLabelClasses: Record<TextSize, string> = {
+  small: 'text-sm',
+  medium: 'text-base',
+  large: 'text-lg',
+  xl: 'text-xl',
+};
+
+/** Reusable Puck field definition for text size */
+export function textSizeField(label = 'Text Size') {
+  return {
+    type: 'select' as const,
+    label,
+    options: [
+      { label: 'Small', value: 'small' as const },
+      { label: 'Medium', value: 'medium' as const },
+      { label: 'Large', value: 'large' as const },
+      { label: 'XL', value: 'xl' as const },
+    ],
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- src/lib/puck/__tests__/text-styles.test.ts`
+Expected: PASS — all 7 tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/puck/text-styles.ts src/lib/puck/__tests__/text-styles.test.ts
+git commit -m "feat: add shared text-styles module with size maps and field factory"
+```
+
+---
+
+### Task 2: Add textSize to RichText
+
+**Files:**
+- Modify: `src/lib/puck/types.ts` (add `textSize` to `RichTextProps`)
+- Modify: `src/lib/puck/config.ts` (add field + default for RichText)
+- Modify: `src/lib/puck/components/page/RichText.tsx` (use `proseSizeClasses`)
+- Modify: `src/lib/puck/components/page/__tests__/page-components.test.tsx` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `RichText` describe block in `src/lib/puck/components/page/__tests__/page-components.test.tsx`:
+
+```typescript
+  it('applies prose-lg class by default (no textSize prop)', () => {
+    const { container } = render(<RichText content="Hello" alignment="left" columns={1} />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-lg');
+  });
+
+  it('applies prose-sm class when textSize is small', () => {
+    const { container } = render(<RichText content="Hello" alignment="left" columns={1} textSize="small" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-sm');
+  });
+
+  it('applies prose-xl class when textSize is xl', () => {
+    const { container } = render(<RichText content="Hello" alignment="left" columns={1} textSize="xl" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-xl');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: FAIL — `textSize` prop not recognized / `prose-lg` still hardcoded
+
+- [ ] **Step 3: Update types**
+
+In `src/lib/puck/types.ts`, add the import and update `RichTextProps`:
+
+```typescript
+// Add at top of file, after existing imports:
+import type { TextSize } from './text-styles';
+
+// Update RichTextProps:
+export interface RichTextProps {
+  content: string;
+  alignment: 'left' | 'center';
+  columns: 1 | 2;
+  textSize?: TextSize;
+}
+```
+
+- [ ] **Step 4: Update the component**
+
+Replace `src/lib/puck/components/page/RichText.tsx`:
+
+```typescript
+import type { RichTextProps } from '../../types';
+import { proseSizeClasses } from '../../text-styles';
+
+export function RichText({ content, alignment, columns, textSize = 'large' }: RichTextProps) {
+  const alignClass = alignment === 'center' ? 'text-center' : 'text-left';
+  const colClass = columns === 2 ? 'md:columns-2 md:gap-8' : '';
+  const proseSize = proseSizeClasses[textSize];
+
+  return (
+    <div className={`mx-auto max-w-4xl px-4 py-8 ${alignClass} ${colClass}`}>
+      <div className={`prose ${proseSize} max-w-none prose-headings:text-[var(--color-primary-dark)] prose-a:text-[var(--color-primary)]`}>
+        <RichTextContent content={content} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders rich text content. Handles three formats:
+ * - ReactNode (from Puck richtext field at edit time)
+ * - HTML string (from Puck richtext field when saved)
+ * - Plain text / markdown (legacy textarea content)
+ */
+function RichTextContent({ content }: { content: any }) {
+  // ReactNode from Puck richtext field (not a string)
+  if (typeof content !== 'string') {
+    return <>{content}</>;
+  }
+
+  // Empty content
+  if (!content) return null;
+
+  // HTML string (from saved richtext data)
+  const isHtml = content.startsWith('<') || content.includes('<p>') || content.includes('<h');
+  if (isHtml) {
+    return <div dangerouslySetInnerHTML={{ __html: content }} />;
+  }
+
+  // Legacy plain text / markdown
+  const ReactMarkdown = require('react-markdown').default;
+  const remarkGfm = require('remark-gfm').default;
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>;
+}
+```
+
+- [ ] **Step 5: Update config**
+
+In `src/lib/puck/config.ts`, add the import at the top:
+
+```typescript
+import { textSizeField } from './text-styles';
+```
+
+Then update the RichText config entry — add `textSize: 'large'` to `defaultProps` and `textSize: textSizeField()` to `fields`:
+
+```typescript
+    RichText: {
+      label: 'Rich Text',
+      defaultProps: {
+        content: '',
+        alignment: 'left',
+        columns: 1,
+        textSize: 'large',
+      },
+      fields: {
+        content: { type: 'richtext', label: 'Content', contentEditable: true },
+        textSize: textSizeField(),
+        alignment: {
+          type: 'radio',
+          label: 'Alignment',
+          options: [
+            { label: 'Left', value: 'left' },
+            { label: 'Center', value: 'center' },
+          ],
+        },
+        columns: {
+          type: 'radio',
+          label: 'Columns',
+          options: [
+            { label: '1', value: 1 },
+            { label: '2', value: 2 },
+          ],
+        },
+      },
+      render: RichText,
+    },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: PASS — all RichText tests green (including existing ones)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/puck/types.ts src/lib/puck/config.ts src/lib/puck/components/page/RichText.tsx src/lib/puck/components/page/__tests__/page-components.test.tsx
+git commit -m "feat: add textSize field to RichText component"
+```
+
+---
+
+### Task 3: Add textSize to Hero
+
+**Files:**
+- Modify: `src/lib/puck/types.ts` (add `textSize` to `HeroProps`)
+- Modify: `src/lib/puck/config.ts` (add field + default for Hero)
+- Modify: `src/lib/puck/components/page/Hero.tsx` (use `heroTitleClasses` + `heroSubtitleClasses`)
+- Modify: `src/lib/puck/components/page/__tests__/page-components.test.tsx` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `Hero` describe block in `src/lib/puck/components/page/__tests__/page-components.test.tsx`:
+
+```typescript
+  it('applies large title classes by default (no textSize prop)', () => {
+    render(<Hero title="Welcome" subtitle="" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" />);
+    const h1 = screen.getByRole('heading', { name: 'Welcome' });
+    expect(h1.className).toContain('text-4xl');
+  });
+
+  it('applies small title classes when textSize is small', () => {
+    render(<Hero title="Welcome" subtitle="" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" textSize="small" />);
+    const h1 = screen.getByRole('heading', { name: 'Welcome' });
+    expect(h1.className).toContain('text-2xl');
+  });
+
+  it('applies xl subtitle classes when textSize is xl', () => {
+    render(<Hero title="Welcome" subtitle="Hello world" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" textSize="xl" />);
+    const subtitle = screen.getByText('Hello world');
+    expect(subtitle.className).toContain('text-2xl');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: FAIL — `textSize` prop not recognized on Hero
+
+- [ ] **Step 3: Update types**
+
+In `src/lib/puck/types.ts`, update `HeroProps` (the `TextSize` import already exists from Task 2):
+
+```typescript
+export interface HeroProps {
+  title: string;
+  subtitle: string;
+  backgroundImageUrl: string;
+  overlay: 'primary' | 'dark' | 'none';
+  ctaLabel: string;
+  ctaHref: string | LinkValue;
+  icon?: IconValue;
+  textSize?: TextSize;
+}
+```
+
+- [ ] **Step 4: Update the component**
+
+Replace `src/lib/puck/components/page/Hero.tsx`:
+
+```typescript
+import Link from 'next/link';
+import type { HeroProps } from '../../types';
+import { resolveLink } from '../../fields/link-utils';
+import { IconRenderer } from '../../icons/IconRenderer';
+import { heroTitleClasses, heroSubtitleClasses } from '../../text-styles';
+
+const overlayClasses = {
+  primary: 'bg-[var(--color-primary)]/70',
+  dark: 'bg-black/60',
+  none: '',
+};
+
+export function Hero({ title, subtitle, backgroundImageUrl, overlay, ctaLabel, ctaHref, icon, textSize = 'large' }: HeroProps) {
+  const cta = resolveLink(ctaHref);
+  return (
+    <section
+      className="relative flex min-h-[300px] items-center justify-center"
+      style={backgroundImageUrl ? { backgroundImage: `url(${backgroundImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' } : undefined}
+    >
+      {!backgroundImageUrl && (
+        <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-primary)] to-[var(--color-primary-dark)]" />
+      )}
+      {overlay !== 'none' && (
+        <div className={`absolute inset-0 ${overlayClasses[overlay]}`} />
+      )}
+      <div className="relative z-10 mx-auto max-w-3xl px-4 py-16 text-center text-white">
+        {icon && (
+          <div className="mb-4 flex justify-center">
+            <IconRenderer icon={icon} size={48} className="text-white" />
+          </div>
+        )}
+        {title && <h1 className={`${heroTitleClasses[textSize]} font-bold`}>{title}</h1>}
+        {subtitle && <p className={`mt-4 ${heroSubtitleClasses[textSize]} opacity-90`}>{subtitle}</p>}
+        {ctaLabel && cta.href && (
+          <Link
+            href={cta.href}
+            target={cta.target}
+            className="mt-8 inline-block rounded-lg bg-white px-8 py-3 font-semibold text-[var(--color-primary-dark)] transition hover:bg-opacity-90"
+            style={cta.color ? { color: cta.color } : undefined}
+          >
+            {ctaLabel}
+          </Link>
+        )}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 5: Update config**
+
+In `src/lib/puck/config.ts`, update the Hero config — add `textSize: 'large'` to `defaultProps` and `textSize: textSizeField()` to `fields`:
+
+```typescript
+    Hero: {
+      label: 'Hero',
+      defaultProps: {
+        title: 'Welcome',
+        subtitle: '',
+        backgroundImageUrl: '',
+        overlay: 'primary',
+        ctaLabel: '',
+        ctaHref: '',
+        textSize: 'large',
+      },
+      fields: {
+        title: { type: 'text', label: 'Title' },
+        subtitle: { type: 'text', label: 'Subtitle' },
+        textSize: textSizeField(),
+        backgroundImageUrl: imagePickerField('Background Image', fetchLandingAssets),
+        overlay: {
+          type: 'select',
+          label: 'Overlay',
+          options: [
+            { label: 'Primary', value: 'primary' },
+            { label: 'Dark', value: 'dark' },
+            { label: 'None', value: 'none' },
+          ],
+        },
+        ctaLabel: { type: 'text', label: 'CTA Label' },
+        ctaHref: linkField('CTA Link'),
+        icon: iconPickerField('Icon'),
+      },
+      render: Hero,
+    },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: PASS — all Hero tests green
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/puck/types.ts src/lib/puck/config.ts src/lib/puck/components/page/Hero.tsx src/lib/puck/components/page/__tests__/page-components.test.tsx
+git commit -m "feat: add textSize field to Hero component"
+```
+
+---
+
+### Task 4: Add textSize to Card
+
+**Files:**
+- Modify: `src/lib/puck/types.ts` (add `textSize` to `CardProps`)
+- Modify: `src/lib/puck/config.ts` (add field + default for Card)
+- Modify: `src/lib/puck/components/page/Card.tsx` (use `proseSizeClasses`)
+- Modify: `src/lib/puck/components/page/__tests__/new-components.test.tsx` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `Card` describe block in `src/lib/puck/components/page/__tests__/new-components.test.tsx`:
+
+```typescript
+  it('applies prose-sm class by default (no textSize prop)', () => {
+    const { container } = render(<Card title="Card" text="<p>Body</p>" imageUrl="" linkHref="" linkLabel="" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-sm');
+  });
+
+  it('applies prose-lg class when textSize is large', () => {
+    const { container } = render(<Card title="Card" text="<p>Body</p>" imageUrl="" linkHref="" linkLabel="" textSize="large" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-lg');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/new-components.test.tsx`
+Expected: FAIL — `textSize` prop not recognized on Card
+
+- [ ] **Step 3: Update types**
+
+In `src/lib/puck/types.ts`, update `CardProps`:
+
+```typescript
+export interface CardProps {
+  imageUrl: string;
+  title: string;
+  text: string;
+  linkHref: string | LinkValue;
+  linkLabel: string;
+  icon?: IconValue;
+  textSize?: TextSize;
+}
+```
+
+- [ ] **Step 4: Update the component**
+
+Replace `src/lib/puck/components/page/Card.tsx`:
+
+```typescript
+import type { CardProps } from '../../types';
+import { resolveLink } from '../../fields/link-utils';
+import { IconRenderer } from '../../icons/IconRenderer';
+import { proseSizeClasses } from '../../text-styles';
+
+export function Card({ imageUrl, title, text, linkHref, linkLabel, icon, textSize = 'small' }: CardProps) {
+  const link = resolveLink(linkHref);
+  const proseSize = proseSizeClasses[textSize];
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:shadow-md">
+      {imageUrl && <img src={imageUrl} alt={title} className="h-48 w-full object-cover" loading="lazy" />}
+      <div className="p-4">
+        {icon && (
+          <div className="mb-2">
+            <IconRenderer icon={icon} size={24} className="text-[var(--color-primary)]" />
+          </div>
+        )}
+        {title && <h3 className="text-lg font-semibold text-[var(--color-primary-dark)]">{title}</h3>}
+        {text && (
+          typeof text === 'string'
+            ? <div className={`mt-2 text-gray-600 prose ${proseSize} max-w-none`} dangerouslySetInnerHTML={{ __html: text }} />
+            : <div className={`mt-2 text-gray-600 prose ${proseSize} max-w-none`}>{text}</div>
+        )}
+        {link.href && linkLabel && (
+          <a
+            href={link.href}
+            target={link.target}
+            className="mt-3 inline-block text-sm font-medium text-[var(--color-primary)] hover:underline"
+            style={link.color ? { color: link.color } : undefined}
+          >
+            {linkLabel} &rarr;
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+Note: The original Card had `text-sm` hardcoded alongside `prose-sm`. The `text-sm` was redundant since `prose-sm` already sets the base size. We remove the redundant `text-sm` and let the prose scale control it.
+
+- [ ] **Step 5: Update config**
+
+In `src/lib/puck/config.ts`, update the Card config — add `textSize: 'small'` to `defaultProps` and `textSize: textSizeField()` to `fields`:
+
+```typescript
+    Card: {
+      label: 'Card',
+      defaultProps: {
+        imageUrl: '',
+        title: '',
+        text: '',
+        linkHref: '',
+        linkLabel: '',
+        textSize: 'small',
+      },
+      fields: {
+        imageUrl: imagePickerField('Image', fetchLandingAssets),
+        title: { type: 'text', label: 'Title' },
+        text: { type: 'richtext', label: 'Text' },
+        textSize: textSizeField(),
+        linkHref: linkField('Link URL'),
+        linkLabel: { type: 'text', label: 'Link Label' },
+        icon: iconPickerField('Icon'),
+      },
+      render: Card,
+    },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/new-components.test.tsx`
+Expected: PASS — all Card tests green
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/puck/types.ts src/lib/puck/config.ts src/lib/puck/components/page/Card.tsx src/lib/puck/components/page/__tests__/new-components.test.tsx
+git commit -m "feat: add textSize field to Card component"
+```
+
+---
+
+### Task 5: Add textSize to Stats
+
+**Files:**
+- Modify: `src/lib/puck/types.ts` (add `textSize` to `StatsProps`)
+- Modify: `src/lib/puck/config.ts` (add field + default for Stats)
+- Modify: `src/lib/puck/components/page/Stats.tsx` (use `statValueClasses`)
+- Modify: `src/lib/puck/components/page/__tests__/page-components.test.tsx` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `Stats` describe block in `src/lib/puck/components/page/__tests__/page-components.test.tsx`:
+
+```typescript
+  it('applies text-3xl to stat values by default (no textSize prop)', () => {
+    const { container } = render(
+      <Stats source="manual" items={[{ value: '42', label: 'Species' }]} />
+    );
+    const valueEl = container.querySelector('.text-3xl') as HTMLElement;
+    expect(valueEl).not.toBeNull();
+    expect(valueEl.textContent).toBe('42');
+  });
+
+  it('applies text-xl to stat values when textSize is small', () => {
+    const { container } = render(
+      <Stats source="manual" items={[{ value: '42', label: 'Species' }]} textSize="small" />
+    );
+    const valueEl = container.querySelector('.text-xl') as HTMLElement;
+    expect(valueEl).not.toBeNull();
+    expect(valueEl.textContent).toBe('42');
+  });
+
+  it('applies text-4xl to stat values when textSize is xl', () => {
+    const { container } = render(
+      <Stats source="manual" items={[{ value: '42', label: 'Species' }]} textSize="xl" />
+    );
+    const valueEl = container.querySelector('.text-4xl') as HTMLElement;
+    expect(valueEl).not.toBeNull();
+    expect(valueEl.textContent).toBe('42');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: FAIL — `textSize` prop not recognized on Stats
+
+- [ ] **Step 3: Update types**
+
+In `src/lib/puck/types.ts`, update `StatsProps`:
+
+```typescript
+export interface StatsProps {
+  source: 'auto' | 'manual';
+  items: Array<{
+    label: string;
+    value: string;
+  }>;
+  textSize?: TextSize;
+}
+```
+
+- [ ] **Step 4: Update the component**
+
+Replace `src/lib/puck/components/page/Stats.tsx`:
+
+```typescript
+import type { StatsProps } from '../../types';
+import { statValueClasses } from '../../text-styles';
+
+export function Stats({ items, textSize = 'large' }: StatsProps) {
+  if (!items?.length) return <></>;
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        {items.map((item, i) => (
+          <div key={i} className="rounded-xl bg-[var(--color-surface-light)] p-6 text-center">
+            <div className={`${statValueClasses[textSize]} font-bold text-[var(--color-primary)]`}>{item.value}</div>
+            <div className="mt-1 text-sm text-gray-600">{item.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Update config**
+
+In `src/lib/puck/config.ts`, update the Stats config — add `textSize: 'large'` to `defaultProps` and `textSize: textSizeField()` to `fields`:
+
+```typescript
+    Stats: {
+      label: 'Stats',
+      defaultProps: {
+        source: 'manual',
+        items: [],
+        textSize: 'large',
+      },
+      fields: {
+        source: {
+          type: 'radio',
+          label: 'Source',
+          options: [
+            { label: 'Auto', value: 'auto' },
+            { label: 'Manual', value: 'manual' },
+          ],
+        },
+        items: {
+          type: 'array',
+          label: 'Items',
+          arrayFields: {
+            label: { type: 'text', label: 'Label' },
+            value: { type: 'text', label: 'Value' },
+          },
+          defaultItemProps: {
+            label: 'Stat',
+            value: '0',
+          },
+        },
+        textSize: textSizeField(),
+      },
+      render: Stats,
+    },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: PASS — all Stats tests green
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/puck/types.ts src/lib/puck/config.ts src/lib/puck/components/page/Stats.tsx src/lib/puck/components/page/__tests__/page-components.test.tsx
+git commit -m "feat: add textSize field to Stats component"
+```
+
+---
+
+### Task 6: Add textSize to Testimonial
+
+**Files:**
+- Modify: `src/lib/puck/types.ts` (add `textSize` to `TestimonialProps`)
+- Modify: `src/lib/puck/config.ts` (add field + default for Testimonial)
+- Modify: `src/lib/puck/components/page/Testimonial.tsx` (use `proseSizeClasses`)
+- Modify: `src/lib/puck/components/page/__tests__/new-components.test.tsx` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `Testimonial` describe block in `src/lib/puck/components/page/__tests__/new-components.test.tsx`:
+
+```typescript
+  it('applies prose-lg class by default (no textSize prop)', () => {
+    const { container } = render(<Testimonial quote="Great" attribution="A" photoUrl="" style="default" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-lg');
+  });
+
+  it('applies prose-sm class when textSize is small', () => {
+    const { container } = render(<Testimonial quote="Great" attribution="A" photoUrl="" style="default" textSize="small" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-sm');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/new-components.test.tsx`
+Expected: FAIL — `textSize` prop not recognized on Testimonial
+
+- [ ] **Step 3: Update types**
+
+In `src/lib/puck/types.ts`, update `TestimonialProps`:
+
+```typescript
+export interface TestimonialProps {
+  quote: string;
+  attribution: string;
+  photoUrl: string;
+  style: 'default' | 'accent';
+  textSize?: TextSize;
+}
+```
+
+- [ ] **Step 4: Update the component**
+
+Replace `src/lib/puck/components/page/Testimonial.tsx`:
+
+```typescript
+import type { TestimonialProps } from '../../types';
+import { proseSizeClasses } from '../../text-styles';
+
+const borderClasses = {
+  default: 'border-[var(--color-primary)]',
+  accent: 'border-[var(--color-accent)]',
+};
+
+export function Testimonial({ quote, attribution, photoUrl, style, textSize = 'large' }: TestimonialProps) {
+  const proseSize = proseSizeClasses[textSize];
+  return (
+    <blockquote className={`mx-auto max-w-2xl border-l-4 ${borderClasses[style]} px-4 py-8 pl-6`}>
+      <div className={`italic text-gray-700 prose ${proseSize} max-w-none`}>
+        &ldquo;{typeof quote === 'string'
+          ? <span dangerouslySetInnerHTML={{ __html: quote }} />
+          : <span>{quote}</span>
+        }&rdquo;
+      </div>
+      <footer className="mt-4 flex items-center gap-3">
+        {photoUrl && <img src={photoUrl} alt={attribution} className="h-10 w-10 rounded-full object-cover" />}
+        <cite className="text-sm font-medium not-italic text-gray-600">{attribution}</cite>
+      </footer>
+    </blockquote>
+  );
+}
+```
+
+Note: The original had `text-lg` alongside `prose-lg` — redundant since prose sets the base size. Removed.
+
+- [ ] **Step 5: Update config**
+
+In `src/lib/puck/config.ts`, update the Testimonial config — add `textSize: 'large'` to `defaultProps` and `textSize: textSizeField()` to `fields`:
+
+```typescript
+    Testimonial: {
+      label: 'Testimonial',
+      defaultProps: {
+        quote: '',
+        attribution: '',
+        photoUrl: '',
+        style: 'default',
+        textSize: 'large',
+      },
+      fields: {
+        quote: { type: 'richtext', label: 'Quote' },
+        attribution: { type: 'text', label: 'Attribution' },
+        photoUrl: imagePickerField('Photo', fetchLandingAssets),
+        textSize: textSizeField(),
+        style: {
+          type: 'radio',
+          label: 'Style',
+          options: [
+            { label: 'Default', value: 'default' },
+            { label: 'Accent', value: 'accent' },
+          ],
+        },
+      },
+      render: Testimonial,
+    },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/new-components.test.tsx`
+Expected: PASS — all Testimonial tests green
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/puck/types.ts src/lib/puck/config.ts src/lib/puck/components/page/Testimonial.tsx src/lib/puck/components/page/__tests__/new-components.test.tsx
+git commit -m "feat: add textSize field to Testimonial component"
+```
+
+---
+
+### Task 7: Add textSize to LinkList
+
+**Files:**
+- Modify: `src/lib/puck/types.ts` (add `textSize` to `LinkListProps`)
+- Modify: `src/lib/puck/config.ts` (add field + default for LinkList)
+- Modify: `src/lib/puck/components/page/LinkList.tsx` (use `linkLabelClasses`)
+- Modify: `src/lib/puck/components/page/__tests__/page-components.test.tsx` (add tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `LinkList` describe block in `src/lib/puck/components/page/__tests__/page-components.test.tsx`:
+
+```typescript
+  it('applies default text size to link labels (no textSize prop)', () => {
+    const { container } = render(
+      <LinkList items={[{ label: 'Link', url: '/a', description: '' }]} layout="stacked" />
+    );
+    const label = container.querySelector('span.font-medium') as HTMLElement;
+    expect(label).not.toBeNull();
+    // Default 'medium' maps to text-base — no explicit class since it's the browser default
+  });
+
+  it('applies text-lg class to link labels when textSize is large', () => {
+    const { container } = render(
+      <LinkList items={[{ label: 'Link', url: '/a', description: '' }]} layout="stacked" textSize="large" />
+    );
+    const label = container.querySelector('span.font-medium') as HTMLElement;
+    expect(label.className).toContain('text-lg');
+  });
+
+  it('applies text-sm class to link labels when textSize is small', () => {
+    const { container } = render(
+      <LinkList items={[{ label: 'Link', url: '/a', description: '' }]} layout="stacked" textSize="small" />
+    );
+    const label = container.querySelector('span.font-medium') as HTMLElement;
+    expect(label.className).toContain('text-sm');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: FAIL — `textSize` prop not recognized on LinkList
+
+- [ ] **Step 3: Update types**
+
+In `src/lib/puck/types.ts`, update `LinkListProps`:
+
+```typescript
+export interface LinkListProps {
+  items: Array<{
+    label: string;
+    url: string | LinkValue;
+    description: string;
+  }>;
+  layout: 'inline' | 'stacked';
+  textSize?: TextSize;
+}
+```
+
+- [ ] **Step 4: Update the component**
+
+Replace `src/lib/puck/components/page/LinkList.tsx`:
+
+```typescript
+import type { LinkListProps } from '../../types';
+import { resolveLink } from '../../fields/link-utils';
+import { linkLabelClasses } from '../../text-styles';
+
+export function LinkList({ items, layout, textSize = 'medium' }: LinkListProps) {
+  if (!items?.length) return <></>;
+  const containerClass =
+    layout === 'inline'
+      ? 'flex flex-wrap items-center justify-center gap-4'
+      : 'flex flex-col gap-3';
+  const labelSize = linkLabelClasses[textSize];
+  return (
+    <div className={`mx-auto max-w-2xl px-4 py-4 ${containerClass}`}>
+      {items.map((item, i) => {
+        const link = resolveLink(item.url);
+        return (
+          <a
+            key={i}
+            href={link.href}
+            target={link.target}
+            rel="noopener noreferrer"
+            className="group block rounded-lg border border-gray-200 p-3 transition hover:border-[var(--color-primary)] hover:shadow-sm"
+            style={link.color ? { color: link.color } : undefined}
+          >
+            <span className={`${labelSize} font-medium text-[var(--color-primary)] group-hover:underline`}>{item.label}</span>
+            {item.description && (
+              <span className="mt-1 block text-sm text-gray-600">{item.description}</span>
+            )}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Update config**
+
+In `src/lib/puck/config.ts`, update the LinkList config — add `textSize: 'medium'` to `defaultProps` and `textSize: textSizeField()` to `fields`:
+
+```typescript
+    LinkList: {
+      label: 'Link List',
+      defaultProps: {
+        items: [],
+        layout: 'stacked',
+        textSize: 'medium',
+      },
+      fields: {
+        items: {
+          type: 'array',
+          label: 'Links',
+          arrayFields: {
+            label: { type: 'text', label: 'Label' },
+            url: linkField('URL'),
+            description: { type: 'text', label: 'Description' },
+          },
+          defaultItemProps: {
+            label: 'Link',
+            url: '#',
+            description: '',
+          },
+        },
+        textSize: textSizeField(),
+        layout: {
+          type: 'radio',
+          label: 'Layout',
+          options: [
+            { label: 'Inline', value: 'inline' },
+            { label: 'Stacked', value: 'stacked' },
+          ],
+        },
+      },
+      render: LinkList,
+    },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/puck/components/page/__tests__/page-components.test.tsx`
+Expected: PASS — all LinkList tests green
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/puck/types.ts src/lib/puck/config.ts src/lib/puck/components/page/LinkList.tsx src/lib/puck/components/page/__tests__/page-components.test.tsx
+git commit -m "feat: add textSize field to LinkList component"
+```
+
+---
+
+### Task 8: Investigate and Fix Rich Text Heading Sizes in Preview
+
+**Files:**
+- Possibly modify: `src/lib/puck/components/page/RichText.tsx`
+- Possibly modify: CSS/Tailwind config
+- Modify: `src/lib/puck/components/page/__tests__/page-components.test.tsx` (if fix changes behavior)
+
+This task requires investigation — the bug is that heading sizes (h1, h2, etc.) in the rich text editor don't visually change in preview mode.
+
+- [ ] **Step 1: Reproduce the issue**
+
+Run: `npm run dev`
+
+Open the site builder, add a RichText component, type heading text and use the rich text toolbar to set it as H1, H2, H3. Check if the headings render at different sizes in the preview pane.
+
+- [ ] **Step 2: Investigate root cause**
+
+Check these likely causes:
+1. **Prose classes not applied to edit-time ReactNode content** — When Puck renders in edit mode, `content` is a ReactNode (not a string). Check if the `<div className="prose ...">` wrapper is actually wrapping the content.
+2. **CSS specificity** — Tailwind's prose plugin styles may be overridden by Puck's editor styles. Inspect elements in browser DevTools.
+3. **Missing prose heading modifiers** — The component uses `prose-headings:text-[var(--color-primary-dark)]` which changes color but not size — sizes come from the base prose class. Check if Puck's editor CSS resets heading sizes.
+
+- [ ] **Step 3: Implement the fix**
+
+Based on investigation, apply the fix. Common solutions:
+- If Puck editor CSS overrides prose heading sizes: add specificity via `prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl` modifiers
+- If content isn't wrapped in prose: adjust the component structure
+- If Tailwind purge removes prose heading classes: ensure they're in the safelist
+
+- [ ] **Step 4: Verify the fix**
+
+Confirm in the browser that heading sizes now render correctly in both:
+- Edit mode (Puck editor)
+- Preview mode
+- Published page view
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npm run test`
+Expected: PASS — no regressions
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix: ensure rich text heading sizes render correctly in preview"
+```
+
+---
+
+### Task 9: Full Test Suite + Type Check
+
+**Files:** None — verification only
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm run test`
+Expected: PASS — all tests green, no regressions
+
+- [ ] **Step 2: Run type check**
+
+Run: `npm run type-check`
+Expected: PASS — no TypeScript errors
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: PASS — successful production build with no errors

--- a/docs/superpowers/specs/2026-04-01-text-size-controls-design.md
+++ b/docs/superpowers/specs/2026-04-01-text-size-controls-design.md
@@ -1,0 +1,67 @@
+# Text Size Controls for Puck Editor Components
+
+**Date:** 2026-04-01
+**Status:** Approved
+
+## Overview
+
+Add a configurable text size field to all text-rendering Puck page components using a shared text styles module. Also fix the bug where rich text editor heading sizes don't render in preview.
+
+## Shared Text Styles Module
+
+New file: `src/lib/puck/text-styles.ts`
+
+Exports:
+- `TextSize` type — `'small' | 'medium' | 'large' | 'xl'`
+- Per-component-type size class maps:
+  - `proseSizeClasses` — for RichText, Card, Testimonial (`prose-sm` through `prose-xl`)
+  - `heroTitleClasses` — Hero title (`text-2xl md:text-3xl` through `text-5xl md:text-6xl`)
+  - `heroSubtitleClasses` — Hero subtitle (`text-base` through `text-2xl md:text-3xl`)
+  - `statValueClasses` — Stats value (`text-xl` through `text-4xl`)
+  - `linkLabelClasses` — LinkList label (`text-sm` through `text-xl`)
+- `textSizeField(label?)` — factory function returning a Puck select field definition with the 4 size options
+
+## Component Changes
+
+Each component gets a `textSize` prop (optional, with default matching current hardcoded behavior):
+
+| Component | New prop | Default | Class map used | What changes |
+|---|---|---|---|---|
+| RichText | `textSize` | `'large'` | `proseSizeClasses` | Replaces hardcoded `prose-lg` |
+| Hero | `textSize` | `'large'` | `heroTitleClasses` + `heroSubtitleClasses` | Replaces hardcoded `text-4xl md:text-5xl` / `text-lg md:text-xl` |
+| Card | `textSize` | `'small'` | `proseSizeClasses` | Replaces hardcoded `prose-sm` |
+| Stats | `textSize` | `'large'` | `statValueClasses` | Replaces hardcoded `text-3xl` |
+| Testimonial | `textSize` | `'large'` | `proseSizeClasses` | Replaces hardcoded `prose-lg` |
+| LinkList | `textSize` | `'medium'` | `linkLabelClasses` | Replaces hardcoded implicit `text-base` |
+
+**Section** is excluded — it's a wrapper with no text of its own.
+
+## Types Update
+
+`src/lib/puck/types.ts` — add `textSize?: TextSize` to:
+- `RichTextProps`
+- `HeroProps`
+- `CardProps`
+- `StatsProps`
+- `TestimonialProps`
+- `LinkListProps`
+
+The field is optional (`?`) so existing saved page data without the field renders identically using defaults.
+
+## Config Update
+
+`src/lib/puck/config.ts` — for each affected component:
+- Add `textSize: 'medium'` (or appropriate default) to `defaultProps`
+- Add `textSize: textSizeField()` to `fields`
+
+## Bug Fix: Rich Text Heading Sizes in Preview
+
+Heading sizes (h1, h2, etc.) within the rich text editor don't visually change in preview mode. Investigate and fix during implementation — likely a CSS specificity issue or prose classes not applying to Puck's edit-time rendered content.
+
+## Design Decisions
+
+- **Consistent labels, component-appropriate scales:** All components use the same 4 labels (Small/Medium/Large/XL) but map to different Tailwind classes appropriate for their context (e.g., Hero "Large" = `text-4xl`, Card "Large" = `prose-lg`)
+- **Prose scale for rich text components:** Uses Tailwind Typography's prose sizing which proportionally scales all headings, paragraphs, lists — cleanest approach
+- **No font weight controls:** Scope limited to text size only for now
+- **Backward compatible:** Defaults match current hardcoded values, no migration needed
+- **Shared module over inline:** Prevents drift across 6 components, makes global changes easy

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@serwist/next": "^9.5.7",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.47.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.96.1",
         "@tmcw/togeojson": "^7.1.2",
         "@turf/bbox": "^7.3.4",
@@ -143,7 +144,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1174,7 +1174,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1185,7 +1184,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1195,14 +1193,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1386,7 +1382,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1400,7 +1395,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1410,7 +1404,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2706,6 +2699,31 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -4277,14 +4295,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4298,7 +4314,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4649,7 +4664,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4673,7 +4687,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4797,7 +4810,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4917,7 +4929,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4942,7 +4953,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4998,7 +5008,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5099,7 +5108,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5323,14 +5331,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6135,7 +6141,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6152,7 +6157,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6179,7 +6183,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6214,7 +6217,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6364,7 +6366,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6379,7 +6380,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6533,7 +6533,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6751,7 +6750,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7012,7 +7010,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7065,7 +7062,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7126,7 +7122,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7181,7 +7176,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7230,7 +7224,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7481,7 +7474,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -7957,7 +7949,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7970,7 +7961,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -8422,7 +8412,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -9001,7 +8990,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -9078,7 +9066,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -9245,7 +9232,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9585,7 +9571,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -9621,7 +9606,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9634,7 +9618,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9644,7 +9627,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -9730,7 +9712,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9760,7 +9741,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -9778,7 +9758,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9804,7 +9783,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9847,7 +9825,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9873,7 +9850,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -9887,7 +9863,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -10216,7 +10191,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10407,7 +10381,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -10438,7 +10411,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -10585,7 +10557,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -10626,7 +10597,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -10729,7 +10699,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11514,7 +11483,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -11550,7 +11518,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11570,8 +11537,8 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11615,7 +11582,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -11625,7 +11591,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -11655,7 +11620,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11672,7 +11636,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -11690,7 +11653,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11734,7 +11696,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -11806,7 +11767,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@serwist/next": "^9.5.7",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.0",
+    "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.96.1",
     "@tmcw/togeojson": "^7.1.2",
     "@turf/bbox": "^7.3.4",

--- a/src/components/puck/PuckChromeEditor.tsx
+++ b/src/components/puck/PuckChromeEditor.tsx
@@ -5,8 +5,9 @@ import '@puckeditor/core/dist/index.css';
 import { chromeConfig } from '@/lib/puck/chrome-config';
 import { savePuckRootDraft, publishPuckRoot } from '@/app/admin/site-builder/actions';
 import { PuckSuggestionsProvider } from '@/lib/puck/fields';
+import { sanitizePuckData } from '@/lib/puck/sanitize-data';
 import type { Data } from '@puckeditor/core';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 interface PuckChromeEditorProps {
   initialData: Data;
@@ -14,7 +15,8 @@ interface PuckChromeEditorProps {
 
 export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
-  const [puckData, setPuckData] = useState<Data>(initialData);
+  const sanitizedData = useMemo(() => sanitizePuckData(initialData), [initialData]);
+  const [puckData, setPuckData] = useState<Data>(sanitizedData);
 
   const handleChange = useCallback(async (data: Data) => {
     setPuckData(data);
@@ -36,7 +38,7 @@ export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
       <PuckSuggestionsProvider data={puckData}>
         <Puck
           config={chromeConfig}
-          data={initialData}
+          data={sanitizedData}
           onChange={handleChange}
           onPublish={handlePublish}
         />

--- a/src/components/puck/PuckPageEditor.tsx
+++ b/src/components/puck/PuckPageEditor.tsx
@@ -5,8 +5,9 @@ import '@puckeditor/core/dist/index.css';
 import { pageConfig } from '@/lib/puck/config';
 import { savePuckPageDraft, publishPuckPages } from '@/app/admin/site-builder/actions';
 import { PuckSuggestionsProvider } from '@/lib/puck/fields';
+import { sanitizePuckData } from '@/lib/puck/sanitize-data';
 import type { Data } from '@puckeditor/core';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 interface PuckPageEditorProps {
   initialData: Data;
@@ -15,7 +16,8 @@ interface PuckPageEditorProps {
 
 export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
-  const [puckData, setPuckData] = useState<Data>(initialData);
+  const sanitizedData = useMemo(() => sanitizePuckData(initialData), [initialData]);
+  const [puckData, setPuckData] = useState<Data>(sanitizedData);
 
   const handleChange = useCallback(async (data: Data) => {
     setPuckData(data);
@@ -37,7 +39,7 @@ export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
       <PuckSuggestionsProvider data={puckData}>
         <Puck
           config={pageConfig}
-          data={initialData}
+          data={sanitizedData}
           onChange={handleChange}
           onPublish={handlePublish}
         />

--- a/src/lib/puck/__tests__/sanitize-data.test.ts
+++ b/src/lib/puck/__tests__/sanitize-data.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizePuckData } from '../sanitize-data';
+import type { Data } from '@puckeditor/core';
+
+describe('sanitizePuckData', () => {
+  it('removes empty text nodes from ProseMirror JSON content', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'RichText',
+          props: {
+            id: 'rt-1',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: '' },
+                    { type: 'text', text: 'Hello' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    const content = (result.content[0].props as any).content;
+    expect(content.content[0].content).toHaveLength(1);
+    expect(content.content[0].content[0].text).toBe('Hello');
+  });
+
+  it('preserves valid text nodes', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'RichText',
+          props: {
+            id: 'rt-1',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'Hello world' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    const content = (result.content[0].props as any).content;
+    expect(content.content[0].content).toHaveLength(1);
+    expect(content.content[0].content[0].text).toBe('Hello world');
+  });
+
+  it('handles string content (HTML) without modification', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'RichText',
+          props: {
+            id: 'rt-1',
+            content: '<p>Hello</p>',
+          },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    expect((result.content[0].props as any).content).toBe('<p>Hello</p>');
+  });
+
+  it('sanitizes zone content too', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [],
+      zones: {
+        'Section-1:content': [
+          {
+            type: 'RichText',
+            props: {
+              id: 'rt-z',
+              content: {
+                type: 'doc',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: '' }],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const result = sanitizePuckData(data);
+    const content = (result.zones!['Section-1:content'][0].props as any).content;
+    expect(content.content[0].content).toHaveLength(0);
+  });
+
+  it('does not mutate the original data', () => {
+    const original = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: '' },
+            { type: 'text', text: 'Keep' },
+          ],
+        },
+      ],
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'RichText',
+          props: { id: 'rt-1', content: original },
+        },
+      ],
+    };
+
+    sanitizePuckData(data);
+    // Original should be unchanged
+    expect(original.content[0].content).toHaveLength(2);
+  });
+});

--- a/src/lib/puck/__tests__/text-styles.test.ts
+++ b/src/lib/puck/__tests__/text-styles.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  proseSizeClasses,
+  heroTitleClasses,
+  heroSubtitleClasses,
+  statValueClasses,
+  linkLabelClasses,
+  textSizeField,
+} from '../text-styles';
+import type { TextSize } from '../text-styles';
+
+const allSizes: TextSize[] = ['small', 'medium', 'large', 'xl'];
+
+describe('text-styles', () => {
+  it('proseSizeClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(proseSizeClasses[size]).toBeDefined();
+      expect(proseSizeClasses[size]).toContain('prose-');
+    }
+  });
+
+  it('heroTitleClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(heroTitleClasses[size]).toBeDefined();
+      expect(heroTitleClasses[size]).toContain('text-');
+    }
+  });
+
+  it('heroSubtitleClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(heroSubtitleClasses[size]).toBeDefined();
+      expect(heroSubtitleClasses[size]).toContain('text-');
+    }
+  });
+
+  it('statValueClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(statValueClasses[size]).toBeDefined();
+      expect(statValueClasses[size]).toContain('text-');
+    }
+  });
+
+  it('linkLabelClasses has entries for all sizes', () => {
+    for (const size of allSizes) {
+      expect(linkLabelClasses[size]).toBeDefined();
+      expect(linkLabelClasses[size]).toContain('text-');
+    }
+  });
+
+  it('textSizeField returns a valid Puck select field', () => {
+    const field = textSizeField();
+    expect(field.type).toBe('select');
+    expect(field.label).toBe('Text Size');
+    expect(field.options).toHaveLength(4);
+    expect(field.options.map((o: { value: string }) => o.value)).toEqual(allSizes);
+  });
+
+  it('textSizeField accepts a custom label', () => {
+    const field = textSizeField('Quote Size');
+    expect(field.label).toBe('Quote Size');
+  });
+});

--- a/src/lib/puck/chrome-config.ts
+++ b/src/lib/puck/chrome-config.ts
@@ -128,7 +128,7 @@ export const chromeConfig: Config<ChromeComponents> = {
           label: 'Header Links',
           arrayFields: {
             label: { type: 'text', label: 'Label' },
-            href: { type: 'text', label: 'URL' },
+            href: linkField('URL'),
           },
           defaultItemProps: {
             label: 'Link',

--- a/src/lib/puck/components/chrome/HeaderBar.tsx
+++ b/src/lib/puck/components/chrome/HeaderBar.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useConfig } from '@/lib/config/client';
 import type { HeaderBarProps } from '../../types';
+import { resolveLink } from '../../fields/link-utils';
 import { IconRenderer } from '../../icons/IconRenderer';
 
 const bgClasses = {
@@ -97,18 +98,21 @@ export function HeaderBar({
 
           {links && links.length > 0 && (
             <nav className="flex items-center gap-4">
-              {links.map((link, i) => (
-                <Link
-                  key={i}
-                  href={link.href}
-                  target={link.href.startsWith('http') ? '_blank' : undefined}
-                  rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                  className="text-sm hover:underline"
-                  style={linkColor ? { color: linkColor } : undefined}
-                >
-                  {link.label}
-                </Link>
-              ))}
+              {links.map((link, i) => {
+                const resolved = resolveLink(link.href);
+                return (
+                  <Link
+                    key={i}
+                    href={resolved.href}
+                    target={resolved.target}
+                    rel={resolved.target === '_blank' ? 'noopener noreferrer' : undefined}
+                    className="text-sm hover:underline"
+                    style={linkColor ? { color: linkColor } : undefined}
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
             </nav>
           )}
         </div>

--- a/src/lib/puck/components/page/Card.tsx
+++ b/src/lib/puck/components/page/Card.tsx
@@ -1,9 +1,11 @@
 import type { CardProps } from '../../types';
 import { resolveLink } from '../../fields/link-utils';
 import { IconRenderer } from '../../icons/IconRenderer';
+import { proseSizeClasses } from '../../text-styles';
 
-export function Card({ imageUrl, title, text, linkHref, linkLabel, icon }: CardProps) {
+export function Card({ imageUrl, title, text, linkHref, linkLabel, icon, textSize = 'small' }: CardProps) {
   const link = resolveLink(linkHref);
+  const proseSize = proseSizeClasses[textSize];
   return (
     <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:shadow-md">
       {imageUrl && <img src={imageUrl} alt={title} className="h-48 w-full object-cover" loading="lazy" />}
@@ -16,8 +18,8 @@ export function Card({ imageUrl, title, text, linkHref, linkLabel, icon }: CardP
         {title && <h3 className="text-lg font-semibold text-[var(--color-primary-dark)]">{title}</h3>}
         {text && (
           typeof text === 'string'
-            ? <div className="mt-2 text-sm text-gray-600 prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: text }} />
-            : <div className="mt-2 text-sm text-gray-600 prose prose-sm max-w-none">{text}</div>
+            ? <div className={`mt-2 text-gray-600 prose ${proseSize} max-w-none`} dangerouslySetInnerHTML={{ __html: text }} />
+            : <div className={`mt-2 text-gray-600 prose ${proseSize} max-w-none`}>{text}</div>
         )}
         {link.href && linkLabel && (
           <a

--- a/src/lib/puck/components/page/Hero.tsx
+++ b/src/lib/puck/components/page/Hero.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import type { HeroProps } from '../../types';
 import { resolveLink } from '../../fields/link-utils';
 import { IconRenderer } from '../../icons/IconRenderer';
+import { heroTitleClasses, heroSubtitleClasses } from '../../text-styles';
 
 const overlayClasses = {
   primary: 'bg-[var(--color-primary)]/70',
@@ -9,7 +10,7 @@ const overlayClasses = {
   none: '',
 };
 
-export function Hero({ title, subtitle, backgroundImageUrl, overlay, ctaLabel, ctaHref, icon }: HeroProps) {
+export function Hero({ title, subtitle, backgroundImageUrl, overlay, ctaLabel, ctaHref, icon, textSize = 'large' }: HeroProps) {
   const cta = resolveLink(ctaHref);
   return (
     <section
@@ -28,8 +29,8 @@ export function Hero({ title, subtitle, backgroundImageUrl, overlay, ctaLabel, c
             <IconRenderer icon={icon} size={48} className="text-white" />
           </div>
         )}
-        {title && <h1 className="text-4xl font-bold md:text-5xl">{title}</h1>}
-        {subtitle && <p className="mt-4 text-lg opacity-90 md:text-xl">{subtitle}</p>}
+        {title && <h1 className={`${heroTitleClasses[textSize]} font-bold`}>{title}</h1>}
+        {subtitle && <p className={`mt-4 ${heroSubtitleClasses[textSize]} opacity-90`}>{subtitle}</p>}
         {ctaLabel && cta.href && (
           <Link
             href={cta.href}

--- a/src/lib/puck/components/page/LinkList.tsx
+++ b/src/lib/puck/components/page/LinkList.tsx
@@ -1,12 +1,14 @@
 import type { LinkListProps } from '../../types';
 import { resolveLink } from '../../fields/link-utils';
+import { linkLabelClasses } from '../../text-styles';
 
-export function LinkList({ items, layout }: LinkListProps) {
+export function LinkList({ items, layout, textSize = 'medium' }: LinkListProps) {
   if (!items?.length) return <></>;
   const containerClass =
     layout === 'inline'
       ? 'flex flex-wrap items-center justify-center gap-4'
       : 'flex flex-col gap-3';
+  const labelSize = linkLabelClasses[textSize];
   return (
     <div className={`mx-auto max-w-2xl px-4 py-4 ${containerClass}`}>
       {items.map((item, i) => {
@@ -20,7 +22,7 @@ export function LinkList({ items, layout }: LinkListProps) {
             className="group block rounded-lg border border-gray-200 p-3 transition hover:border-[var(--color-primary)] hover:shadow-sm"
             style={link.color ? { color: link.color } : undefined}
           >
-            <span className="font-medium text-[var(--color-primary)] group-hover:underline">{item.label}</span>
+            <span className={`${labelSize} font-medium text-[var(--color-primary)] group-hover:underline`}>{item.label}</span>
             {item.description && (
               <span className="mt-1 block text-sm text-gray-600">{item.description}</span>
             )}

--- a/src/lib/puck/components/page/RichText.tsx
+++ b/src/lib/puck/components/page/RichText.tsx
@@ -1,12 +1,14 @@
 import type { RichTextProps } from '../../types';
+import { proseSizeClasses } from '../../text-styles';
 
-export function RichText({ content, alignment, columns }: RichTextProps) {
+export function RichText({ content, alignment, columns, textSize = 'large' }: RichTextProps) {
   const alignClass = alignment === 'center' ? 'text-center' : 'text-left';
   const colClass = columns === 2 ? 'md:columns-2 md:gap-8' : '';
+  const proseSize = proseSizeClasses[textSize];
 
   return (
     <div className={`mx-auto max-w-4xl px-4 py-8 ${alignClass} ${colClass}`}>
-      <div className="prose prose-lg max-w-none prose-headings:text-[var(--color-primary-dark)] prose-a:text-[var(--color-primary)]">
+      <div className={`prose ${proseSize} max-w-none prose-headings:text-[var(--color-primary-dark)] prose-a:text-[var(--color-primary)]`}>
         <RichTextContent content={content} />
       </div>
     </div>

--- a/src/lib/puck/components/page/Stats.tsx
+++ b/src/lib/puck/components/page/Stats.tsx
@@ -1,13 +1,14 @@
 import type { StatsProps } from '../../types';
+import { statValueClasses } from '../../text-styles';
 
-export function Stats({ items }: StatsProps) {
+export function Stats({ items, textSize = 'large' }: StatsProps) {
   if (!items?.length) return <></>;
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
         {items.map((item, i) => (
           <div key={i} className="rounded-xl bg-[var(--color-surface-light)] p-6 text-center">
-            <div className="text-3xl font-bold text-[var(--color-primary)]">{item.value}</div>
+            <div className={`${statValueClasses[textSize]} font-bold text-[var(--color-primary)]`}>{item.value}</div>
             <div className="mt-1 text-sm text-gray-600">{item.label}</div>
           </div>
         ))}

--- a/src/lib/puck/components/page/Testimonial.tsx
+++ b/src/lib/puck/components/page/Testimonial.tsx
@@ -1,10 +1,16 @@
 import type { TestimonialProps } from '../../types';
+import { proseSizeClasses } from '../../text-styles';
 
-export function Testimonial({ quote, attribution, photoUrl, style }: TestimonialProps) {
-  const borderColor = style === 'accent' ? 'border-[var(--color-accent)]' : 'border-[var(--color-primary)]';
+const borderClasses = {
+  default: 'border-[var(--color-primary)]',
+  accent: 'border-[var(--color-accent)]',
+};
+
+export function Testimonial({ quote, attribution, photoUrl, style, textSize = 'large' }: TestimonialProps) {
+  const proseSize = proseSizeClasses[textSize];
   return (
-    <blockquote className={`mx-auto max-w-2xl border-l-4 ${borderColor} px-4 py-8 pl-6`}>
-      <div className="text-lg italic text-gray-700 prose prose-lg max-w-none">
+    <blockquote className={`mx-auto max-w-2xl border-l-4 ${borderClasses[style]} px-4 py-8 pl-6`}>
+      <div className={`italic text-gray-700 prose ${proseSize} max-w-none`}>
         &ldquo;{typeof quote === 'string'
           ? <span dangerouslySetInnerHTML={{ __html: quote }} />
           : <span>{quote}</span>

--- a/src/lib/puck/components/page/__tests__/new-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/new-components.test.tsx
@@ -78,6 +78,18 @@ describe('Testimonial', () => {
     const blockquote = container.querySelector('blockquote') as HTMLElement;
     expect(blockquote.className).toContain('border-[var(--color-primary)]');
   });
+
+  it('applies prose-lg class by default (no textSize prop)', () => {
+    const { container } = render(<Testimonial quote="Great" attribution="A" photoUrl="" style="default" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-lg');
+  });
+
+  it('applies prose-sm class when textSize is small', () => {
+    const { container } = render(<Testimonial quote="Great" attribution="A" photoUrl="" style="default" textSize="small" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-sm');
+  });
 });
 
 // Embed

--- a/src/lib/puck/components/page/__tests__/new-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/new-components.test.tsx
@@ -34,6 +34,18 @@ describe('Card', () => {
     const img = screen.getByRole('img', { name: 'Card' });
     expect(img.getAttribute('src')).toBe('/photo.jpg');
   });
+
+  it('applies prose-sm class by default (no textSize prop)', () => {
+    const { container } = render(<Card title="Card" text="<p>Body</p>" imageUrl="" linkHref="" linkLabel="" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-sm');
+  });
+
+  it('applies prose-lg class when textSize is large', () => {
+    const { container } = render(<Card title="Card" text="<p>Body</p>" imageUrl="" linkHref="" linkLabel="" textSize="large" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-lg');
+  });
 });
 
 // Testimonial

--- a/src/lib/puck/components/page/__tests__/page-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/page-components.test.tsx
@@ -65,6 +65,24 @@ describe('RichText', () => {
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain('text-left');
   });
+
+  it('applies prose-lg class by default (no textSize prop)', () => {
+    const { container } = render(<RichText content="Hello" alignment="left" columns={1} />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-lg');
+  });
+
+  it('applies prose-sm class when textSize is small', () => {
+    const { container } = render(<RichText content="Hello" alignment="left" columns={1} textSize="small" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-sm');
+  });
+
+  it('applies prose-xl class when textSize is xl', () => {
+    const { container } = render(<RichText content="Hello" alignment="left" columns={1} textSize="xl" />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('prose-xl');
+  });
 });
 
 // ImageBlock

--- a/src/lib/puck/components/page/__tests__/page-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/page-components.test.tsx
@@ -45,6 +45,24 @@ describe('Hero', () => {
     render(<Hero title="Hello" subtitle="" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" icon={{ set: 'lucide', name: 'Bird' }} />);
     expect(screen.getByRole('heading', { name: 'Hello' })).toBeDefined();
   });
+
+  it('applies large title classes by default (no textSize prop)', () => {
+    render(<Hero title="Welcome" subtitle="" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" />);
+    const h1 = screen.getByRole('heading', { name: 'Welcome' });
+    expect(h1.className).toContain('text-4xl');
+  });
+
+  it('applies small title classes when textSize is small', () => {
+    render(<Hero title="Welcome" subtitle="" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" textSize="small" />);
+    const h1 = screen.getByRole('heading', { name: 'Welcome' });
+    expect(h1.className).toContain('text-2xl');
+  });
+
+  it('applies xl subtitle classes when textSize is xl', () => {
+    render(<Hero title="Welcome" subtitle="Hello world" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" textSize="xl" />);
+    const subtitle = screen.getByText('Hello world');
+    expect(subtitle.className).toContain('text-2xl');
+  });
 });
 
 // RichText

--- a/src/lib/puck/components/page/__tests__/page-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/page-components.test.tsx
@@ -61,7 +61,8 @@ describe('Hero', () => {
   it('applies xl subtitle classes when textSize is xl', () => {
     render(<Hero title="Welcome" subtitle="Hello world" backgroundImageUrl="" overlay="none" ctaLabel="" ctaHref="" textSize="xl" />);
     const subtitle = screen.getByText('Hello world');
-    expect(subtitle.className).toContain('text-2xl');
+    expect(subtitle.className).toContain('text-xl');
+    expect(subtitle.className).toContain('md:text-2xl');
   });
 });
 

--- a/src/lib/puck/components/page/__tests__/page-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/page-components.test.tsx
@@ -209,6 +209,22 @@ describe('LinkList', () => {
     expect(link.getAttribute('href')).toBe('https://example.com');
     expect(link.getAttribute('target')).toBe('_blank');
   });
+
+  it('applies text-lg class to link labels when textSize is large', () => {
+    const { container } = render(
+      <LinkList items={[{ label: 'Link', url: '/a', description: '' }]} layout="stacked" textSize="large" />
+    );
+    const label = container.querySelector('span.font-medium') as HTMLElement;
+    expect(label.className).toContain('text-lg');
+  });
+
+  it('applies text-sm class to link labels when textSize is small', () => {
+    const { container } = render(
+      <LinkList items={[{ label: 'Link', url: '/a', description: '' }]} layout="stacked" textSize="small" />
+    );
+    const label = container.querySelector('span.font-medium') as HTMLElement;
+    expect(label.className).toContain('text-sm');
+  });
 });
 
 // Stats

--- a/src/lib/puck/components/page/__tests__/page-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/page-components.test.tsx
@@ -233,6 +233,33 @@ describe('Stats', () => {
     const { container } = render(<Stats source="manual" items={[]} />);
     expect(container.firstChild).toBeNull();
   });
+
+  it('applies text-3xl to stat values by default (no textSize prop)', () => {
+    const { container } = render(
+      <Stats source="manual" items={[{ value: '42', label: 'Species' }]} />
+    );
+    const valueEl = container.querySelector('.text-3xl') as HTMLElement;
+    expect(valueEl).not.toBeNull();
+    expect(valueEl.textContent).toBe('42');
+  });
+
+  it('applies text-xl to stat values when textSize is small', () => {
+    const { container } = render(
+      <Stats source="manual" items={[{ value: '42', label: 'Species' }]} textSize="small" />
+    );
+    const valueEl = container.querySelector('.text-xl') as HTMLElement;
+    expect(valueEl).not.toBeNull();
+    expect(valueEl.textContent).toBe('42');
+  });
+
+  it('applies text-4xl to stat values when textSize is xl', () => {
+    const { container } = render(
+      <Stats source="manual" items={[{ value: '42', label: 'Species' }]} textSize="xl" />
+    );
+    const valueEl = container.querySelector('.text-4xl') as HTMLElement;
+    expect(valueEl).not.toBeNull();
+    expect(valueEl.textContent).toBe('42');
+  });
 });
 
 // Gallery

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -229,6 +229,7 @@ export const pageConfig: Config<PageComponents> = {
       defaultProps: {
         source: 'manual',
         items: [],
+        textSize: 'large',
       },
       fields: {
         source: {
@@ -251,6 +252,7 @@ export const pageConfig: Config<PageComponents> = {
             value: '0',
           },
         },
+        textSize: textSizeField(),
       },
       render: Stats,
     },

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -420,11 +420,13 @@ export const pageConfig: Config<PageComponents> = {
         attribution: '',
         photoUrl: '',
         style: 'default',
+        textSize: 'large',
       },
       fields: {
         quote: { type: 'richtext', label: 'Quote' },
         attribution: { type: 'text', label: 'Attribution' },
         photoUrl: imagePickerField('Photo', fetchLandingAssets),
+        textSize: textSizeField(),
         style: {
           type: 'radio',
           label: 'Style',

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -196,6 +196,7 @@ export const pageConfig: Config<PageComponents> = {
       defaultProps: {
         items: [],
         layout: 'stacked',
+        textSize: 'medium',
       },
       fields: {
         items: {
@@ -220,6 +221,7 @@ export const pageConfig: Config<PageComponents> = {
             { label: 'Stacked', value: 'stacked' },
           ],
         },
+        textSize: textSizeField(),
       },
       render: LinkList,
     },

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -1,5 +1,6 @@
 import type { Config } from '@puckeditor/core';
 import { imagePickerField, iconPickerField, linkField } from './fields';
+import { textSizeField } from './text-styles';
 import { fetchLandingAssets } from './fields/fetch-assets';
 import type {
   HeroProps,
@@ -96,9 +97,11 @@ export const pageConfig: Config<PageComponents> = {
         content: '',
         alignment: 'left',
         columns: 1,
+        textSize: 'large',
       },
       fields: {
         content: { type: 'richtext', label: 'Content', contentEditable: true },
+        textSize: textSizeField(),
         alignment: {
           type: 'radio',
           label: 'Alignment',

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -362,11 +362,13 @@ export const pageConfig: Config<PageComponents> = {
         text: '',
         linkHref: '',
         linkLabel: '',
+        textSize: 'small',
       },
       fields: {
         imageUrl: imagePickerField('Image', fetchLandingAssets),
         title: { type: 'text', label: 'Title' },
         text: { type: 'richtext', label: 'Text' },
+        textSize: textSizeField(),
         linkHref: linkField('Link URL'),
         linkLabel: { type: 'text', label: 'Link Label' },
         icon: iconPickerField('Icon'),

--- a/src/lib/puck/config.ts
+++ b/src/lib/puck/config.ts
@@ -70,10 +70,12 @@ export const pageConfig: Config<PageComponents> = {
         overlay: 'primary',
         ctaLabel: '',
         ctaHref: '',
+        textSize: 'large',
       },
       fields: {
         title: { type: 'text', label: 'Title' },
         subtitle: { type: 'text', label: 'Subtitle' },
+        textSize: textSizeField(),
         backgroundImageUrl: imagePickerField('Background Image', fetchLandingAssets),
         overlay: {
           type: 'select',

--- a/src/lib/puck/sanitize-data.ts
+++ b/src/lib/puck/sanitize-data.ts
@@ -1,0 +1,74 @@
+import type { Data } from '@puckeditor/core';
+
+/**
+ * Recursively removes empty text nodes from ProseMirror JSON content.
+ * ProseMirror throws "Empty text nodes are not allowed" when it encounters
+ * text nodes with empty string content during deserialization.
+ */
+function sanitizeProseMirrorNode(node: unknown): unknown {
+  if (!node || typeof node !== 'object') return node;
+
+  const obj = node as Record<string, unknown>;
+
+  // Filter out empty text nodes from content arrays
+  if (Array.isArray(obj.content)) {
+    obj.content = obj.content
+      .filter((child: unknown) => {
+        if (!child || typeof child !== 'object') return true;
+        const c = child as Record<string, unknown>;
+        // Remove text nodes with empty or missing text
+        return !(c.type === 'text' && (!c.text || c.text === ''));
+      })
+      .map((child: unknown) => sanitizeProseMirrorNode(child));
+  }
+
+  return obj;
+}
+
+/**
+ * Sanitizes Puck editor data by cleaning up richtext field content
+ * that may contain empty ProseMirror text nodes.
+ */
+export function sanitizePuckData(data: Data): Data {
+  if (!data) return data;
+
+  const sanitizeComponentProps = (props: Record<string, unknown>) => {
+    const cleaned = { ...props };
+    for (const [key, value] of Object.entries(cleaned)) {
+      // ProseMirror JSON objects have a "type" field (e.g., "doc", "paragraph")
+      if (
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        'type' in value &&
+        'content' in value
+      ) {
+        cleaned[key] = sanitizeProseMirrorNode(structuredClone(value));
+      }
+    }
+    return cleaned;
+  };
+
+  const sanitizeComponents = (
+    components: Data['content']
+  ): Data['content'] =>
+    components.map((component) => ({
+      ...component,
+      props: sanitizeComponentProps(component.props as Record<string, unknown>),
+    }));
+
+  const result: Data = {
+    ...data,
+    content: sanitizeComponents(data.content || []),
+  };
+
+  // Also sanitize zone content
+  if (data.zones) {
+    result.zones = {};
+    for (const [zone, components] of Object.entries(data.zones)) {
+      result.zones[zone] = sanitizeComponents(components);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/puck/text-styles.ts
+++ b/src/lib/puck/text-styles.ts
@@ -1,0 +1,55 @@
+export type TextSize = 'small' | 'medium' | 'large' | 'xl';
+
+/** Prose-based components: RichText, Card body, Testimonial quote */
+export const proseSizeClasses: Record<TextSize, string> = {
+  small: 'prose-sm',
+  medium: 'prose-base',
+  large: 'prose-lg',
+  xl: 'prose-xl',
+};
+
+/** Hero title */
+export const heroTitleClasses: Record<TextSize, string> = {
+  small: 'text-2xl md:text-3xl',
+  medium: 'text-3xl md:text-4xl',
+  large: 'text-4xl md:text-5xl',
+  xl: 'text-5xl md:text-6xl',
+};
+
+/** Hero subtitle */
+export const heroSubtitleClasses: Record<TextSize, string> = {
+  small: 'text-base',
+  medium: 'text-lg md:text-xl',
+  large: 'text-xl md:text-2xl',
+  xl: 'text-2xl md:text-3xl',
+};
+
+/** Stats value number */
+export const statValueClasses: Record<TextSize, string> = {
+  small: 'text-xl',
+  medium: 'text-2xl',
+  large: 'text-3xl',
+  xl: 'text-4xl',
+};
+
+/** LinkList label text */
+export const linkLabelClasses: Record<TextSize, string> = {
+  small: 'text-sm',
+  medium: 'text-base',
+  large: 'text-lg',
+  xl: 'text-xl',
+};
+
+/** Reusable Puck field definition for text size */
+export function textSizeField(label = 'Text Size') {
+  return {
+    type: 'select' as const,
+    label,
+    options: [
+      { label: 'Small', value: 'small' as const },
+      { label: 'Medium', value: 'medium' as const },
+      { label: 'Large', value: 'large' as const },
+      { label: 'XL', value: 'xl' as const },
+    ],
+  };
+}

--- a/src/lib/puck/text-styles.ts
+++ b/src/lib/puck/text-styles.ts
@@ -18,10 +18,10 @@ export const heroTitleClasses: Record<TextSize, string> = {
 
 /** Hero subtitle */
 export const heroSubtitleClasses: Record<TextSize, string> = {
-  small: 'text-base',
-  medium: 'text-lg md:text-xl',
-  large: 'text-xl md:text-2xl',
-  xl: 'text-2xl md:text-3xl',
+  small: 'text-sm md:text-base',
+  medium: 'text-base md:text-lg',
+  large: 'text-lg md:text-xl',
+  xl: 'text-xl md:text-2xl',
 };
 
 /** Stats value number */

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -15,6 +15,7 @@ export interface HeroProps {
   ctaLabel: string;
   ctaHref: string | LinkValue;
   icon?: IconValue;
+  textSize?: TextSize;
 }
 
 export interface RichTextProps {

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -104,6 +104,7 @@ export interface TestimonialProps {
   attribution: string;
   photoUrl: string;
   style: 'default' | 'accent';
+  textSize?: TextSize;
 }
 
 export interface EmbedProps {

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -1,5 +1,6 @@
 import type { Data, Config } from '@puckeditor/core';
 import type { LinkValue, IconValue } from './fields/link-utils';
+import type { TextSize } from './text-styles';
 
 // Re-export field value types for component use
 export type { LinkValue, IconValue } from './fields/link-utils';
@@ -20,6 +21,7 @@ export interface RichTextProps {
   content: string;
   alignment: 'left' | 'center';
   columns: 1 | 2;
+  textSize?: TextSize;
 }
 
 export interface ImageBlockProps {

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -123,7 +123,7 @@ export interface HeaderBarProps {
   taglineSize?: 'small' | 'medium' | 'large' | 'xl';
   taglineWeight?: 'normal' | 'medium' | 'semibold' | 'bold';
   taglineColor?: string;
-  links?: Array<{ label: string; href: string }>;
+  links?: Array<{ label: string; href: string | LinkValue }>;
   linkColor?: string;
 }
 

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -49,6 +49,7 @@ export interface LinkListProps {
     description: string;
   }>;
   layout: 'inline' | 'stacked';
+  textSize?: TextSize;
 }
 
 export interface StatsProps {

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -89,6 +89,7 @@ export interface CardProps {
   linkHref: string | LinkValue;
   linkLabel: string;
   icon?: IconValue;
+  textSize?: TextSize;
 }
 
 export interface MapPreviewProps {

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -57,6 +57,7 @@ export interface StatsProps {
     label: string;
     value: string;
   }>;
+  textSize?: TextSize;
 }
 
 export interface GalleryProps {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,12 @@
 import type { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
 
 const config: Config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/lib/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {
@@ -28,7 +30,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [typography],
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- Adds a configurable **Text Size** field (Small / Medium / Large / XL) to 6 Puck page components: RichText, Hero, Card, Stats, Testimonial, LinkList
- Creates a shared `text-styles.ts` module with per-component Tailwind class maps and a `textSizeField()` factory
- **Bug fix:** Installs missing `@tailwindcss/typography` plugin — prose classes were generating no CSS
- **Bug fix:** Sanitizes empty ProseMirror text nodes before loading the editor, fixing the `RangeError: Empty text nodes are not allowed` crash on the site builder page
- Adds `src/lib/` to Tailwind content paths so Puck component classes are detected by JIT
- All defaults match current hardcoded values — existing sites render identically

## Components Updated

| Component | Default | What it controls |
|---|---|---|
| RichText | Large | Prose scale (prose-sm → prose-xl) |
| Hero | Large | Title + subtitle sizes |
| Card | Small | Card body prose scale |
| Stats | Large | Stat value number size |
| Testimonial | Large | Quote prose scale |
| LinkList | Medium | Link label size |

## Test plan

- [x] 569 tests passing (27 new tests added)
- [x] TypeScript type-check clean
- [x] Production build succeeds
- [ ] Manual: open site builder — verify it loads without crashing (was throwing `RangeError: Empty text nodes are not allowed`)
- [ ] Manual: add RichText component, verify Text Size dropdown appears and changes prose size in preview
- [ ] Manual: verify heading sizes (H1, H2, H3) now render at distinct sizes in rich text (was broken without typography plugin)
- [ ] Manual: verify existing pages render identically (backward-compatible defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)