### PR TITLE
fix: prevent ProseMirror crash on empty richtext fields

### DIFF
--- a/src/lib/puck/__tests__/sanitize-data.test.ts
+++ b/src/lib/puck/__tests__/sanitize-data.test.ts
@@ -3,75 +3,58 @@ import { sanitizePuckData } from '../sanitize-data';
 import type { Data } from '@puckeditor/core';
 
 describe('sanitizePuckData', () => {
-  it('removes empty text nodes from ProseMirror JSON content', () => {
+  it('converts empty string richtext content to null', () => {
     const data: Data = {
       root: { props: {} },
       content: [
         {
           type: 'RichText',
-          props: {
-            id: 'rt-1',
-            content: {
-              type: 'doc',
-              content: [
-                {
-                  type: 'paragraph',
-                  content: [
-                    { type: 'text', text: '' },
-                    { type: 'text', text: 'Hello' },
-                  ],
-                },
-              ],
-            },
-          },
+          props: { id: 'rt-1', content: '', alignment: 'left', columns: 1 },
         },
       ],
     };
 
     const result = sanitizePuckData(data);
-    const content = (result.content[0].props as any).content;
-    expect(content.content[0].content).toHaveLength(1);
-    expect(content.content[0].content[0].text).toBe('Hello');
+    expect((result.content[0].props as any).content).toBeNull();
   });
 
-  it('preserves valid text nodes', () => {
+  it('converts empty string Card text to null', () => {
     const data: Data = {
       root: { props: {} },
       content: [
         {
-          type: 'RichText',
-          props: {
-            id: 'rt-1',
-            content: {
-              type: 'doc',
-              content: [
-                {
-                  type: 'paragraph',
-                  content: [{ type: 'text', text: 'Hello world' }],
-                },
-              ],
-            },
-          },
+          type: 'Card',
+          props: { id: 'c-1', title: 'Hello', text: '', imageUrl: '', linkHref: '', linkLabel: '' },
         },
       ],
     };
 
     const result = sanitizePuckData(data);
-    const content = (result.content[0].props as any).content;
-    expect(content.content[0].content).toHaveLength(1);
-    expect(content.content[0].content[0].text).toBe('Hello world');
+    expect((result.content[0].props as any).text).toBeNull();
   });
 
-  it('handles HTML string content without modification', () => {
+  it('converts empty string Testimonial quote to null', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Testimonial',
+          props: { id: 't-1', quote: '', attribution: '', photoUrl: '', style: 'default' },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    expect((result.content[0].props as any).quote).toBeNull();
+  });
+
+  it('preserves non-empty richtext content', () => {
     const data: Data = {
       root: { props: {} },
       content: [
         {
           type: 'RichText',
-          props: {
-            id: 'rt-1',
-            content: '<p>Hello</p>',
-          },
+          props: { id: 'rt-1', content: '<p>Hello</p>', alignment: 'left', columns: 1 },
         },
       ],
     };
@@ -80,7 +63,23 @@ describe('sanitizePuckData', () => {
     expect((result.content[0].props as any).content).toBe('<p>Hello</p>');
   });
 
-  it('sanitizes zone content', () => {
+  it('preserves non-richtext empty string props', () => {
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: 'Hero',
+          props: { id: 'h-1', title: '', subtitle: '', backgroundImageUrl: '', overlay: 'none', ctaLabel: '', ctaHref: '' },
+        },
+      ],
+    };
+
+    const result = sanitizePuckData(data);
+    expect((result.content[0].props as any).title).toBe('');
+    expect((result.content[0].props as any).subtitle).toBe('');
+  });
+
+  it('sanitizes components inside zones', () => {
     const data: Data = {
       root: { props: {} },
       content: [],
@@ -88,139 +87,70 @@ describe('sanitizePuckData', () => {
         'Section-1:content': [
           {
             type: 'RichText',
-            props: {
-              id: 'rt-z',
-              content: {
-                type: 'doc',
-                content: [
-                  {
-                    type: 'paragraph',
-                    content: [{ type: 'text', text: '' }],
-                  },
-                ],
-              },
-            },
+            props: { id: 'rt-z', content: '', alignment: 'left', columns: 1 },
           },
         ],
       },
     };
 
     const result = sanitizePuckData(data);
-    const content = (result.zones!['Section-1:content'][0].props as any).content;
-    expect(content.content[0].content).toHaveLength(0);
+    expect((result.zones!['Section-1:content'][0].props as any).content).toBeNull();
   });
 
-  it('does not mutate the original data', () => {
-    const original = {
-      type: 'doc',
+  it('sanitizes components inside slot props (nested arrays)', () => {
+    const data: Data = {
+      root: { props: {} },
       content: [
         {
-          type: 'paragraph',
-          content: [
-            { type: 'text', text: '' },
-            { type: 'text', text: 'Keep' },
-          ],
+          type: 'Columns',
+          props: {
+            id: 'col-1',
+            'column-1': [
+              {
+                type: 'RichText',
+                props: { id: 'rt-slot', content: '', alignment: 'left', columns: 1 },
+              },
+            ],
+          },
         },
       ],
     };
 
+    const result = sanitizePuckData(data);
+    const slotContent = (result.content[0].props as any)['column-1'];
+    expect(slotContent[0].props.content).toBeNull();
+  });
+
+  it('does not mutate the original data', () => {
     const data: Data = {
       root: { props: {} },
       content: [
         {
           type: 'RichText',
-          props: { id: 'rt-1', content: original },
+          props: { id: 'rt-1', content: '', alignment: 'left', columns: 1 },
         },
       ],
     };
 
     sanitizePuckData(data);
-    expect(original.content[0].content).toHaveLength(2);
+    expect((data.content[0].props as any).content).toBe('');
   });
 
-  it('sanitizes stringified ProseMirror JSON in props', () => {
-    const pmJson = JSON.stringify({
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            { type: 'text', text: '' },
-            { type: 'text', text: 'Hello' },
-          ],
-        },
-      ],
-    });
-
-    const data: Data = {
-      root: { props: {} },
-      content: [
-        {
-          type: 'RichText',
-          props: { id: 'rt-1', content: pmJson },
-        },
-      ],
-    };
-
-    const result = sanitizePuckData(data);
-    const content = (result.content[0].props as any).content;
-    // Should have been parsed and sanitized — now an object, not a string
-    expect(typeof content).toBe('object');
-    expect(content.content[0].content).toHaveLength(1);
-    expect(content.content[0].content[0].text).toBe('Hello');
-  });
-
-  it('removes text nodes with null text', () => {
-    const data: Data = {
-      root: { props: {} },
-      content: [
-        {
-          type: 'RichText',
-          props: {
-            id: 'rt-1',
-            content: {
-              type: 'doc',
-              content: [
-                {
-                  type: 'paragraph',
-                  content: [
-                    { type: 'text', text: null },
-                    { type: 'text', text: 'Keep' },
-                  ],
-                },
-              ],
-            },
-          },
-        },
-      ],
-    };
-
-    const result = sanitizePuckData(data);
-    const content = (result.content[0].props as any).content;
-    expect(content.content[0].content).toHaveLength(1);
-    expect(content.content[0].content[0].text).toBe('Keep');
-  });
-
-  it('sanitizes root props (chrome components)', () => {
+  it('sanitizes root content (chrome components)', () => {
     const data = {
       root: {
-        props: {
-          announcement: {
-            type: 'doc',
-            content: [
-              {
-                type: 'paragraph',
-                content: [{ type: 'text', text: '' }],
-              },
-            ],
+        props: {},
+        content: [
+          {
+            type: 'AnnouncementBar',
+            props: { id: 'ab-1', text: '' },
           },
-        },
+        ],
       },
       content: [],
     } as unknown as Data;
 
     const result = sanitizePuckData(data);
-    const announcement = (result.root.props as any).announcement;
-    expect(announcement.content[0].content).toHaveLength(0);
+    expect((result.root as any).content[0].props.text).toBeNull();
   });
 });

--- a/src/lib/puck/sanitize-data.ts
+++ b/src/lib/puck/sanitize-data.ts
@@ -1,85 +1,42 @@
 import type { Data } from '@puckeditor/core';
 
 /**
- * Recursively remove empty text nodes from a ProseMirror JSON tree.
- * ProseMirror throws `RangeError: Empty text nodes are not allowed`
- * when encountering `{ type: "text", text: "" }` during deserialization.
+ * Prop names that are richtext fields in Puck component configs.
+ * Puck's RichTextRender crashes when these are empty strings — it creates
+ * { type: "text", text: "" } which ProseMirror rejects. Setting to null
+ * makes Puck create a safe empty doc instead.
  */
-function stripEmptyTextNodes(node: unknown): unknown {
-  if (!node || typeof node !== 'object') return node;
-  if (Array.isArray(node)) {
-    return node
-      .filter(
-        (item) =>
-          !(
-            item &&
-            typeof item === 'object' &&
-            !Array.isArray(item) &&
-            (item as Record<string, unknown>).type === 'text' &&
-            !(item as Record<string, unknown>).text
-          )
-      )
-      .map(stripEmptyTextNodes);
-  }
-  const obj = node as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    result[key] = stripEmptyTextNodes(value);
-  }
-  return result;
-}
+const RICHTEXT_PROP_NAMES = ['content', 'text', 'quote'];
 
 /**
- * If a string looks like stringified ProseMirror JSON, parse and sanitize it.
- */
-function sanitizeStringValue(value: string): string | unknown {
-  if (
-    value.startsWith('{') &&
-    value.includes('"type"') &&
-    value.includes('"content"')
-  ) {
-    try {
-      const parsed = JSON.parse(value);
-      if (parsed && typeof parsed === 'object' && parsed.type) {
-        return stripEmptyTextNodes(parsed);
-      }
-    } catch {
-      // Not valid JSON, return as-is
-    }
-  }
-  return value;
-}
-
-/**
- * Sanitize Puck data to remove empty text nodes from richtext (ProseMirror/TipTap) content.
+ * Sanitize Puck data to prevent ProseMirror "Empty text nodes" crash.
  *
- * Handles three cases:
- * 1. ProseMirror JSON nested as objects in component props
- * 2. ProseMirror JSON stored as stringified JSON strings in component props
- * 3. Deeply nested content in zones and slots
+ * Root cause: Puck's RichTextRender converts empty string "" to
+ * { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "" }] }] }
+ * which crashes ProseMirror's Node.fromJSON. Setting empty richtext to null
+ * makes Puck use { type: "doc", content: [] } instead (safe).
  */
 export function sanitizePuckData(data: Data): Data {
   const clone = JSON.parse(JSON.stringify(data));
-
-  function walkProps(props: Record<string, unknown>): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(props)) {
-      if (typeof value === 'string') {
-        result[key] = sanitizeStringValue(value);
-      } else if (value && typeof value === 'object') {
-        result[key] = stripEmptyTextNodes(value);
-      } else {
-        result[key] = value;
-      }
-    }
-    return result;
-  }
 
   function walkComponents(
     components: Array<{ type: string; props: Record<string, unknown> }>
   ) {
     for (const component of components) {
-      component.props = walkProps(component.props);
+      if (!component.props) continue;
+      // Nullify empty richtext strings to prevent ProseMirror crash
+      for (let i = 0; i < RICHTEXT_PROP_NAMES.length; i++) {
+        const key = RICHTEXT_PROP_NAMES[i];
+        if (component.props[key] === '') {
+          component.props[key] = null;
+        }
+      }
+      // Recursively walk slot content (arrays of components in props)
+      for (const value of Object.values(component.props)) {
+        if (Array.isArray(value) && value.length > 0 && value[0]?.type && value[0]?.props) {
+          walkComponents(value);
+        }
+      }
     }
   }
 
@@ -93,9 +50,9 @@ export function sanitizePuckData(data: Data): Data {
     }
   }
 
-  // Also walk root props (chrome components may have richtext fields)
-  if (clone.root?.props) {
-    clone.root.props = walkProps(clone.root.props);
+  // Chrome root content also has components with richtext
+  if (clone.root?.content) {
+    walkComponents(clone.root.content);
   }
 
   return clone;


### PR DESCRIPTION
## Summary

Fixes `RangeError: Empty text nodes are not allowed` crash on the site builder page.

**Root cause:** Puck's internal `RichTextRender` converts empty string `""` content to `{ type: "text", text: "" }` which ProseMirror rejects. The empty text nodes were never in the database — they were generated at runtime by Puck.

### Three layers of defense:

| Layer | What it handles | How |
|---|---|---|
| **Sanitizer on load** | Existing data in Supabase with `""` richtext fields | Converts `""` → `null` before passing to Puck |
| **Default props** | New components added via drag-and-drop | Changed `content/text/quote` defaults from `''` to `null` |
| **Sanitizer on onChange** | Any empty strings generated during editing | Runs sanitizer before saving to Supabase |

Also walks slot content (nested component arrays) and root chrome components.

## Test plan

- [x] 9 unit tests covering all sanitizer cases
- [x] Full test suite passing (573 tests)
- [x] TypeScript type-check clean
- [ ] Manual: verify site builder loads without crash
- [ ] Manual: add a new RichText component — verify no crash
- [ ] Manual: type text, delete all text, save, reload — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)