### PR TITLE
fix: VaultPicker flickering and mobile layout

### DIFF
--- a/src/components/vault/VaultBrowseTab.tsx
+++ b/src/components/vault/VaultBrowseTab.tsx
@@ -44,7 +44,7 @@ function ThumbnailImage({ item }: { item: VaultItem }) {
     } else {
       result.then(setUrl).catch(() => setUrl(null));
     }
-  }, [item]);
+  }, [item.id, item.storage_bucket, item.storage_path]);
 
   if (!url) {
     return (
@@ -178,7 +178,7 @@ export default function VaultBrowseTab({
       {/* Thumbnail grid */}
       <div className="min-h-[240px]">
         {loading ? (
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
             {Array.from({ length: 8 }).map((_, i) => (
               <SkeletonCard key={i} />
             ))}
@@ -189,7 +189,7 @@ export default function VaultBrowseTab({
             <p className="text-sm">No files found</p>
           </div>
         ) : (
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
             {items.map((item) => {
               const isSelected = selectedIds.has(item.id);
               return (

--- a/src/components/vault/VaultPicker.tsx
+++ b/src/components/vault/VaultPicker.tsx
@@ -49,7 +49,7 @@ export default function VaultPicker({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={handleBackdropClick}
     >
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 flex flex-col max-h-[90vh]">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md sm:max-w-lg mx-4 flex flex-col max-h-[90vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
           <h2 className="text-lg font-semibold text-forest-dark">Select from Data Vault</h2>


### PR DESCRIPTION
## Summary

- **Re-render loop fix:** `ThumbnailImage` useEffect had `[item]` (object reference) as dependency, causing URL to reset/refetch on every parent render — visible as flickering between placeholder and preview. Changed to stable scalar deps `[item.id, item.storage_bucket, item.storage_path]`
- **Responsive grid:** Hardcoded `grid-cols-4` caused layout thrashing on mobile. Now `grid-cols-2 sm:grid-cols-3 md:grid-cols-4`
- **Modal width:** `max-w-lg` (512px) overflowed mobile viewports. Added `max-w-md sm:max-w-lg`

## Test plan

- [ ] Open VaultPicker on mobile — no flickering, 2-column grid fits
- [ ] Open VaultPicker on tablet — 3-column grid
- [ ] Open VaultPicker on desktop — 4-column grid, no regression
- [ ] Select an image — thumbnail stays stable, no flicker

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)