### PR TITLE
fix: show native OS picker instead of forcing camera on mobile

### DIFF
--- a/src/components/manage/PhotoUploader.tsx
+++ b/src/components/manage/PhotoUploader.tsx
@@ -117,7 +117,6 @@ export default function PhotoUploader({
             accept="image/*"
             maxFiles={maxFiles - previews.length}
             maxWidth={1200}
-            capture="environment"
             onFilesSelected={handleFilesSelected}
           />
         </div>

--- a/src/components/map/QuickAddSheet.tsx
+++ b/src/components/map/QuickAddSheet.tsx
@@ -191,7 +191,6 @@ export default function QuickAddSheet({ open, onClose, defaultLocation }: QuickA
                 ref={fileInputRef}
                 type="file"
                 accept="image/*"
-                capture="environment"
                 onChange={handlePhotoChange}
                 className="hidden"
               />

--- a/src/components/photos/DeviceSource.tsx
+++ b/src/components/photos/DeviceSource.tsx
@@ -6,7 +6,6 @@ import { useDropzone } from 'react-dropzone';
 interface DeviceSourceProps {
   accept: string;
   maxFiles: number;
-  capture?: string;
   multiple: boolean;
   onFilesSelected: (files: File[]) => void;
   disabled?: boolean;
@@ -24,7 +23,6 @@ function parseAccept(accept: string): Record<string, string[]> {
 export default function DeviceSource({
   accept,
   maxFiles,
-  capture,
   multiple,
   onFilesSelected,
   disabled = false,
@@ -57,7 +55,7 @@ export default function DeviceSource({
             : 'border-gray-300 hover:border-gray-400'
       }`}
     >
-      <input {...getInputProps()} capture={capture as 'user' | 'environment' | boolean | undefined} />
+      <input {...getInputProps()} />
       <p className="text-gray-600 mb-1">
         {isDragActive ? 'Drop files here' : 'Drop files here or tap to browse'}
       </p>

--- a/src/components/photos/PhotoSourcePicker.tsx
+++ b/src/components/photos/PhotoSourcePicker.tsx
@@ -9,7 +9,6 @@ interface PhotoSourcePickerProps {
   accept: string;
   maxFiles?: number;
   maxWidth?: number;
-  capture?: string;
   onFilesSelected: (files: File[]) => void;
   multiple?: boolean;
 }
@@ -20,7 +19,6 @@ export default function PhotoSourcePicker({
   accept,
   maxFiles = 5,
   maxWidth,
-  capture,
   onFilesSelected,
   multiple = true,
 }: PhotoSourcePickerProps) {
@@ -32,7 +30,6 @@ export default function PhotoSourcePicker({
       <DeviceSource
         accept={accept}
         maxFiles={maxFiles}
-        capture={capture}
         multiple={multiple}
         onFilesSelected={onFilesSelected}
       />
@@ -70,7 +67,6 @@ export default function PhotoSourcePicker({
         <DeviceSource
           accept={accept}
           maxFiles={maxFiles}
-          capture={capture}
           multiple={multiple}
           onFilesSelected={onFilesSelected}
         />


### PR DESCRIPTION
## Summary

- Removes `capture="environment"` from all photo file inputs across 4 components
- On mobile, the OS now shows its native picker with Camera, Photo Library, and Browse Files options instead of jumping straight to the camera

## Files changed

- `DeviceSource.tsx` — removed `capture` prop from interface and input element
- `PhotoSourcePicker.tsx` — removed `capture` prop pass-through
- `PhotoUploader.tsx` — removed `capture="environment"` from PhotoSourcePicker usage
- `QuickAddSheet.tsx` — removed `capture="environment"` from file input

## Test plan

- [ ] On iOS: tap photo upload → should show action sheet with Camera / Photo Library / Browse
- [ ] On Android: tap photo upload → should show chooser with Camera / Files / Gallery
- [ ] On desktop: click upload → should open file picker as before
- [ ] Verify drag-and-drop still works on desktop

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)