### PR TITLE
fix: bump Dexie DB version for update_type_fields table

### DIFF
--- a/src/components/manage/UpdateForm.tsx
+++ b/src/components/manage/UpdateForm.tsx
@@ -67,7 +67,7 @@ export default function UpdateForm() {
         offlineStore.getUpdateTypes(resolvedOrgId),
         offlineStore.getItemTypes(resolvedOrgId),
         offlineStore.getEntityTypes(resolvedOrgId),
-        offlineStore.getUpdateTypeFields(resolvedOrgId),
+        offlineStore.getUpdateTypeFields(resolvedOrgId).catch(() => [] as Awaited<ReturnType<typeof offlineStore.getUpdateTypeFields>>),
       ]);
 
       // Sort items by name for the dropdown

--- a/src/lib/offline/db.ts
+++ b/src/lib/offline/db.ts
@@ -56,7 +56,6 @@ export class OfflineDatabase extends Dexie {
       custom_fields: 'id, item_type_id, org_id',
       item_updates: 'id, item_id, org_id, property_id, update_date',
       update_types: 'id, org_id',
-      update_type_fields: 'id, update_type_id, org_id',
       photos: 'id, item_id, update_id, org_id, property_id',
       entities: 'id, entity_type_id, org_id',
       entity_types: 'id, org_id',
@@ -72,6 +71,10 @@ export class OfflineDatabase extends Dexie {
       photo_blobs: 'id, mutation_id, item_id',
       sync_metadata: 'id, property_id, table_name',
       tile_cache_metadata: 'id, property_id, zoom',
+    });
+
+    this.version(2).stores({
+      update_type_fields: 'id, update_type_id, org_id',
     });
   }
 }


### PR DESCRIPTION
## Summary

- Bump Dexie IndexedDB schema from version 1 to version 2, adding `update_type_fields` table in the upgrade
- Add `.catch()` safety on `getUpdateTypeFields` in UpdateForm so a missing table doesn't break the entire data fetch

## Problem

PR #180 added `update_type_fields` to Dexie's `version(1)` schema. Existing browsers already have an IndexedDB at version 1 without that table. Dexie only triggers schema upgrades when the version number increases, so the table was never created. This caused `getUpdateTypeFields()` to throw, which broke the `Promise.all` in `fetchData`, leaving the update type picker completely empty.

## Test plan

- [x] 642/642 unit tests passing
- [ ] Clear browser IndexedDB, reload app, verify update type picker populates
- [ ] Verify existing browsers auto-upgrade to version 2 on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)