### PR TITLE
fix(knowledge): save button stuck and server action serialization error

### DIFF
--- a/src/components/knowledge/KnowledgeEditor.tsx
+++ b/src/components/knowledge/KnowledgeEditor.tsx
@@ -107,49 +107,62 @@ export default function KnowledgeEditor({ orgId, item, onSaved }: KnowledgeEdito
     setSaving(true);
     setError(null);
 
-    const bodyHtml = body ? generateHTML(body, getEditorExtensions()) : '';
-    const excerpt = bodyHtml ? generateExcerpt(bodyHtml) : '';
-
-    if (item) {
-      // Update existing
-      const result = await updateKnowledgeItem(item.id, {
-        title: title.trim(),
-        body: body ?? undefined,
-        bodyHtml,
-        excerpt,
-        coverImageUrl: coverImageUrl || undefined,
-        tags,
-        visibility,
-        isAiContext,
-      });
-
-      if ('error' in result) {
-        setError(result.error);
-      } else if (onSaved) {
-        onSaved({ ...item, title: title.trim(), body, body_html: bodyHtml, excerpt, cover_image_url: coverImageUrl, tags, visibility, is_ai_context: isAiContext });
+    try {
+      let bodyHtml = '';
+      let excerpt = '';
+      try {
+        bodyHtml = body ? generateHTML(body, getEditorExtensions()) : '';
+        excerpt = bodyHtml ? generateExcerpt(bodyHtml) : '';
+      } catch {
+        // generateHTML can fail if body shape doesn't match extensions; proceed with empty HTML
       }
-    } else {
-      // Create new
-      const result = await createKnowledgeItem({
-        orgId,
-        title: title.trim(),
-        body: body ?? undefined,
-        bodyHtml,
-        excerpt,
-        coverImageUrl: coverImageUrl || undefined,
-        tags,
-        visibility,
-        isAiContext,
-      });
 
-      if ('error' in result) {
-        setError(result.error);
-      } else if (onSaved) {
-        onSaved(result.item);
+      // Serialize TipTap JSONContent to plain object for server action compatibility
+      const plainBody = body ? JSON.parse(JSON.stringify(body)) : undefined;
+
+      if (item) {
+        // Update existing
+        const result = await updateKnowledgeItem(item.id, {
+          title: title.trim(),
+          body: plainBody,
+          bodyHtml,
+          excerpt,
+          coverImageUrl: coverImageUrl || undefined,
+          tags,
+          visibility,
+          isAiContext,
+        });
+
+        if ('error' in result) {
+          setError(result.error);
+        } else if (onSaved) {
+          onSaved({ ...item, title: title.trim(), body, body_html: bodyHtml, excerpt, cover_image_url: coverImageUrl, tags, visibility, is_ai_context: isAiContext });
+        }
+      } else {
+        // Create new
+        const result = await createKnowledgeItem({
+          orgId,
+          title: title.trim(),
+          body: plainBody,
+          bodyHtml,
+          excerpt,
+          coverImageUrl: coverImageUrl || undefined,
+          tags,
+          visibility,
+          isAiContext,
+        });
+
+        if ('error' in result) {
+          setError(result.error);
+        } else if (onSaved) {
+          onSaved(result.item);
+        }
       }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
+    } finally {
+      setSaving(false);
     }
-
-    setSaving(false);
   }
 
   return (


### PR DESCRIPTION
## Summary

- Fix save button getting permanently stuck in "Saving..." state when an error occurs
- Fix `Only plain objects can be passed to Server Actions` error caused by TipTap's `JSONContent` having class prototypes

## Changes

- Wrap `handleSave` in `try/finally` so `setSaving(false)` always runs
- Serialize TipTap `JSONContent` via `JSON.parse(JSON.stringify())` before passing to server action
- Add inner `try/catch` around `generateHTML` which can throw on empty/malformed editor state

## Test plan

- [x] Existing unit tests pass
- [ ] Manual: create knowledge article — save button should work and redirect to edit page
- [ ] Manual: create article with empty body — should save without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)