### PR TITLE
fix: prevent loading spinner stuck on map and list pages

### DIFF
--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -29,50 +29,55 @@ export default function ListPage() {
     async function fetchData() {
       if (!propertyId) { setLoading(false); return; }
 
-      // Resolve orgId from the properties table in IndexedDB
-      let property = await offlineStore.db.properties.get(propertyId);
+      try {
+        // Resolve orgId from the properties table in IndexedDB
+        let property = await offlineStore.db.properties.get(propertyId);
 
-      // If no property in IndexedDB yet and we're online, bootstrap from Supabase
-      if (!property && offlineStore.isOnline) {
-        try {
-          const { createClient } = await import("@/lib/supabase/client");
-          const supabase = createClient();
-          const { data: propData } = await supabase.from('properties').select('*').eq('id', propertyId).single();
-          if (propData) {
-            await offlineStore.db.properties.put({ ...propData, _synced_at: new Date().toISOString() });
-            await offlineStore.syncProperty(propertyId, propData.org_id);
-            property = await offlineStore.db.properties.get(propertyId);
+        // If no property in IndexedDB yet and we're online, bootstrap from Supabase
+        if (!property && offlineStore.isOnline) {
+          try {
+            const { createClient } = await import("@/lib/supabase/client");
+            const supabase = createClient();
+            const { data: propData } = await supabase.from('properties').select('*').eq('id', propertyId).single();
+            if (propData) {
+              await offlineStore.db.properties.put({ ...propData, _synced_at: new Date().toISOString() });
+              await offlineStore.syncProperty(propertyId, propData.org_id);
+              property = await offlineStore.db.properties.get(propertyId);
+            }
+          } catch {
+            // Fall through to read whatever is cached
           }
-        } catch {
-          // Fall through to read whatever is cached
         }
-      }
 
-      const orgId = property?.org_id;
+        const orgId = property?.org_id;
 
-      const [itemData, typeData, fieldData] = await Promise.all([
-        offlineStore.getItems(propertyId),
-        orgId ? offlineStore.getItemTypes(orgId) : Promise.resolve([]),
-        orgId ? offlineStore.getCustomFields(orgId) : Promise.resolve([]),
-      ]);
+        const [itemData, typeData, fieldData] = await Promise.all([
+          offlineStore.getItems(propertyId),
+          orgId ? offlineStore.getItemTypes(orgId) : Promise.resolve([]),
+          orgId ? offlineStore.getCustomFields(orgId) : Promise.resolve([]),
+        ]);
 
-      setItems(itemData);
-      setItemTypes(typeData);
-      setCustomFields(fieldData);
-      setLoading(false);
+        setItems(itemData);
+        setItemTypes(typeData);
+        setCustomFields(fieldData);
 
-      // Background sync refresh
-      if (orgId && offlineStore.isOnline) {
-        offlineStore.syncProperty(propertyId, orgId).then(async () => {
-          const [freshItems, freshTypes, freshFields] = await Promise.all([
-            offlineStore.getItems(propertyId),
-            offlineStore.getItemTypes(orgId!),
-            offlineStore.getCustomFields(orgId!),
-          ]);
-          setItems(freshItems);
-          setItemTypes(freshTypes);
-          setCustomFields(freshFields);
-        });
+        // Background sync refresh
+        if (orgId && offlineStore.isOnline) {
+          offlineStore.syncProperty(propertyId, orgId).then(async () => {
+            const [freshItems, freshTypes, freshFields] = await Promise.all([
+              offlineStore.getItems(propertyId),
+              offlineStore.getItemTypes(orgId!),
+              offlineStore.getCustomFields(orgId!),
+            ]);
+            setItems(freshItems);
+            setItemTypes(freshTypes);
+            setCustomFields(freshFields);
+          });
+        }
+      } catch (err) {
+        console.error('Failed to load list data:', err);
+      } finally {
+        setLoading(false);
       }
     }
 

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -71,77 +71,81 @@ function HomeMapViewContent() {
     async function fetchData() {
       if (!propertyId) { setLoading(false); return; }
 
-      // Resolve orgId from the properties table in IndexedDB
-      const property = await offlineStore.db.properties.get(propertyId);
-      const orgId = property?.org_id;
+      try {
+        // Resolve orgId from the properties table in IndexedDB
+        const property = await offlineStore.db.properties.get(propertyId);
+        const orgId = property?.org_id;
 
-      // If no property in IndexedDB yet and we're online, sync first to bootstrap
-      if (!property && offlineStore.isOnline) {
+        // If no property in IndexedDB yet and we're online, sync first to bootstrap
+        if (!property && offlineStore.isOnline) {
+          try {
+            const { createClient } = await import("@/lib/supabase/client");
+            const supabase = createClient();
+            // Get the property from Supabase to find orgId
+            const { data: propData } = await supabase.from('properties').select('*').eq('id', propertyId).single();
+            if (propData) {
+              await offlineStore.db.properties.put({ ...propData, _synced_at: new Date().toISOString() });
+              await offlineStore.syncProperty(propertyId, propData.org_id);
+              // Re-read property after sync
+              const freshProp = await offlineStore.db.properties.get(propertyId);
+              if (freshProp) {
+                const [itemData, typeData, fieldData] = await Promise.all([
+                  offlineStore.getItems(propertyId),
+                  offlineStore.getItemTypes(freshProp.org_id),
+                  offlineStore.getCustomFields(freshProp.org_id),
+                ]);
+                setItems(itemData);
+                setItemTypes(typeData);
+                setCustomFields(fieldData);
+              }
+            }
+            const { data: { user } } = await supabase.auth.getUser();
+            setIsAuthenticated(!!user);
+          } catch {
+            setIsAuthenticated(false);
+          }
+          setLoading(false);
+          return;
+        }
+
+        // Read from IndexedDB (cached data available)
+        const [itemData, typeData, fieldData] = await Promise.all([
+          offlineStore.getItems(propertyId),
+          orgId ? offlineStore.getItemTypes(orgId) : Promise.resolve([]),
+          orgId ? offlineStore.getCustomFields(orgId) : Promise.resolve([]),
+        ]);
+
+        setItems(itemData);
+        setItemTypes(typeData);
+        setCustomFields(fieldData);
+
+        // Check authentication via cached session
         try {
           const { createClient } = await import("@/lib/supabase/client");
           const supabase = createClient();
-          // Get the property from Supabase to find orgId
-          const { data: propData } = await supabase.from('properties').select('*').eq('id', propertyId).single();
-          if (propData) {
-            await offlineStore.db.properties.put({ ...propData, _synced_at: new Date().toISOString() });
-            await offlineStore.syncProperty(propertyId, propData.org_id);
-            // Re-read property after sync
-            const freshProp = await offlineStore.db.properties.get(propertyId);
-            if (freshProp) {
-              const [itemData, typeData, fieldData] = await Promise.all([
-                offlineStore.getItems(propertyId),
-                offlineStore.getItemTypes(freshProp.org_id),
-                offlineStore.getCustomFields(freshProp.org_id),
-              ]);
-              setItems(itemData);
-              setItemTypes(typeData);
-              setCustomFields(fieldData);
-            }
-          }
           const { data: { user } } = await supabase.auth.getUser();
           setIsAuthenticated(!!user);
         } catch {
           setIsAuthenticated(false);
         }
+
+        // Trigger background sync and refresh data when done
+        if (orgId && offlineStore.isOnline) {
+          offlineStore.syncProperty(propertyId, orgId).then(async () => {
+            const [freshItems, freshTypes, freshFields] = await Promise.all([
+              offlineStore.getItems(propertyId),
+              offlineStore.getItemTypes(orgId!),
+              offlineStore.getCustomFields(orgId!),
+            ]);
+            setItems(freshItems);
+            setItemTypes(freshTypes);
+            setCustomFields(freshFields);
+          });
+        }
+      } catch (err) {
+        console.error('Failed to load map data:', err);
+      } finally {
         setLoading(false);
-        return;
-      }
-
-      // Read from IndexedDB (cached data available)
-      const [itemData, typeData, fieldData] = await Promise.all([
-        offlineStore.getItems(propertyId),
-        orgId ? offlineStore.getItemTypes(orgId) : Promise.resolve([]),
-        orgId ? offlineStore.getCustomFields(orgId) : Promise.resolve([]),
-      ]);
-
-      setItems(itemData);
-      setItemTypes(typeData);
-      setCustomFields(fieldData);
-
-      // Check authentication via cached session
-      try {
-        const { createClient } = await import("@/lib/supabase/client");
-        const supabase = createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        setIsAuthenticated(!!user);
-      } catch {
-        setIsAuthenticated(false);
-      }
-
-      setLoading(false);
-
-      // Trigger background sync and refresh data when done
-      if (orgId && offlineStore.isOnline) {
-        offlineStore.syncProperty(propertyId, orgId).then(async () => {
-          const [freshItems, freshTypes, freshFields] = await Promise.all([
-            offlineStore.getItems(propertyId),
-            offlineStore.getItemTypes(orgId!),
-            offlineStore.getCustomFields(orgId!),
-          ]);
-          setItems(freshItems);
-          setItemTypes(freshTypes);
-          setCustomFields(freshFields);
-        });
       }
     }
 


### PR DESCRIPTION
## Summary

- Wraps `fetchData()` in both `HomeMapView` and `ListPage` with `try-catch-finally` so `setLoading(false)` always runs
- Previously, an unhandled error from IndexedDB (e.g. stale service worker serving old JS chunks causing a Dexie version conflict) would leave the loading spinner stuck indefinitely
- Confirmed: incognito works fine (no stale cache), regular browser shows permanent spinner

## Root Cause

The service worker (`CacheFirst` strategy for `/_next/static` JS) can serve stale JS chunks after a deployment. When old cached JS conflicts with the new server state, IndexedDB operations throw unhandled errors, and `setLoading(false)` never executes.

## Test plan

- [ ] Verify map loads in regular browser after clearing SW cache
- [ ] Verify list loads in regular browser after clearing SW cache
- [ ] Verify incognito still works
- [ ] Verify existing tests pass (697/697 passing)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)