### PR TITLE
fix: auto-refresh Puck preview on editor changes

### DIFF
--- a/src/app/admin/properties/[slug]/site-builder/layout.tsx
+++ b/src/app/admin/properties/[slug]/site-builder/layout.tsx
@@ -2,11 +2,13 @@
 
 import Link from 'next/link';
 import { usePathname, useParams } from 'next/navigation';
+import { useRef } from 'react';
 
 export default function SiteBuilderLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { slug } = useParams<{ slug: string }>();
   const base = `/admin/properties/${slug}/site-builder`;
+  const previewWindowRef = useRef<Window | null>(null);
 
   const tabs = [
     { label: 'Landing Page', href: `${base}/landing` },
@@ -15,7 +17,13 @@ export default function SiteBuilderLayout({ children }: { children: React.ReactN
   ];
 
   const handlePreview = () => {
-    window.open('/?preview=true', '_blank');
+    // Reuse existing preview window if still open
+    if (previewWindowRef.current && !previewWindowRef.current.closed) {
+      previewWindowRef.current.location.href = '/?preview=true';
+      previewWindowRef.current.focus();
+    } else {
+      previewWindowRef.current = window.open('/?preview=true', 'puck-preview');
+    }
   };
 
   return (

--- a/src/app/admin/site-builder/actions.ts
+++ b/src/app/admin/site-builder/actions.ts
@@ -88,6 +88,7 @@ export async function savePuckPageDraft(path: string, data: unknown) {
     .eq('id', result.propertyId);
 
   if (error) return { error: error.message };
+  invalidateConfig();
   return { success: true as const };
 }
 
@@ -107,6 +108,7 @@ export async function savePuckRootDraft(data: unknown) {
     .eq('id', result.propertyId);
 
   if (error) return { error: error.message };
+  invalidateConfig();
   return { success: true as const };
 }
 

--- a/src/components/puck/PuckChromeEditor.tsx
+++ b/src/components/puck/PuckChromeEditor.tsx
@@ -6,8 +6,15 @@ import { chromeConfig } from '@/lib/puck/chrome-config';
 import { savePuckRootDraft, publishPuckRoot } from '@/app/admin/site-builder/actions';
 import { PuckSuggestionsProvider } from '@/lib/puck/fields';
 import type { Data } from '@puckeditor/core';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { sanitizePuckData } from '@/lib/puck/sanitize-data';
+
+function refreshPreviewWindow() {
+  const preview = window.open('', 'puck-preview');
+  if (preview && !preview.closed && preview.location.href !== 'about:blank') {
+    preview.location.reload();
+  }
+}
 
 interface PuckChromeEditorProps {
   initialData: Data;
@@ -17,12 +24,19 @@ export function PuckChromeEditor({ initialData }: PuckChromeEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
   const safeInitialData = useMemo(() => sanitizePuckData(initialData), [initialData]);
   const [puckData, setPuckData] = useState<Data>(safeInitialData);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleChange = useCallback(async (data: Data) => {
     setPuckData(data);
+
+    // Debounce saves to avoid hammering the server on every keystroke
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setIsSaving(true);
-    await savePuckRootDraft(data);
-    setIsSaving(false);
+    saveTimerRef.current = setTimeout(async () => {
+      await savePuckRootDraft(data);
+      setIsSaving(false);
+      refreshPreviewWindow();
+    }, 800);
   }, []);
 
   const handlePublish = useCallback(async (data: Data) => {

--- a/src/components/puck/PuckPageEditor.tsx
+++ b/src/components/puck/PuckPageEditor.tsx
@@ -6,8 +6,15 @@ import { pageConfig } from '@/lib/puck/config';
 import { savePuckPageDraft, publishPuckPages } from '@/app/admin/site-builder/actions';
 import { PuckSuggestionsProvider } from '@/lib/puck/fields';
 import type { Data } from '@puckeditor/core';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { sanitizePuckData } from '@/lib/puck/sanitize-data';
+
+function refreshPreviewWindow() {
+  const preview = window.open('', 'puck-preview');
+  if (preview && !preview.closed && preview.location.href !== 'about:blank') {
+    preview.location.reload();
+  }
+}
 
 interface PuckPageEditorProps {
   initialData: Data;
@@ -18,12 +25,19 @@ export function PuckPageEditor({ initialData, pagePath }: PuckPageEditorProps) {
   const [isSaving, setIsSaving] = useState(false);
   const safeInitialData = useMemo(() => sanitizePuckData(initialData), [initialData]);
   const [puckData, setPuckData] = useState<Data>(safeInitialData);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleChange = useCallback(async (data: Data) => {
     setPuckData(data);
+
+    // Debounce saves to avoid hammering the server on every keystroke
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setIsSaving(true);
-    await savePuckPageDraft(pagePath, data);
-    setIsSaving(false);
+    saveTimerRef.current = setTimeout(async () => {
+      await savePuckPageDraft(pagePath, data);
+      setIsSaving(false);
+      refreshPreviewWindow();
+    }, 800);
   }, [pagePath]);
 
   const handlePublish = useCallback(async (data: Data) => {


### PR DESCRIPTION
## Summary
- Draft saves now call `invalidateConfig()` so the preview page always loads fresh data from the cache instead of stale 60s-old data
- Editor `onChange` is debounced (800ms) and auto-reloads the named preview window after each save settles
- Preview Site button reuses the same browser tab (`puck-preview`) instead of opening duplicates on each click

## Test plan
- [ ] Open Puck landing page editor, click "Preview Site" to open preview tab
- [ ] Make edits in the editor — verify the preview tab auto-refreshes ~1s after you stop editing
- [ ] Click "Preview Site" again — verify it reuses the same tab instead of opening a new one
- [ ] Repeat with the Header & Footer editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)