### PR TITLE
fix: default new properties to publicly listed

### DIFF
--- a/supabase/migrations/027_properties_default_public.sql
+++ b/supabase/migrations/027_properties_default_public.sql
@@ -1,0 +1,2 @@
+-- Default new properties to publicly listed
+ALTER TABLE properties ALTER COLUMN is_publicly_listed SET DEFAULT true;


### PR DESCRIPTION
## Summary

- New properties were created with `is_publicly_listed = false` by default, meaning anonymous users couldn't see them on the map
- Changes the column default to `true` so new properties are visible immediately

Already applied to production.

## Test plan

- [x] Migration applied to prod successfully
- [ ] Create a new property and verify it's visible to anonymous users without manual config

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)