### PR TITLE
fix: robust ProseMirror empty text node sanitizer

### DIFF
--- a/src/lib/puck/__tests__/sanitize-data.test.ts
+++ b/src/lib/puck/__tests__/sanitize-data.test.ts
@@ -47,9 +47,7 @@ describe('sanitizePuckData', () => {
               content: [
                 {
                   type: 'paragraph',
-                  content: [
-                    { type: 'text', text: 'Hello world' },
-                  ],
+                  content: [{ type: 'text', text: 'Hello world' }],
                 },
               ],
             },
@@ -64,7 +62,7 @@ describe('sanitizePuckData', () => {
     expect(content.content[0].content[0].text).toBe('Hello world');
   });
 
-  it('handles string content (HTML) without modification', () => {
+  it('handles HTML string content without modification', () => {
     const data: Data = {
       root: { props: {} },
       content: [
@@ -82,7 +80,7 @@ describe('sanitizePuckData', () => {
     expect((result.content[0].props as any).content).toBe('<p>Hello</p>');
   });
 
-  it('sanitizes zone content too', () => {
+  it('sanitizes zone content', () => {
     const data: Data = {
       root: { props: {} },
       content: [],
@@ -137,7 +135,92 @@ describe('sanitizePuckData', () => {
     };
 
     sanitizePuckData(data);
-    // Original should be unchanged
     expect(original.content[0].content).toHaveLength(2);
+  });
+
+  it('sanitizes stringified ProseMirror JSON in props', () => {
+    const pmJson = JSON.stringify({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: '' },
+            { type: 'text', text: 'Hello' },
+          ],
+        },
+      ],
+    });
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'RichText',
+          props: { id: 'rt-1', content: pmJson },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    const content = (result.content[0].props as any).content;
+    // Should have been parsed and sanitized — now an object, not a string
+    expect(typeof content).toBe('object');
+    expect(content.content[0].content).toHaveLength(1);
+    expect(content.content[0].content[0].text).toBe('Hello');
+  });
+
+  it('removes text nodes with null text', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'RichText',
+          props: {
+            id: 'rt-1',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: null },
+                    { type: 'text', text: 'Keep' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    const content = (result.content[0].props as any).content;
+    expect(content.content[0].content).toHaveLength(1);
+    expect(content.content[0].content[0].text).toBe('Keep');
+  });
+
+  it('sanitizes root props (chrome components)', () => {
+    const data = {
+      root: {
+        props: {
+          announcement: {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: '' }],
+              },
+            ],
+          },
+        },
+      },
+      content: [],
+    } as unknown as Data;
+
+    const result = sanitizePuckData(data);
+    const announcement = (result.root.props as any).announcement;
+    expect(announcement.content[0].content).toHaveLength(0);
   });
 });

--- a/src/lib/puck/sanitize-data.ts
+++ b/src/lib/puck/sanitize-data.ts
@@ -1,27 +1,102 @@
 import type { Data } from '@puckeditor/core';
 
 /**
- * Sanitize Puck data to remove empty text nodes from richtext (ProseMirror/TipTap) content.
- *
- * ProseMirror throws `RangeError: Empty text nodes are not allowed` when deserializing
- * JSON that contains `{ type: "text", text: "" }`. This walks the entire Puck data tree
- * and strips those nodes before the editor loads the data.
+ * Recursively remove empty text nodes from a ProseMirror JSON tree.
+ * ProseMirror throws `RangeError: Empty text nodes are not allowed`
+ * when encountering `{ type: "text", text: "" }` during deserialization.
  */
-export function sanitizePuckData(data: Data): Data {
-  return JSON.parse(JSON.stringify(data), (_key, value) => {
-    // Look for ProseMirror node content arrays and filter out empty text nodes
-    if (Array.isArray(value)) {
-      const filtered = value.filter(
+function stripEmptyTextNodes(node: unknown): unknown {
+  if (!node || typeof node !== 'object') return node;
+  if (Array.isArray(node)) {
+    return node
+      .filter(
         (item) =>
           !(
             item &&
             typeof item === 'object' &&
-            item.type === 'text' &&
-            (item.text === '' || item.text == null)
+            !Array.isArray(item) &&
+            (item as Record<string, unknown>).type === 'text' &&
+            !(item as Record<string, unknown>).text
           )
-      );
-      return filtered;
+      )
+      .map(stripEmptyTextNodes);
+  }
+  const obj = node as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = stripEmptyTextNodes(value);
+  }
+  return result;
+}
+
+/**
+ * If a string looks like stringified ProseMirror JSON, parse and sanitize it.
+ */
+function sanitizeStringValue(value: string): string | unknown {
+  if (
+    value.startsWith('{') &&
+    value.includes('"type"') &&
+    value.includes('"content"')
+  ) {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && parsed.type) {
+        return stripEmptyTextNodes(parsed);
+      }
+    } catch {
+      // Not valid JSON, return as-is
     }
-    return value;
-  });
+  }
+  return value;
+}
+
+/**
+ * Sanitize Puck data to remove empty text nodes from richtext (ProseMirror/TipTap) content.
+ *
+ * Handles three cases:
+ * 1. ProseMirror JSON nested as objects in component props
+ * 2. ProseMirror JSON stored as stringified JSON strings in component props
+ * 3. Deeply nested content in zones and slots
+ */
+export function sanitizePuckData(data: Data): Data {
+  const clone = JSON.parse(JSON.stringify(data));
+
+  function walkProps(props: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(props)) {
+      if (typeof value === 'string') {
+        result[key] = sanitizeStringValue(value);
+      } else if (value && typeof value === 'object') {
+        result[key] = stripEmptyTextNodes(value);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  function walkComponents(
+    components: Array<{ type: string; props: Record<string, unknown> }>
+  ) {
+    for (const component of components) {
+      component.props = walkProps(component.props);
+    }
+  }
+
+  if (clone.content) {
+    walkComponents(clone.content);
+  }
+
+  if (clone.zones) {
+    for (const zone of Object.values(clone.zones)) {
+      walkComponents(zone as Array<{ type: string; props: Record<string, unknown> }>);
+    }
+  }
+
+  // Also walk root props (chrome components may have richtext fields)
+  if (clone.root?.props) {
+    clone.root.props = walkProps(clone.root.props);
+  }
+
+  return clone;
 }


### PR DESCRIPTION
## Summary

Fixes the `RangeError: Empty text nodes are not allowed` crash on the site builder page.

The previous sanitizer used a `JSON.parse` reviver which missed ProseMirror JSON stored as **stringified JSON strings** within component props. The new version:

- Recursively walks all component props (content, zones, root)
- Detects and parses stringified ProseMirror JSON strings (double-encoded JSON)
- Strips empty text nodes from ProseMirror JSON objects at any nesting depth
- Also sanitizes root props (chrome components with richtext fields)

## Test plan

- [x] 8 unit tests covering: object JSON, string JSON, HTML passthrough, zones, root props, null text, immutability
- [x] Full test suite passing (572 tests)
- [x] TypeScript type-check clean
- [ ] Manual: verify site builder at `/admin/properties/default/site-builder/landing` loads without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)