### PR TITLE
fix: VaultPicker infinite fetch loop from unstable categoryFilter

### DIFF
--- a/src/components/vault/VaultBrowseTab.tsx
+++ b/src/components/vault/VaultBrowseTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { getVaultItems } from '@/lib/vault/actions';
 import { getVaultUrl } from '@/lib/vault/helpers';
 import type { VaultItem, VaultCategory } from '@/lib/vault/types';
@@ -84,7 +84,11 @@ export default function VaultBrowseTab({
   multiple = false,
   onSelect,
 }: VaultBrowseTabProps) {
-  const availableCategories = categoryFilter ?? ALL_CATEGORIES;
+  const availableCategories = useMemo(
+    () => categoryFilter ?? ALL_CATEGORIES,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [categoryFilter?.join(',')],
+  );
 
   const [activeCategory, setActiveCategory] = useState<VaultCategory | 'all'>('all');
   const [search, setSearch] = useState('');


### PR DESCRIPTION
## Summary

- `categoryFilter={['photo']}` in callers creates a new array reference every render
- This cascaded: new array → `availableCategories` changes → `fetchItems` useCallback recreates → useEffect re-runs → `setLoading(true)` (skeletons) → fetch → `setItems` (thumbnails) → parent re-renders → repeat
- Memoize `availableCategories` by value (`join(',')`) instead of object reference

## Test plan

- [ ] Open VaultPicker via photo upload on mobile — no flickering
- [ ] Switch category tabs — still fetches correctly
- [ ] Search — still works

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)