### PR TITLE
ci: auto-apply migrations on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,28 @@ jobs:
         run: supabase db push --dry-run
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+  migrate:
+    name: Apply Migrations
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Push migrations to production
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `migrate` job to CI that runs `supabase db push` on pushes to main, after the `ci` job passes
- PR dry-run validation stays unchanged — migrations are still checked before merge
- On merge to main, migrations are automatically applied to production

## How it works

```
PR opened → migration-check (dry-run) → validates
PR merged → ci (lint/test/build) → migrate (supabase db push) → applied to prod
```

## Test plan

- [x] Existing `migration-check` job unchanged (still dry-run on PRs only)
- [ ] Merge this PR and verify the `Apply Migrations` job runs and succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)