### PR TITLE
fix: use StaleWhileRevalidate for Next.js static JS in service worker

### DIFF
--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -1,6 +1,6 @@
 import { defaultCache } from '@serwist/next/worker';
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist';
-import { Serwist, CacheFirst, ExpirationPlugin, NetworkFirst } from 'serwist';
+import { Serwist, CacheFirst, ExpirationPlugin, NetworkFirst, StaleWhileRevalidate } from 'serwist';
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -16,6 +16,20 @@ const serwist = new Serwist({
   clientsClaim: true,
   navigationPreload: true,
   runtimeCaching: [
+    // Override defaultCache's CacheFirst for /_next/static JS with
+    // StaleWhileRevalidate so deployments aren't blocked by stale chunks.
+    {
+      matcher: /\/_next\/static.+\.js$/i,
+      handler: new StaleWhileRevalidate({
+        cacheName: 'next-static-js-assets',
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 64,
+            maxAgeSeconds: 24 * 60 * 60,
+          }),
+        ],
+      }),
+    },
     {
       matcher: ({ url }) => {
         return (


### PR DESCRIPTION
## Summary

- Overrides serwist's default `CacheFirst` strategy for `/_next/static` JS chunks with `StaleWhileRevalidate`
- Prevents stale JS bundles from being served after deployments, which was the root cause of the loading spinner getting stuck (#185)

## Why

The default `CacheFirst` strategy serves cached JS forever (up to 24h) without checking the network. After a new deploy, returning visitors get old cached JS that can conflict with the new server state, breaking hydration. `StaleWhileRevalidate` serves the cached version instantly but revalidates in the background, so the next load always has fresh chunks.

## Test plan

- [ ] Deploy, then visit in a browser that previously cached the site
- [ ] Verify map and list load without clearing cache
- [ ] Verify map tiles still cache correctly (unchanged `CacheFirst`)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)