### PR TITLE
feat: Item Type Layout Builder

### DIFF
--- a/docs/superpowers/plans/2026-04-03-item-type-layout-builder.md
+++ b/docs/superpowers/plans/2026-04-03-item-type-layout-builder.md
@@ -1,0 +1,4793 @@
+# Item Type Layout Builder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a drag-and-drop layout builder for ItemTypes that lets non-technical admins design custom detail views with live preview, producing a JSON layout stored on the ItemType and rendered via a new multi-snap bottom sheet.
+
+**Architecture:** Layout-first type creation where the builder IS the type definition tool. A `TypeLayout` JSON (JSONB column on `item_types`) describes blocks arranged vertically or in rows. A `LayoutRenderer` interprets this JSON in both the live DetailPanel and builder preview. The existing BottomSheet is replaced with a multi-snap (peek/half/full) sheet. An auto-generated form preview derives input forms from the detail layout.
+
+**Tech Stack:** Next.js 14, Supabase PostgreSQL, Tailwind CSS, @dnd-kit/sortable (new), Framer Motion (existing), Zod (existing), Dexie (existing), Vitest + Testing Library (existing)
+
+---
+
+## File Structure
+
+### New Files
+
+```
+src/lib/layout/
+  types.ts                  — TypeLayout, LayoutNode, LayoutBlock, LayoutRow, BlockConfig interfaces
+  schemas.ts                — Zod validation for layout JSON
+  defaults.ts               — Generate default layout from custom fields
+  mock-data.ts              — Generate mock ItemWithDetails for preview
+  form-derivation.ts        — Derive form field list from detail layout
+  spacing.ts                — Spacing preset constants (gap, padding values)
+
+src/components/layout/
+  LayoutRenderer.tsx         — Iterates layout nodes, renders block components
+  BlockErrorBoundary.tsx     — Per-block error boundary
+
+  blocks/
+    FieldDisplayBlock.tsx
+    PhotoGalleryBlock.tsx
+    StatusBadgeBlock.tsx
+    EntityListBlock.tsx
+    TimelineBlock.tsx
+    TextLabelBlock.tsx
+    DividerBlock.tsx
+    MapSnippetBlock.tsx
+    ActionButtonsBlock.tsx
+    RowBlock.tsx             — Renders horizontal row of children
+
+  builder/
+    LayoutBuilder.tsx        — Main builder orchestrator (state, tabs, responsive)
+    BlockPalette.tsx         — Horizontally scrollable block type pills
+    BlockList.tsx            — Sortable block list with @dnd-kit
+    BlockListItem.tsx        — Single block row: drag handle, label, delete, accordion config
+    BlockConfigPanel.tsx     — Config UI per block type (switch on type)
+    RowEditor.tsx            — Row config: distribution, gap, add/remove children
+    PeekBoundary.tsx         — Draggable line showing peek fold
+    InlineFieldCreator.tsx   — Create custom field inline in builder
+    SpacingPicker.tsx        — Three-option compact/comfortable/spacious toggle
+
+  preview/
+    DetailPreview.tsx        — Simulated bottom sheet with peek line
+    FormPreview.tsx          — Auto-generated form from layout
+
+src/components/ui/
+  MultiSnapBottomSheet.tsx   — Three-snap-point bottom sheet (replaces BottomSheet)
+
+src/app/admin/properties/[slug]/types/
+  layout-actions.ts          — Server actions: saveTypeWithLayout, deleteLayout
+
+supabase/migrations/
+  030_item_type_layout.sql   — ALTER TABLE item_types ADD COLUMN layout JSONB
+```
+
+### Modified Files
+
+```
+src/lib/types.ts                              — Add layout field to ItemType interface
+src/lib/offline/db.ts                         — Layout included in item_types cache (no schema change needed, JSONB stored as-is)
+src/components/item/DetailPanel.tsx            — Integrate LayoutRenderer, use MultiSnapBottomSheet
+src/components/map/MapView.tsx                 — FAB repositioning when bottom sheet is in peek state
+src/app/admin/properties/[slug]/types/page.tsx — Restructure to tabs (Layout/Fields/Settings)
+src/components/manage/ItemForm.tsx             — Use form derivation for field ordering when layout exists
+package.json                                  — Add @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities, nanoid
+```
+
+---
+
+## Task 1: Database Migration + TypeScript Types
+
+**Files:**
+- Create: `supabase/migrations/030_item_type_layout.sql`
+- Create: `src/lib/layout/types.ts`
+- Modify: `src/lib/types.ts`
+- Create: `src/lib/layout/__tests__/types.test.ts`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/030_item_type_layout.sql
+-- Add layout JSONB column to item_types for custom detail panel layouts
+
+ALTER TABLE item_types
+ADD COLUMN layout jsonb DEFAULT NULL;
+
+COMMENT ON COLUMN item_types.layout IS
+  'JSON layout definition for the item detail panel. NULL = use default rendering.';
+```
+
+- [ ] **Step 2: Create layout type definitions**
+
+```typescript
+// src/lib/layout/types.ts
+
+export type SpacingPreset = 'compact' | 'comfortable' | 'spacious';
+
+export interface TypeLayout {
+  version: 1;
+  blocks: LayoutNode[];
+  spacing: SpacingPreset;
+  peekBlockCount: number;
+}
+
+export type LayoutNode = LayoutBlock | LayoutRow;
+
+export interface LayoutBlock {
+  id: string;
+  type: BlockType;
+  config: BlockConfig;
+  hideWhenEmpty?: boolean;
+}
+
+export interface LayoutRow {
+  id: string;
+  type: 'row';
+  children: LayoutBlock[];
+  gap: 'tight' | 'normal' | 'loose';
+  distribution: 'equal' | 'auto' | number[];
+}
+
+export type BlockType =
+  | 'field_display'
+  | 'photo_gallery'
+  | 'status_badge'
+  | 'entity_list'
+  | 'text_label'
+  | 'divider'
+  | 'action_buttons'
+  | 'map_snippet'
+  | 'timeline';
+
+export type BlockConfig =
+  | FieldDisplayConfig
+  | PhotoGalleryConfig
+  | StatusBadgeConfig
+  | EntityListConfig
+  | TimelineConfig
+  | TextLabelConfig
+  | DividerConfig
+  | MapSnippetConfig
+  | ActionButtonsConfig;
+
+export interface FieldDisplayConfig {
+  fieldId: string;
+  size: 'compact' | 'normal' | 'large';
+  showLabel: boolean;
+}
+
+export interface PhotoGalleryConfig {
+  style: 'hero' | 'grid' | 'carousel';
+  maxPhotos: number;
+}
+
+export interface StatusBadgeConfig {}
+
+export interface EntityListConfig {
+  entityTypeIds: string[];
+}
+
+export interface TimelineConfig {
+  showUpdates: boolean;
+  showScheduled: boolean;
+  maxItems: number;
+}
+
+export interface TextLabelConfig {
+  text: string;
+  style: 'heading' | 'subheading' | 'body' | 'caption';
+}
+
+export interface DividerConfig {}
+
+export interface MapSnippetConfig {}
+
+export interface ActionButtonsConfig {}
+
+// Type guard helpers
+export function isLayoutRow(node: LayoutNode): node is LayoutRow {
+  return node.type === 'row';
+}
+
+export function isLayoutBlock(node: LayoutNode): node is LayoutBlock {
+  return node.type !== 'row';
+}
+```
+
+- [ ] **Step 3: Add layout to ItemType interface**
+
+In `src/lib/types.ts`, add the `layout` field to `ItemType`:
+
+```typescript
+// Add import at top
+import type { TypeLayout } from '@/lib/layout/types';
+
+// Add to ItemType interface (after sort_order field):
+  layout: TypeLayout | null;
+```
+
+- [ ] **Step 4: Write type guard tests**
+
+```typescript
+// src/lib/layout/__tests__/types.test.ts
+import { describe, it, expect } from 'vitest';
+import { isLayoutRow, isLayoutBlock } from '../types';
+import type { LayoutBlock, LayoutRow } from '../types';
+
+describe('layout type guards', () => {
+  const block: LayoutBlock = {
+    id: 'b1',
+    type: 'status_badge',
+    config: {},
+  };
+
+  const row: LayoutRow = {
+    id: 'r1',
+    type: 'row',
+    children: [block],
+    gap: 'normal',
+    distribution: 'equal',
+  };
+
+  it('isLayoutRow returns true for rows', () => {
+    expect(isLayoutRow(row)).toBe(true);
+  });
+
+  it('isLayoutRow returns false for blocks', () => {
+    expect(isLayoutRow(block)).toBe(false);
+  });
+
+  it('isLayoutBlock returns true for blocks', () => {
+    expect(isLayoutBlock(block)).toBe(true);
+  });
+
+  it('isLayoutBlock returns false for rows', () => {
+    expect(isLayoutBlock(row)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/types.test.ts`
+Expected: PASS — 4 tests pass
+
+- [ ] **Step 6: Apply migration**
+
+Run: `cd /Users/patrick/birdhousemapper && npx supabase db push` (or appropriate migration command for local dev)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add supabase/migrations/030_item_type_layout.sql src/lib/layout/types.ts src/lib/types.ts src/lib/layout/__tests__/types.test.ts
+git commit -m "feat: add layout JSONB column and TypeScript types for item type layouts"
+```
+
+---
+
+## Task 2: Zod Validation Schemas
+
+**Files:**
+- Create: `src/lib/layout/schemas.ts`
+- Create: `src/lib/layout/__tests__/schemas.test.ts`
+
+- [ ] **Step 1: Write failing tests for schema validation**
+
+```typescript
+// src/lib/layout/__tests__/schemas.test.ts
+import { describe, it, expect } from 'vitest';
+import { typeLayoutSchema } from '../schemas';
+
+describe('typeLayoutSchema', () => {
+  it('accepts a valid layout with blocks', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 4 } },
+        {
+          id: 'b3',
+          type: 'field_display',
+          config: { fieldId: 'f1', size: 'normal', showLabel: true },
+          hideWhenEmpty: true,
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a layout with a row', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'compact', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'compact', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'compact',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts row with number[] distribution', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'status_badge', config: {} },
+            { id: 'b2', type: 'text_label', config: { text: 'Hello', style: 'heading' } },
+          ],
+          gap: 'tight',
+          distribution: [2, 1],
+        },
+      ],
+      spacing: 'spacious',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty blocks array', () => {
+    const layout = {
+      version: 1,
+      blocks: [],
+      spacing: 'comfortable',
+      peekBlockCount: 0,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid block type', () => {
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'unknown_block', config: {} }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects row with fewer than 2 children', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [{ id: 'b1', type: 'status_badge', config: {} }],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects row with more than 4 children', () => {
+    const children = Array.from({ length: 5 }, (_, i) => ({
+      id: `b${i}`,
+      type: 'status_badge' as const,
+      config: {},
+    }));
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'r1', type: 'row', children, gap: 'normal', distribution: 'equal' }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects maxPhotos outside 1-20', () => {
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 25 } }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid spacing preset', () => {
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'divider', config: {} }],
+      spacing: 'extra-wide',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults to version 1', () => {
+    const layout = {
+      blocks: [{ id: 'b1', type: 'divider', config: {} }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe(1);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/schemas.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the Zod schemas**
+
+```typescript
+// src/lib/layout/schemas.ts
+import { z } from 'zod';
+
+// Block config schemas
+const fieldDisplayConfigSchema = z.object({
+  fieldId: z.string().min(1),
+  size: z.enum(['compact', 'normal', 'large']),
+  showLabel: z.boolean(),
+});
+
+const photoGalleryConfigSchema = z.object({
+  style: z.enum(['hero', 'grid', 'carousel']),
+  maxPhotos: z.number().int().min(1).max(20),
+});
+
+const statusBadgeConfigSchema = z.object({});
+
+const entityListConfigSchema = z.object({
+  entityTypeIds: z.array(z.string()),
+});
+
+const timelineConfigSchema = z.object({
+  showUpdates: z.boolean(),
+  showScheduled: z.boolean(),
+  maxItems: z.number().int().min(1).max(50),
+});
+
+const textLabelConfigSchema = z.object({
+  text: z.string(),
+  style: z.enum(['heading', 'subheading', 'body', 'caption']),
+});
+
+const emptyConfigSchema = z.object({});
+
+// Block type enum
+const blockTypeSchema = z.enum([
+  'field_display',
+  'photo_gallery',
+  'status_badge',
+  'entity_list',
+  'text_label',
+  'divider',
+  'action_buttons',
+  'map_snippet',
+  'timeline',
+]);
+
+// Discriminated block schemas
+const fieldDisplayBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('field_display'),
+  config: fieldDisplayConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const photoGalleryBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('photo_gallery'),
+  config: photoGalleryConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const statusBadgeBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('status_badge'),
+  config: statusBadgeConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const entityListBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('entity_list'),
+  config: entityListConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const textLabelBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('text_label'),
+  config: textLabelConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const timelineBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('timeline'),
+  config: timelineConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const dividerBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('divider'),
+  config: emptyConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const actionButtonsBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('action_buttons'),
+  config: emptyConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const mapSnippetBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('map_snippet'),
+  config: emptyConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+export const layoutBlockSchema = z.discriminatedUnion('type', [
+  fieldDisplayBlockSchema,
+  photoGalleryBlockSchema,
+  statusBadgeBlockSchema,
+  entityListBlockSchema,
+  textLabelBlockSchema,
+  timelineBlockSchema,
+  dividerBlockSchema,
+  actionButtonsBlockSchema,
+  mapSnippetBlockSchema,
+]);
+
+const layoutRowSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('row'),
+  children: z.array(layoutBlockSchema).min(2).max(4),
+  gap: z.enum(['tight', 'normal', 'loose']),
+  distribution: z.union([
+    z.enum(['equal', 'auto']),
+    z.array(z.number().positive()),
+  ]),
+});
+
+export const layoutNodeSchema = z.union([layoutBlockSchema, layoutRowSchema]);
+
+export const typeLayoutSchema = z.object({
+  version: z.literal(1).default(1),
+  blocks: z.array(layoutNodeSchema).min(1),
+  spacing: z.enum(['compact', 'comfortable', 'spacious']),
+  peekBlockCount: z.number().int().min(0).max(10),
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/schemas.test.ts`
+Expected: PASS — all 9 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/layout/schemas.ts src/lib/layout/__tests__/schemas.test.ts
+git commit -m "feat: add Zod validation schemas for layout JSON"
+```
+
+---
+
+## Task 3: Install Dependencies
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install @dnd-kit packages and nanoid**
+
+Run: `cd /Users/patrick/birdhousemapper && npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities nanoid`
+
+- [ ] **Step 2: Verify installation**
+
+Run: `cd /Users/patrick/birdhousemapper && node -e "require('@dnd-kit/core'); require('@dnd-kit/sortable'); require('nanoid'); console.log('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities, nanoid"
+```
+
+---
+
+## Task 4: Spacing Constants + Default Layout Generation
+
+**Files:**
+- Create: `src/lib/layout/spacing.ts`
+- Create: `src/lib/layout/defaults.ts`
+- Create: `src/lib/layout/__tests__/defaults.test.ts`
+
+- [ ] **Step 1: Create spacing constants**
+
+```typescript
+// src/lib/layout/spacing.ts
+import type { SpacingPreset } from './types';
+
+export const SPACING = {
+  compact: { blockGap: 8, rowGap: 8, sectionPadding: 12 },
+  comfortable: { blockGap: 12, rowGap: 12, sectionPadding: 16 },
+  spacious: { blockGap: 16, rowGap: 16, sectionPadding: 20 },
+} as const satisfies Record<SpacingPreset, { blockGap: number; rowGap: number; sectionPadding: number }>;
+
+/** Width below which rows collapse to vertical stacking */
+export const ROW_COLLAPSE_BREAKPOINT = 480;
+```
+
+- [ ] **Step 2: Write failing tests for default layout generation**
+
+```typescript
+// src/lib/layout/__tests__/defaults.test.ts
+import { describe, it, expect } from 'vitest';
+import { generateDefaultLayout } from '../defaults';
+import type { CustomField } from '@/lib/types';
+
+describe('generateDefaultLayout', () => {
+  it('generates starter layout with no custom fields', () => {
+    const layout = generateDefaultLayout([]);
+    expect(layout.version).toBe(1);
+    expect(layout.spacing).toBe('comfortable');
+    expect(layout.peekBlockCount).toBe(2);
+    expect(layout.blocks).toHaveLength(3);
+    expect(layout.blocks[0].type).toBe('status_badge');
+    expect(layout.blocks[1].type).toBe('photo_gallery');
+    expect(layout.blocks[2].type).toBe('action_buttons');
+  });
+
+  it('inserts field_display blocks for each custom field', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin'], required: true, sort_order: 0, org_id: 'o1' },
+      { id: 'f2', item_type_id: 't1', name: 'Install Date', field_type: 'date', options: null, required: false, sort_order: 1, org_id: 'o1' },
+    ];
+    const layout = generateDefaultLayout(fields);
+    // Status Badge, Photo Gallery, Field(Species), Field(Install Date), Action Buttons
+    expect(layout.blocks).toHaveLength(5);
+    expect(layout.blocks[2].type).toBe('field_display');
+    expect(layout.blocks[3].type).toBe('field_display');
+    const config0 = layout.blocks[2].config as { fieldId: string };
+    const config1 = layout.blocks[3].config as { fieldId: string };
+    expect(config0.fieldId).toBe('f1');
+    expect(config1.fieldId).toBe('f2');
+  });
+
+  it('sorts fields by sort_order', () => {
+    const fields: CustomField[] = [
+      { id: 'f2', item_type_id: 't1', name: 'B', field_type: 'text', options: null, required: false, sort_order: 2, org_id: 'o1' },
+      { id: 'f1', item_type_id: 't1', name: 'A', field_type: 'text', options: null, required: false, sort_order: 1, org_id: 'o1' },
+    ];
+    const layout = generateDefaultLayout(fields);
+    const config0 = layout.blocks[2].config as { fieldId: string };
+    const config1 = layout.blocks[3].config as { fieldId: string };
+    expect(config0.fieldId).toBe('f1');
+    expect(config1.fieldId).toBe('f2');
+  });
+
+  it('generates unique IDs for all blocks', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'A', field_type: 'text', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const layout = generateDefaultLayout(fields);
+    const ids = layout.blocks.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/defaults.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: Implement default layout generation**
+
+```typescript
+// src/lib/layout/defaults.ts
+import { nanoid } from 'nanoid';
+import type { TypeLayout, LayoutBlock } from './types';
+import type { CustomField } from '@/lib/types';
+
+export function generateDefaultLayout(customFields: CustomField[]): TypeLayout {
+  const sorted = [...customFields].sort((a, b) => a.sort_order - b.sort_order);
+
+  const fieldBlocks: LayoutBlock[] = sorted.map((field) => ({
+    id: nanoid(10),
+    type: 'field_display',
+    config: { fieldId: field.id, size: 'normal' as const, showLabel: true },
+  }));
+
+  return {
+    version: 1,
+    spacing: 'comfortable',
+    peekBlockCount: 2,
+    blocks: [
+      { id: nanoid(10), type: 'status_badge', config: {} },
+      { id: nanoid(10), type: 'photo_gallery', config: { style: 'hero' as const, maxPhotos: 4 } },
+      ...fieldBlocks,
+      { id: nanoid(10), type: 'action_buttons', config: {} },
+    ],
+  };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/defaults.test.ts`
+Expected: PASS — all 4 tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/layout/spacing.ts src/lib/layout/defaults.ts src/lib/layout/__tests__/defaults.test.ts
+git commit -m "feat: add spacing constants and default layout generation"
+```
+
+---
+
+## Task 5: Mock Data Generation
+
+**Files:**
+- Create: `src/lib/layout/mock-data.ts`
+- Create: `src/lib/layout/__tests__/mock-data.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/lib/layout/__tests__/mock-data.test.ts
+import { describe, it, expect } from 'vitest';
+import { generateMockItem } from '../mock-data';
+import type { CustomField, ItemType } from '@/lib/types';
+
+describe('generateMockItem', () => {
+  const itemType: ItemType = {
+    id: 't1',
+    name: 'Bird Box',
+    icon: '🏠',
+    color: '#5D7F3A',
+    sort_order: 0,
+    created_at: '2026-01-01',
+    org_id: 'o1',
+    layout: null,
+  };
+
+  it('generates a mock item with correct type info', () => {
+    const mock = generateMockItem(itemType, []);
+    expect(mock.name).toBe('Sample Bird Box');
+    expect(mock.item_type_id).toBe('t1');
+    expect(mock.status).toBe('active');
+    expect(mock.latitude).toBeTypeOf('number');
+    expect(mock.longitude).toBeTypeOf('number');
+  });
+
+  it('generates mock values for text fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Notes', field_type: 'text', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe('Sample text');
+  });
+
+  it('generates mock values for number fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Count', field_type: 'number', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe(42);
+  });
+
+  it('generates first option for dropdown fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin', 'Wren'], required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe('Robin');
+  });
+
+  it('generates today for date fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Installed', field_type: 'date', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe(new Date().toISOString().split('T')[0]);
+  });
+
+  it('includes mock photos', () => {
+    const mock = generateMockItem(itemType, []);
+    expect(mock.photos.length).toBeGreaterThan(0);
+  });
+
+  it('includes mock updates', () => {
+    const mock = generateMockItem(itemType, []);
+    expect(mock.updates.length).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/mock-data.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement mock data generation**
+
+```typescript
+// src/lib/layout/mock-data.ts
+import type { ItemWithDetails, CustomField, ItemType } from '@/lib/types';
+
+function mockFieldValue(field: CustomField): unknown {
+  switch (field.field_type) {
+    case 'text':
+      return 'Sample text';
+    case 'number':
+      return 42;
+    case 'dropdown':
+      return field.options?.[0] ?? 'Option A';
+    case 'date':
+      return new Date().toISOString().split('T')[0];
+    default:
+      return 'Sample value';
+  }
+}
+
+export function generateMockItem(
+  itemType: ItemType,
+  customFields: CustomField[],
+): ItemWithDetails {
+  const now = new Date().toISOString();
+  const today = now.split('T')[0];
+
+  const custom_field_values: Record<string, unknown> = {};
+  for (const field of customFields) {
+    custom_field_values[field.id] = mockFieldValue(field);
+  }
+
+  return {
+    id: 'mock-item',
+    name: `Sample ${itemType.name}`,
+    description: 'This is a preview with sample data.',
+    latitude: 51.5074,
+    longitude: -0.1278,
+    item_type_id: itemType.id,
+    status: 'active',
+    custom_field_values,
+    created_at: now,
+    updated_at: now,
+    created_by: 'mock-user',
+    org_id: itemType.org_id,
+    property_id: 'mock-property',
+    item_type: itemType,
+    custom_fields: customFields,
+    entities: [
+      {
+        id: 'mock-entity-1',
+        entity_type_id: 'mock-et',
+        org_id: itemType.org_id,
+        name: 'Sample Entity',
+        description: null,
+        photo_path: null,
+        external_link: null,
+        custom_field_values: {},
+        sort_order: 0,
+        created_at: now,
+        updated_at: now,
+        entity_type: { id: 'mock-et', org_id: itemType.org_id, name: 'Category', icon: '🏷', color: '#888', link_to: ['items'], sort_order: 0, created_at: now, updated_at: now },
+      },
+    ],
+    photos: [
+      { id: 'mock-photo-1', item_id: 'mock-item', update_id: null, storage_path: '', url: '/placeholder-photo.jpg', created_at: now, org_id: itemType.org_id },
+    ],
+    updates: [
+      {
+        id: 'mock-update-1',
+        item_id: 'mock-item',
+        update_type_id: 'mock-ut',
+        content: 'Initial installation completed',
+        update_date: today,
+        custom_field_values: {},
+        created_at: now,
+        updated_at: now,
+        created_by: 'mock-user',
+        org_id: itemType.org_id,
+        update_type: { id: 'mock-ut', name: 'Maintenance', icon: '🔧', is_global: true, item_type_id: null, sort_order: 0, org_id: itemType.org_id },
+        photos: [],
+        entities: [],
+      },
+      {
+        id: 'mock-update-2',
+        item_id: 'mock-item',
+        update_type_id: 'mock-ut',
+        content: 'Routine inspection passed',
+        update_date: new Date(Date.now() - 7 * 86400000).toISOString().split('T')[0],
+        custom_field_values: {},
+        created_at: new Date(Date.now() - 7 * 86400000).toISOString(),
+        updated_at: new Date(Date.now() - 7 * 86400000).toISOString(),
+        created_by: 'mock-user',
+        org_id: itemType.org_id,
+        update_type: { id: 'mock-ut', name: 'Inspection', icon: '🔍', is_global: true, item_type_id: null, sort_order: 1, org_id: itemType.org_id },
+        photos: [],
+        entities: [],
+      },
+      {
+        id: 'mock-update-3',
+        item_id: 'mock-item',
+        update_type_id: 'mock-ut',
+        content: 'First occupancy observed',
+        update_date: new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0],
+        custom_field_values: {},
+        created_at: new Date(Date.now() - 30 * 86400000).toISOString(),
+        updated_at: new Date(Date.now() - 30 * 86400000).toISOString(),
+        created_by: 'mock-user',
+        org_id: itemType.org_id,
+        update_type: { id: 'mock-ut', name: 'Observation', icon: '👁', is_global: true, item_type_id: null, sort_order: 2, org_id: itemType.org_id },
+        photos: [],
+        entities: [],
+      },
+    ],
+  };
+}
+```
+
+Note: The exact shape of `ItemWithDetails` may need adjustment based on the current type definition. Check `src/lib/types.ts` for the exact fields and adjust the mock accordingly. The mock must satisfy the same interface the real DetailPanel uses.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/mock-data.test.ts`
+Expected: PASS — all 7 tests pass. If type mismatches occur, adjust the mock to match `ItemWithDetails`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/layout/mock-data.ts src/lib/layout/__tests__/mock-data.test.ts
+git commit -m "feat: add mock data generation for layout preview"
+```
+
+---
+
+## Task 6: Block Components
+
+**Files:**
+- Create: `src/components/layout/BlockErrorBoundary.tsx`
+- Create: `src/components/layout/blocks/StatusBadgeBlock.tsx`
+- Create: `src/components/layout/blocks/FieldDisplayBlock.tsx`
+- Create: `src/components/layout/blocks/PhotoGalleryBlock.tsx`
+- Create: `src/components/layout/blocks/TextLabelBlock.tsx`
+- Create: `src/components/layout/blocks/DividerBlock.tsx`
+- Create: `src/components/layout/blocks/ActionButtonsBlock.tsx`
+- Create: `src/components/layout/blocks/MapSnippetBlock.tsx`
+- Create: `src/components/layout/blocks/EntityListBlock.tsx`
+- Create: `src/components/layout/blocks/TimelineBlock.tsx`
+- Create: `src/components/layout/blocks/RowBlock.tsx`
+- Create: `src/components/layout/blocks/__tests__/blocks.test.tsx`
+
+This task creates all 9 block components + the row container + error boundary. Each block is a focused presentational component.
+
+- [ ] **Step 1: Create BlockErrorBoundary**
+
+```tsx
+// src/components/layout/BlockErrorBoundary.tsx
+'use client';
+
+import { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  blockType: string;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class BlockErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn(`Layout block "${this.props.blockType}" crashed:`, error.message);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="text-xs text-sage italic py-2">
+          Unable to display this block
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+```
+
+- [ ] **Step 2: Create StatusBadgeBlock**
+
+```tsx
+// src/components/layout/blocks/StatusBadgeBlock.tsx
+import StatusBadge from '@/components/item/StatusBadge';
+import type { ItemStatus } from '@/lib/types';
+
+interface Props {
+  status: ItemStatus;
+}
+
+export default function StatusBadgeBlock({ status }: Props) {
+  return (
+    <div className="flex items-center">
+      <StatusBadge status={status} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create FieldDisplayBlock**
+
+```tsx
+// src/components/layout/blocks/FieldDisplayBlock.tsx
+import type { FieldDisplayConfig } from '@/lib/layout/types';
+import type { CustomField } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+interface Props {
+  config: FieldDisplayConfig;
+  field: CustomField | undefined;
+  value: unknown;
+}
+
+const sizeClasses = {
+  compact: 'text-sm',
+  normal: 'text-sm',
+  large: 'text-xl font-semibold leading-tight',
+} as const;
+
+export default function FieldDisplayBlock({ config, field, value }: Props) {
+  if (!field) return null;
+
+  const displayValue =
+    field.field_type === 'date' && value
+      ? formatDate(String(value))
+      : value != null
+        ? String(value)
+        : '—';
+
+  return (
+    <div>
+      {config.showLabel && (
+        <span className="text-xs font-medium text-sage uppercase tracking-wide">
+          {field.name}
+        </span>
+      )}
+      <p className={`text-forest-dark font-medium ${sizeClasses[config.size]}`}>
+        {displayValue}
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create PhotoGalleryBlock**
+
+```tsx
+// src/components/layout/blocks/PhotoGalleryBlock.tsx
+import PhotoViewer from '@/components/ui/PhotoViewer';
+import type { PhotoGalleryConfig } from '@/lib/layout/types';
+import type { Photo } from '@/lib/types';
+
+interface Props {
+  config: PhotoGalleryConfig;
+  photos: Photo[];
+  isEdgeToEdge?: boolean;
+}
+
+export default function PhotoGalleryBlock({ config, photos, isEdgeToEdge }: Props) {
+  if (photos.length === 0) return null;
+
+  const limited = photos.slice(0, config.maxPhotos);
+
+  return (
+    <div className={isEdgeToEdge ? '-mx-4' : ''}>
+      <PhotoViewer photos={limited} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Create TextLabelBlock**
+
+```tsx
+// src/components/layout/blocks/TextLabelBlock.tsx
+import type { TextLabelConfig } from '@/lib/layout/types';
+
+interface Props {
+  config: TextLabelConfig;
+}
+
+const styleClasses = {
+  heading: 'text-lg font-semibold text-forest-dark leading-snug',
+  subheading: 'text-[15px] font-medium text-forest-dark leading-snug',
+  body: 'text-sm text-forest-dark/80 leading-relaxed',
+  caption: 'text-xs text-sage leading-snug',
+} as const;
+
+export default function TextLabelBlock({ config }: Props) {
+  return <p className={styleClasses[config.style]}>{config.text}</p>;
+}
+```
+
+- [ ] **Step 6: Create DividerBlock**
+
+```tsx
+// src/components/layout/blocks/DividerBlock.tsx
+export default function DividerBlock() {
+  return <hr className="border-sage-light" />;
+}
+```
+
+- [ ] **Step 7: Create ActionButtonsBlock**
+
+```tsx
+// src/components/layout/blocks/ActionButtonsBlock.tsx
+import Link from 'next/link';
+
+interface Props {
+  itemId: string;
+  canEdit: boolean;
+  canAddUpdate: boolean;
+  mode: 'live' | 'preview';
+}
+
+export default function ActionButtonsBlock({ itemId, canEdit, canAddUpdate, mode }: Props) {
+  if (mode === 'preview') {
+    return (
+      <div className="flex gap-2">
+        <span className="btn-primary text-sm flex-1 text-center opacity-60 cursor-default">Edit Item</span>
+        <span className="btn-secondary text-sm flex-1 text-center opacity-60 cursor-default">Add Update</span>
+      </div>
+    );
+  }
+
+  if (!canEdit && !canAddUpdate) return null;
+
+  return (
+    <div className="flex gap-2">
+      {canEdit && (
+        <Link href={`/manage/edit/${itemId}`} className="btn-primary text-sm flex-1 text-center">
+          Edit Item
+        </Link>
+      )}
+      {canAddUpdate && (
+        <Link href={`/manage/update?item=${itemId}`} className="btn-secondary text-sm flex-1 text-center">
+          Add Update
+        </Link>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Create MapSnippetBlock**
+
+```tsx
+// src/components/layout/blocks/MapSnippetBlock.tsx
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const MapContainer = dynamic(
+  () => import('react-leaflet').then((m) => m.MapContainer),
+  { ssr: false },
+);
+const TileLayer = dynamic(
+  () => import('react-leaflet').then((m) => m.TileLayer),
+  { ssr: false },
+);
+const Marker = dynamic(
+  () => import('react-leaflet').then((m) => m.Marker),
+  { ssr: false },
+);
+
+interface Props {
+  latitude: number;
+  longitude: number;
+  context: 'bottom-sheet' | 'side-panel' | 'preview';
+}
+
+export default function MapSnippetBlock({ latitude, longitude, context }: Props) {
+  // Hidden on mobile (map visible behind bottom sheet)
+  if (context === 'bottom-sheet') return null;
+
+  return (
+    <div className="h-32 rounded-lg overflow-hidden border border-sage-light">
+      <MapContainer
+        center={[latitude, longitude]}
+        zoom={15}
+        className="w-full h-full"
+        zoomControl={false}
+        dragging={false}
+        scrollWheelZoom={false}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <Marker position={[latitude, longitude]} />
+      </MapContainer>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9: Create EntityListBlock**
+
+```tsx
+// src/components/layout/blocks/EntityListBlock.tsx
+import type { EntityListConfig } from '@/lib/layout/types';
+
+interface EntityDisplay {
+  id: string;
+  name: string;
+  entity_type: { id: string; name: string; icon: string };
+}
+
+interface Props {
+  config: EntityListConfig;
+  entities: EntityDisplay[];
+}
+
+export default function EntityListBlock({ config, entities }: Props) {
+  const filtered =
+    config.entityTypeIds.length > 0
+      ? entities.filter((e) => config.entityTypeIds.includes(e.entity_type.id))
+      : entities;
+
+  if (filtered.length === 0) return null;
+
+  // Group by entity type
+  const grouped = new Map<string, { type: { name: string; icon: string }; items: EntityDisplay[] }>();
+  for (const e of filtered) {
+    const key = e.entity_type.id;
+    if (!grouped.has(key)) grouped.set(key, { type: e.entity_type, items: [] });
+    grouped.get(key)!.items.push(e);
+  }
+
+  return (
+    <div className="space-y-2">
+      {Array.from(grouped.values()).map(({ type, items }) => (
+        <div key={type.name}>
+          <span className="text-xs font-medium text-sage uppercase tracking-wide">
+            {type.icon} {type.name}
+          </span>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {items.map((e) => (
+              <span
+                key={e.id}
+                className="inline-flex items-center gap-1 bg-forest/10 text-forest-dark text-xs px-2 py-1 rounded-full"
+              >
+                {e.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 10: Create TimelineBlock**
+
+```tsx
+// src/components/layout/blocks/TimelineBlock.tsx
+import type { TimelineConfig } from '@/lib/layout/types';
+import UpdateTimeline from '@/components/item/UpdateTimeline';
+import type { ItemUpdate } from '@/lib/types';
+
+interface Props {
+  config: TimelineConfig;
+  updates: ItemUpdate[];
+}
+
+export default function TimelineBlock({ config, updates }: Props) {
+  const filtered = config.showUpdates ? updates : [];
+  const limited = filtered.slice(0, config.maxItems);
+
+  if (limited.length === 0) {
+    return <p className="text-xs text-sage italic">No activity yet</p>;
+  }
+
+  return (
+    <div>
+      <h3 className="text-xs font-medium text-sage uppercase tracking-wide mb-3">
+        Updates
+      </h3>
+      <UpdateTimeline updates={limited} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 11: Create RowBlock**
+
+```tsx
+// src/components/layout/blocks/RowBlock.tsx
+'use client';
+
+import type { LayoutRow } from '@/lib/layout/types';
+import { ROW_COLLAPSE_BREAKPOINT } from '@/lib/layout/spacing';
+import type { ReactNode } from 'react';
+
+interface Props {
+  row: LayoutRow;
+  children: ReactNode[];
+  containerWidth?: number;
+}
+
+const gapClasses = {
+  tight: 'gap-2',
+  normal: 'gap-3',
+  loose: 'gap-4',
+} as const;
+
+function getGridCols(distribution: LayoutRow['distribution'], count: number): string {
+  if (distribution === 'equal') {
+    return `repeat(${count}, 1fr)`;
+  }
+  if (distribution === 'auto') {
+    return `repeat(${count}, auto)`;
+  }
+  // number[] ratios
+  return distribution.map((r) => `${r}fr`).join(' ');
+}
+
+export default function RowBlock({ row, children, containerWidth }: Props) {
+  const shouldCollapse = containerWidth != null && containerWidth < ROW_COLLAPSE_BREAKPOINT;
+
+  if (shouldCollapse) {
+    return <div className="flex flex-col gap-2">{children}</div>;
+  }
+
+  return (
+    <div
+      className={`grid ${gapClasses[row.gap]}`}
+      style={{ gridTemplateColumns: getGridCols(row.distribution, row.children.length) }}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 12: Write block component tests**
+
+```tsx
+// src/components/layout/blocks/__tests__/blocks.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatusBadgeBlock from '../StatusBadgeBlock';
+import FieldDisplayBlock from '../FieldDisplayBlock';
+import TextLabelBlock from '../TextLabelBlock';
+import DividerBlock from '../DividerBlock';
+import EntityListBlock from '../EntityListBlock';
+import TimelineBlock from '../TimelineBlock';
+
+// Mock StatusBadge since it's an existing component
+vi.mock('@/components/item/StatusBadge', () => ({
+  default: ({ status }: { status: string }) => <span data-testid="status-badge">{status}</span>,
+}));
+
+vi.mock('@/components/item/UpdateTimeline', () => ({
+  default: ({ updates }: { updates: unknown[] }) => <div data-testid="timeline">{updates.length} updates</div>,
+}));
+
+vi.mock('@/lib/utils', () => ({
+  formatDate: (d: string) => d,
+}));
+
+describe('StatusBadgeBlock', () => {
+  it('renders the status', () => {
+    render(<StatusBadgeBlock status="active" />);
+    expect(screen.getByTestId('status-badge')).toHaveTextContent('active');
+  });
+});
+
+describe('FieldDisplayBlock', () => {
+  const field = { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'text' as const, options: null, required: false, sort_order: 0, org_id: 'o1' };
+
+  it('renders field label and value', () => {
+    render(<FieldDisplayBlock config={{ fieldId: 'f1', size: 'normal', showLabel: true }} field={field} value="Robin" />);
+    expect(screen.getByText('Species')).toBeInTheDocument();
+    expect(screen.getByText('Robin')).toBeInTheDocument();
+  });
+
+  it('hides label when showLabel is false', () => {
+    render(<FieldDisplayBlock config={{ fieldId: 'f1', size: 'normal', showLabel: false }} field={field} value="Robin" />);
+    expect(screen.queryByText('Species')).not.toBeInTheDocument();
+    expect(screen.getByText('Robin')).toBeInTheDocument();
+  });
+
+  it('shows dash for null value', () => {
+    render(<FieldDisplayBlock config={{ fieldId: 'f1', size: 'normal', showLabel: true }} field={field} value={null} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('returns null for undefined field', () => {
+    const { container } = render(<FieldDisplayBlock config={{ fieldId: 'f1', size: 'normal', showLabel: true }} field={undefined} value="x" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('applies large size class', () => {
+    render(<FieldDisplayBlock config={{ fieldId: 'f1', size: 'large', showLabel: true }} field={field} value="Big" />);
+    const el = screen.getByText('Big');
+    expect(el.className).toContain('text-xl');
+  });
+});
+
+describe('TextLabelBlock', () => {
+  it('renders heading text', () => {
+    render(<TextLabelBlock config={{ text: 'Section Title', style: 'heading' }} />);
+    const el = screen.getByText('Section Title');
+    expect(el.className).toContain('text-lg');
+    expect(el.className).toContain('font-semibold');
+  });
+
+  it('renders caption text', () => {
+    render(<TextLabelBlock config={{ text: 'Note', style: 'caption' }} />);
+    const el = screen.getByText('Note');
+    expect(el.className).toContain('text-xs');
+  });
+});
+
+describe('DividerBlock', () => {
+  it('renders an hr element', () => {
+    const { container } = render(<DividerBlock />);
+    expect(container.querySelector('hr')).toBeInTheDocument();
+  });
+});
+
+describe('EntityListBlock', () => {
+  const entities = [
+    { id: 'e1', name: 'Robin', entity_type: { id: 'et1', name: 'Species', icon: '🐦' } },
+    { id: 'e2', name: 'Wren', entity_type: { id: 'et1', name: 'Species', icon: '🐦' } },
+  ];
+
+  it('renders grouped entities', () => {
+    render(<EntityListBlock config={{ entityTypeIds: [] }} entities={entities} />);
+    expect(screen.getByText('Robin')).toBeInTheDocument();
+    expect(screen.getByText('Wren')).toBeInTheDocument();
+  });
+
+  it('filters by entity type IDs', () => {
+    render(<EntityListBlock config={{ entityTypeIds: ['et2'] }} entities={entities} />);
+    expect(screen.queryByText('Robin')).not.toBeInTheDocument();
+  });
+
+  it('returns null when no entities match', () => {
+    const { container } = render(<EntityListBlock config={{ entityTypeIds: ['et99'] }} entities={entities} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('TimelineBlock', () => {
+  const updates = [
+    { id: 'u1', item_id: 'i1', update_type_id: 'ut1', content: 'test', update_date: '2026-01-01', custom_field_values: {}, created_at: '', updated_at: '', created_by: '', org_id: '', update_type: { id: 'ut1', name: 'Note', icon: '📝', is_global: true, item_type_id: null, sort_order: 0, org_id: '' }, photos: [], entities: [] },
+  ];
+
+  it('renders updates when showUpdates is true', () => {
+    render(<TimelineBlock config={{ showUpdates: true, showScheduled: false, maxItems: 10 }} updates={updates} />);
+    expect(screen.getByTestId('timeline')).toHaveTextContent('1 updates');
+  });
+
+  it('shows empty message when no updates', () => {
+    render(<TimelineBlock config={{ showUpdates: true, showScheduled: false, maxItems: 10 }} updates={[]} />);
+    expect(screen.getByText('No activity yet')).toBeInTheDocument();
+  });
+
+  it('limits to maxItems', () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({ ...updates[0], id: `u${i}` }));
+    render(<TimelineBlock config={{ showUpdates: true, showScheduled: false, maxItems: 2 }} updates={many} />);
+    expect(screen.getByTestId('timeline')).toHaveTextContent('2 updates');
+  });
+});
+```
+
+- [ ] **Step 13: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/components/layout/blocks/__tests__/blocks.test.tsx`
+Expected: PASS — all tests pass
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/components/layout/
+git commit -m "feat: add all layout block components with error boundary and tests"
+```
+
+---
+
+## Task 7: LayoutRenderer
+
+**Files:**
+- Create: `src/components/layout/LayoutRenderer.tsx`
+- Create: `src/components/layout/__tests__/LayoutRenderer.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+// src/components/layout/__tests__/LayoutRenderer.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LayoutRenderer from '../LayoutRenderer';
+import type { TypeLayout } from '@/lib/layout/types';
+import type { ItemWithDetails, CustomField } from '@/lib/types';
+
+// Mock all block components
+vi.mock('../blocks/StatusBadgeBlock', () => ({
+  default: () => <div data-testid="block-status_badge" />,
+}));
+vi.mock('../blocks/FieldDisplayBlock', () => ({
+  default: ({ field }: { field?: { name: string } }) => (
+    <div data-testid="block-field_display">{field?.name}</div>
+  ),
+}));
+vi.mock('../blocks/PhotoGalleryBlock', () => ({
+  default: () => <div data-testid="block-photo_gallery" />,
+}));
+vi.mock('../blocks/TextLabelBlock', () => ({
+  default: ({ config }: { config: { text: string } }) => (
+    <div data-testid="block-text_label">{config.text}</div>
+  ),
+}));
+vi.mock('../blocks/DividerBlock', () => ({
+  default: () => <div data-testid="block-divider" />,
+}));
+vi.mock('../blocks/ActionButtonsBlock', () => ({
+  default: () => <div data-testid="block-action_buttons" />,
+}));
+vi.mock('../blocks/MapSnippetBlock', () => ({
+  default: () => <div data-testid="block-map_snippet" />,
+}));
+vi.mock('../blocks/EntityListBlock', () => ({
+  default: () => <div data-testid="block-entity_list" />,
+}));
+vi.mock('../blocks/TimelineBlock', () => ({
+  default: () => <div data-testid="block-timeline" />,
+}));
+vi.mock('../blocks/RowBlock', () => ({
+  default: ({ children }: { children: React.ReactNode[] }) => (
+    <div data-testid="block-row">{children}</div>
+  ),
+}));
+
+const mockItem = {
+  id: 'i1',
+  name: 'Test',
+  status: 'active',
+  custom_field_values: { f1: 'Robin' },
+  latitude: 0,
+  longitude: 0,
+  photos: [],
+  updates: [],
+  entities: [],
+} as unknown as ItemWithDetails;
+
+const mockFields: CustomField[] = [
+  { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'text', options: null, required: false, sort_order: 0, org_id: 'o1' },
+];
+
+describe('LayoutRenderer', () => {
+  it('renders blocks in order', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'divider', config: {} },
+        { id: 'b3', type: 'action_buttons', config: {} },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    render(
+      <LayoutRenderer layout={layout} item={mockItem} mode="preview" context="preview" customFields={[]} />,
+    );
+    const blocks = screen.getAllByTestId(/^block-/);
+    expect(blocks).toHaveLength(3);
+  });
+
+  it('renders field_display with correct field data', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    render(
+      <LayoutRenderer layout={layout} item={mockItem} mode="preview" context="preview" customFields={mockFields} />,
+    );
+    expect(screen.getByTestId('block-field_display')).toHaveTextContent('Species');
+  });
+
+  it('renders rows with children', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'status_badge', config: {} },
+            { id: 'b2', type: 'divider', config: {} },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    render(
+      <LayoutRenderer layout={layout} item={mockItem} mode="preview" context="preview" customFields={[]} />,
+    );
+    expect(screen.getByTestId('block-row')).toBeInTheDocument();
+    expect(screen.getByTestId('block-status_badge')).toBeInTheDocument();
+    expect(screen.getByTestId('block-divider')).toBeInTheDocument();
+  });
+
+  it('limits blocks in peek state', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 4 } },
+        { id: 'b3', type: 'timeline', config: { showUpdates: true, showScheduled: false, maxItems: 5 } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    render(
+      <LayoutRenderer layout={layout} item={mockItem} mode="live" context="bottom-sheet" sheetState="peek" customFields={[]} />,
+    );
+    const blocks = screen.getAllByTestId(/^block-/);
+    expect(blocks).toHaveLength(2);
+  });
+
+  it('renders all blocks in half/full state', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 4 } },
+        { id: 'b3', type: 'timeline', config: { showUpdates: true, showScheduled: false, maxItems: 5 } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    render(
+      <LayoutRenderer layout={layout} item={mockItem} mode="live" context="bottom-sheet" sheetState="full" customFields={[]} />,
+    );
+    expect(screen.getAllByTestId(/^block-/)).toHaveLength(3);
+  });
+
+  it('skips blocks with unknown type gracefully', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'unknown_type' as any, config: {} },
+        { id: 'b3', type: 'divider', config: {} },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 3,
+    };
+    render(
+      <LayoutRenderer layout={layout} item={mockItem} mode="preview" context="preview" customFields={[]} />,
+    );
+    expect(screen.getAllByTestId(/^block-/)).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/components/layout/__tests__/LayoutRenderer.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement LayoutRenderer**
+
+```tsx
+// src/components/layout/LayoutRenderer.tsx
+'use client';
+
+import type { TypeLayout, LayoutNode, LayoutBlock, LayoutRow } from '@/lib/layout/types';
+import { isLayoutRow } from '@/lib/layout/types';
+import type { FieldDisplayConfig } from '@/lib/layout/types';
+import type { ItemWithDetails, CustomField } from '@/lib/types';
+import { SPACING } from '@/lib/layout/spacing';
+import BlockErrorBoundary from './BlockErrorBoundary';
+import StatusBadgeBlock from './blocks/StatusBadgeBlock';
+import FieldDisplayBlock from './blocks/FieldDisplayBlock';
+import PhotoGalleryBlock from './blocks/PhotoGalleryBlock';
+import TextLabelBlock from './blocks/TextLabelBlock';
+import DividerBlock from './blocks/DividerBlock';
+import ActionButtonsBlock from './blocks/ActionButtonsBlock';
+import MapSnippetBlock from './blocks/MapSnippetBlock';
+import EntityListBlock from './blocks/EntityListBlock';
+import TimelineBlock from './blocks/TimelineBlock';
+import RowBlock from './blocks/RowBlock';
+
+interface LayoutRendererProps {
+  layout: TypeLayout;
+  item: ItemWithDetails;
+  mode: 'live' | 'preview';
+  context: 'bottom-sheet' | 'side-panel' | 'preview';
+  sheetState?: 'peek' | 'half' | 'full';
+  customFields: CustomField[];
+}
+
+export default function LayoutRenderer({
+  layout,
+  item,
+  mode,
+  context,
+  sheetState,
+  customFields,
+}: LayoutRendererProps) {
+  const spacing = SPACING[layout.spacing];
+
+  // In peek state, only show first N top-level nodes
+  const visibleBlocks =
+    sheetState === 'peek'
+      ? layout.blocks.slice(0, layout.peekBlockCount)
+      : layout.blocks;
+
+  const fieldMap = new Map(customFields.map((f) => [f.id, f]));
+
+  function renderBlock(block: LayoutBlock, index: number) {
+    const isHeroPosition = index <= 1;
+
+    switch (block.type) {
+      case 'status_badge':
+        return <StatusBadgeBlock status={item.status} />;
+      case 'field_display': {
+        const config = block.config as FieldDisplayConfig;
+        const field = fieldMap.get(config.fieldId);
+        const value = item.custom_field_values[config.fieldId];
+        if (block.hideWhenEmpty && value == null) return null;
+        return <FieldDisplayBlock config={config} field={field} value={value} />;
+      }
+      case 'photo_gallery':
+        return (
+          <PhotoGalleryBlock
+            config={block.config as any}
+            photos={item.photos}
+            isEdgeToEdge={
+              isHeroPosition &&
+              (block.config as any).style === 'hero' &&
+              context === 'bottom-sheet'
+            }
+          />
+        );
+      case 'text_label':
+        return <TextLabelBlock config={block.config as any} />;
+      case 'divider':
+        return <DividerBlock />;
+      case 'action_buttons':
+        return (
+          <ActionButtonsBlock
+            itemId={item.id}
+            canEdit={true}
+            canAddUpdate={true}
+            mode={mode}
+          />
+        );
+      case 'map_snippet':
+        return (
+          <MapSnippetBlock
+            latitude={item.latitude}
+            longitude={item.longitude}
+            context={context}
+          />
+        );
+      case 'entity_list':
+        return (
+          <EntityListBlock
+            config={block.config as any}
+            entities={item.entities}
+          />
+        );
+      case 'timeline':
+        return (
+          <TimelineBlock
+            config={block.config as any}
+            updates={item.updates}
+          />
+        );
+      default:
+        return null;
+    }
+  }
+
+  function renderNode(node: LayoutNode, index: number) {
+    if (isLayoutRow(node)) {
+      return (
+        <BlockErrorBoundary key={node.id} blockType="row">
+          <RowBlock row={node}>
+            {node.children.map((child, i) => (
+              <BlockErrorBoundary key={child.id} blockType={child.type}>
+                {renderBlock(child, i)}
+              </BlockErrorBoundary>
+            ))}
+          </RowBlock>
+        </BlockErrorBoundary>
+      );
+    }
+
+    const rendered = renderBlock(node, index);
+    if (rendered === null) return null;
+
+    return (
+      <BlockErrorBoundary key={node.id} blockType={node.type}>
+        {rendered}
+      </BlockErrorBoundary>
+    );
+  }
+
+  return (
+    <div className="flex flex-col" style={{ gap: `${spacing.blockGap}px` }}>
+      {visibleBlocks.map((node, i) => renderNode(node, i))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/components/layout/__tests__/LayoutRenderer.test.tsx`
+Expected: PASS — all 6 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout/LayoutRenderer.tsx src/components/layout/__tests__/LayoutRenderer.test.tsx
+git commit -m "feat: add LayoutRenderer component with peek state support"
+```
+
+---
+
+## Task 8: Multi-Snap Bottom Sheet
+
+**Files:**
+- Create: `src/components/ui/MultiSnapBottomSheet.tsx`
+- Create: `src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx`
+
+- [ ] **Step 1: Write the component tests**
+
+```tsx
+// src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MultiSnapBottomSheet from '../MultiSnapBottomSheet';
+
+// Mock framer-motion to avoid animation complexity in tests
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+  useMotionValue: () => ({ get: () => 0, set: () => {} }),
+  useTransform: () => ({ get: () => 0 }),
+  useDragControls: () => ({ start: vi.fn() }),
+  AnimatePresence: ({ children }: any) => children,
+}));
+
+describe('MultiSnapBottomSheet', () => {
+  it('renders children when open', () => {
+    render(
+      <MultiSnapBottomSheet isOpen onClose={vi.fn()} onStateChange={vi.fn()}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>,
+    );
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <MultiSnapBottomSheet isOpen={false} onClose={vi.fn()} onStateChange={vi.fn()}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>,
+    );
+    expect(screen.queryByText('Content')).not.toBeInTheDocument();
+  });
+
+  it('renders handle element', () => {
+    render(
+      <MultiSnapBottomSheet isOpen onClose={vi.fn()} onStateChange={vi.fn()}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>,
+    );
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when overlay is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <MultiSnapBottomSheet isOpen onClose={onClose} onStateChange={vi.fn()}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>,
+    );
+    fireEvent.click(screen.getByTestId('sheet-overlay'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement MultiSnapBottomSheet**
+
+```tsx
+// src/components/ui/MultiSnapBottomSheet.tsx
+'use client';
+
+import { useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
+import { motion, AnimatePresence, useMotionValue, useTransform } from 'framer-motion';
+
+export type SheetState = 'peek' | 'half' | 'full';
+
+interface MultiSnapBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onStateChange: (state: SheetState) => void;
+  initialState?: SheetState;
+  children: ReactNode;
+}
+
+// Snap point heights as percentage of viewport
+const SNAP_POINTS: Record<SheetState, number> = {
+  peek: 0.25,
+  half: 0.50,
+  full: 0.92,
+};
+
+const DISMISS_THRESHOLD = 0.15; // Below peek, dismiss
+
+export default function MultiSnapBottomSheet({
+  isOpen,
+  onClose,
+  onStateChange,
+  initialState = 'peek',
+  children,
+}: MultiSnapBottomSheetProps) {
+  const [state, setState] = useState<SheetState>(initialState);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const startY = useRef(0);
+  const startHeight = useRef(0);
+  const isDragging = useRef(false);
+  const [height, setHeight] = useState(0);
+
+  // Calculate pixel heights from viewport
+  const getSnapHeight = useCallback((s: SheetState) => {
+    if (typeof window === 'undefined') return 0;
+    return Math.round(window.innerHeight * SNAP_POINTS[s]);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setHeight(getSnapHeight(initialState));
+      setState(initialState);
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => { document.body.style.overflow = ''; };
+  }, [isOpen, initialState, getSnapHeight]);
+
+  const snapToNearest = useCallback((currentHeight: number, velocity: number) => {
+    const vh = window.innerHeight;
+    const ratio = currentHeight / vh;
+
+    // Dismiss if below threshold
+    if (ratio < DISMISS_THRESHOLD) {
+      onClose();
+      return;
+    }
+
+    // Fast swipe up → skip to full
+    if (velocity < -500 && state === 'peek') {
+      const next = 'full';
+      setState(next);
+      setHeight(getSnapHeight(next));
+      onStateChange(next);
+      return;
+    }
+
+    // Fast swipe down → skip to peek or dismiss
+    if (velocity > 500 && state === 'full') {
+      const next = 'peek';
+      setState(next);
+      setHeight(getSnapHeight(next));
+      onStateChange(next);
+      return;
+    }
+
+    // Find closest snap point
+    const states: SheetState[] = ['peek', 'half', 'full'];
+    let closest = states[0];
+    let minDist = Infinity;
+    for (const s of states) {
+      const dist = Math.abs(currentHeight - getSnapHeight(s));
+      if (dist < minDist) {
+        minDist = dist;
+        closest = s;
+      }
+    }
+
+    setState(closest);
+    setHeight(getSnapHeight(closest));
+    onStateChange(closest);
+  }, [state, getSnapHeight, onClose, onStateChange]);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startY.current = e.touches[0].clientY;
+    startHeight.current = height;
+    isDragging.current = true;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging.current) return;
+    const deltaY = startY.current - e.touches[0].clientY;
+    const newHeight = Math.max(0, Math.min(window.innerHeight * 0.95, startHeight.current + deltaY));
+    setHeight(newHeight);
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    const endY = e.changedTouches[0].clientY;
+    const velocity = (startY.current - endY) / 0.3; // rough velocity
+    snapToNearest(height, -velocity);
+  };
+
+  const handleHandleTap = () => {
+    const next = state === 'peek' ? 'half' : 'peek';
+    setState(next);
+    setHeight(getSnapHeight(next));
+    onStateChange(next);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div
+        data-testid="sheet-overlay"
+        className="fixed inset-0 z-40 bg-black/30"
+        onClick={onClose}
+        style={{ opacity: state === 'peek' ? 0.1 : 0.3 }}
+      />
+      <motion.div
+        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl"
+        style={{
+          height: `${height}px`,
+          paddingBottom: 'env(safe-area-inset-bottom)',
+        }}
+        initial={{ y: '100%' }}
+        animate={{ y: 0 }}
+        exit={{ y: '100%' }}
+        transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Handle */}
+        <button
+          onClick={handleHandleTap}
+          className="w-full flex justify-center py-3 cursor-grab active:cursor-grabbing"
+          aria-label={state === 'peek' ? 'Expand details' : 'Collapse details'}
+        >
+          <div className="w-10 h-1 rounded-full bg-gray-300" />
+        </button>
+
+        {/* Content */}
+        <div
+          ref={contentRef}
+          className="overflow-y-auto px-4 pb-4"
+          style={{ height: `calc(100% - 40px)` }}
+        >
+          {children}
+        </div>
+      </motion.div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx`
+Expected: PASS — all 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ui/MultiSnapBottomSheet.tsx src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx
+git commit -m "feat: add multi-snap bottom sheet with peek/half/full states"
+```
+
+---
+
+## Task 9: DetailPanel Integration
+
+**Files:**
+- Modify: `src/components/item/DetailPanel.tsx`
+
+- [ ] **Step 1: Integrate LayoutRenderer and MultiSnapBottomSheet into DetailPanel**
+
+Read the current `DetailPanel.tsx` first (already read above). The modification:
+- When `item.item_type?.layout` exists, render via `LayoutRenderer`
+- When null, render the existing fixed layout (backward compatibility)
+- Replace `BottomSheet` with `MultiSnapBottomSheet` on mobile
+
+```tsx
+// src/components/item/DetailPanel.tsx — replace entire file
+'use client';
+
+import type { ItemWithDetails } from '@/lib/types';
+import StatusBadge from './StatusBadge';
+import UpdateTimeline from './UpdateTimeline';
+import MultiSnapBottomSheet, { type SheetState } from '@/components/ui/MultiSnapBottomSheet';
+import LayoutRenderer from '@/components/layout/LayoutRenderer';
+import { formatDate } from '@/lib/utils';
+import { useEffect, useState } from 'react';
+import { useUserLocation } from '@/lib/location/provider';
+import { getDistanceToItem, formatDistance } from '@/lib/location/utils';
+import Link from 'next/link';
+import PhotoViewer from '@/components/ui/PhotoViewer';
+
+interface DetailPanelProps {
+  item: ItemWithDetails | null;
+  onClose: () => void;
+  isAuthenticated?: boolean;
+  canEditItem?: boolean;
+  canAddUpdate?: boolean;
+}
+
+export default function DetailPanel({ item, onClose, isAuthenticated, canEditItem, canAddUpdate }: DetailPanelProps) {
+  const [isMobile, setIsMobile] = useState(false);
+  const [sheetState, setSheetState] = useState<SheetState>('peek');
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  // Reset to peek when a new item is selected
+  useEffect(() => {
+    if (item) setSheetState('peek');
+  }, [item?.id]);
+
+  const { position } = useUserLocation();
+
+  if (!item) return null;
+
+  const distance = getDistanceToItem(position, item);
+  const layout = item.item_type?.layout ?? null;
+
+  // Header: always shown (outside layout)
+  const header = (
+    <div className="flex items-start justify-between mb-3">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          {item.item_type && <span className="text-xl">{item.item_type.icon}</span>}
+          <h2 className="font-heading font-semibold text-forest-dark text-xl">
+            {item.name}
+          </h2>
+        </div>
+        {distance != null && (
+          <span className="text-xs text-forest">
+            {formatDistance(distance)} away
+          </span>
+        )}
+      </div>
+      {!isMobile && (
+        <button
+          onClick={onClose}
+          className="ml-2 p-1 rounded-lg text-sage hover:bg-sage-light transition-colors"
+          aria-label="Close panel"
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+
+  // Content: either layout-driven or legacy
+  const content = layout ? (
+    <div>
+      {header}
+      <LayoutRenderer
+        layout={layout}
+        item={item}
+        mode="live"
+        context={isMobile ? 'bottom-sheet' : 'side-panel'}
+        sheetState={isMobile ? sheetState : undefined}
+        customFields={item.custom_fields ?? []}
+      />
+    </div>
+  ) : (
+    // Legacy fixed layout (unchanged from original)
+    <div>
+      {header}
+      <div className="flex items-center mb-3">
+        <StatusBadge status={item.status} />
+      </div>
+
+      {item.custom_fields && item.custom_fields.length > 0 && (
+        <div className="space-y-2 mb-3">
+          {item.custom_fields
+            .filter((f) => item.custom_field_values[f.id] != null)
+            .map((field) => (
+              <div key={field.id}>
+                <span className="text-xs font-medium text-sage uppercase tracking-wide">
+                  {field.name}
+                </span>
+                <p className="text-sm text-forest-dark font-medium">
+                  {field.field_type === 'date' && item.custom_field_values[field.id]
+                    ? formatDate(String(item.custom_field_values[field.id]))
+                    : String(item.custom_field_values[field.id])}
+                </p>
+              </div>
+            ))}
+        </div>
+      )}
+
+      {item.entities && item.entities.length > 0 && (() => {
+        const grouped = new Map<string, { type: { id: string; name: string; icon: string }; entities: typeof item.entities }>();
+        for (const e of item.entities) {
+          const key = e.entity_type.id;
+          if (!grouped.has(key)) grouped.set(key, { type: e.entity_type, entities: [] });
+          grouped.get(key)!.entities.push(e);
+        }
+        return Array.from(grouped.values()).map(({ type, entities }) => (
+          <div key={type.id} className="mb-3">
+            <span className="text-xs font-medium text-sage uppercase tracking-wide">
+              {type.icon} {type.name}
+            </span>
+            <div className="flex flex-wrap gap-1 mt-1">
+              {entities.map((e) => (
+                <span key={e.id} className="inline-flex items-center gap-1 bg-forest/10 text-forest-dark text-xs px-2 py-1 rounded-full">
+                  {e.name}
+                </span>
+              ))}
+            </div>
+          </div>
+        ));
+      })()}
+
+      {item.description && (
+        <div className="mb-4">
+          <span className="text-xs font-medium text-sage uppercase tracking-wide">Description</span>
+          <p className="text-sm text-forest-dark/80 leading-relaxed mt-0.5">{item.description}</p>
+        </div>
+      )}
+
+      {item.photos.length > 0 && (
+        <div className="mb-4">
+          <PhotoViewer photos={item.photos} />
+        </div>
+      )}
+
+      {isAuthenticated && (canEditItem || canAddUpdate) && (
+        <div className="flex gap-2 mb-4">
+          {canEditItem && (
+            <Link href={`/manage/edit/${item.id}`} className="btn-primary text-sm flex-1 text-center">
+              Edit Item
+            </Link>
+          )}
+          {canAddUpdate && (
+            <Link href={`/manage/update?item=${item.id}`} className="btn-secondary text-sm flex-1 text-center">
+              Add Update
+            </Link>
+          )}
+        </div>
+      )}
+
+      <div>
+        <h3 className="text-xs font-medium text-sage uppercase tracking-wide mb-3">Updates</h3>
+        <UpdateTimeline updates={item.updates} />
+      </div>
+    </div>
+  );
+
+  // Mobile: multi-snap bottom sheet
+  if (isMobile) {
+    return (
+      <MultiSnapBottomSheet
+        isOpen={!!item}
+        onClose={onClose}
+        onStateChange={setSheetState}
+        initialState="peek"
+      >
+        {content}
+      </MultiSnapBottomSheet>
+    );
+  }
+
+  // Desktop: side panel (unchanged)
+  return (
+    <div className="absolute right-0 top-0 h-full w-96 bg-white shadow-2xl border-l border-sage-light z-20 overflow-y-auto animate-slide-in-right">
+      <div className="p-5">{content}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the app compiles**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run type-check`
+Expected: No type errors. If there are type mismatches between `ItemWithDetails` and what LayoutRenderer expects, fix them.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/item/DetailPanel.tsx
+git commit -m "feat: integrate LayoutRenderer and multi-snap bottom sheet into DetailPanel"
+```
+
+---
+
+## Task 10: Form Derivation Logic
+
+**Files:**
+- Create: `src/lib/layout/form-derivation.ts`
+- Create: `src/lib/layout/__tests__/form-derivation.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/lib/layout/__tests__/form-derivation.test.ts
+import { describe, it, expect } from 'vitest';
+import { deriveFormFields } from '../form-derivation';
+import type { TypeLayout } from '../types';
+import type { CustomField } from '@/lib/types';
+
+describe('deriveFormFields', () => {
+  const fields: CustomField[] = [
+    { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin', 'Wren'], required: true, sort_order: 0, org_id: 'o1' },
+    { id: 'f2', item_type_id: 't1', name: 'Install Date', field_type: 'date', options: null, required: false, sort_order: 1, org_id: 'o1' },
+  ];
+
+  it('extracts field_display blocks as form fields in order', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+        { id: 'b3', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = deriveFormFields(layout, fields);
+    expect(result.fields).toHaveLength(2);
+    expect(result.fields[0].id).toBe('f1');
+    expect(result.fields[1].id).toBe('f2');
+  });
+
+  it('extracts fields from rows', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = deriveFormFields(layout, fields);
+    expect(result.fields).toHaveLength(2);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].fieldIds).toEqual(['f1', 'f2']);
+  });
+
+  it('includes photo position when photo_gallery block exists', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+        { id: 'b2', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 4 } },
+        { id: 'b3', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = deriveFormFields(layout, fields);
+    expect(result.photoPosition).toBe(1); // after first field
+  });
+
+  it('omits timeline, map_snippet, action_buttons', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'timeline', config: { showUpdates: true, showScheduled: false, maxItems: 5 } },
+        { id: 'b2', type: 'map_snippet', config: {} },
+        { id: 'b3', type: 'action_buttons', config: {} },
+        { id: 'b4', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = deriveFormFields(layout, fields);
+    expect(result.fields).toHaveLength(1);
+  });
+
+  it('preserves text_label blocks as section headers', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'text_label', config: { text: 'Details', style: 'heading' } },
+        { id: 'b2', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = deriveFormFields(layout, fields);
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0].text).toBe('Details');
+    expect(result.sections[0].beforeFieldIndex).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/form-derivation.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement form derivation**
+
+```typescript
+// src/lib/layout/form-derivation.ts
+import type { TypeLayout, LayoutNode, LayoutBlock, LayoutRow, FieldDisplayConfig } from './types';
+import { isLayoutRow } from './types';
+import type { CustomField } from '@/lib/types';
+
+export interface FormSection {
+  text: string;
+  style: string;
+  beforeFieldIndex: number;
+}
+
+export interface FormRow {
+  fieldIds: string[];
+}
+
+export interface DerivedFormLayout {
+  fields: CustomField[];
+  rows: FormRow[];
+  sections: FormSection[];
+  photoPosition: number | null; // index in fields list where photo uploader should appear, null = after all fields
+}
+
+export function deriveFormFields(layout: TypeLayout, customFields: CustomField[]): DerivedFormLayout {
+  const fieldMap = new Map(customFields.map((f) => [f.id, f]));
+  const fields: CustomField[] = [];
+  const rows: FormRow[] = [];
+  const sections: FormSection[] = [];
+  let photoPosition: number | null = null;
+  let formElementIndex = 0;
+
+  function processBlock(block: LayoutBlock) {
+    switch (block.type) {
+      case 'field_display': {
+        const config = block.config as FieldDisplayConfig;
+        const field = fieldMap.get(config.fieldId);
+        if (field) {
+          fields.push(field);
+          formElementIndex++;
+        }
+        break;
+      }
+      case 'photo_gallery':
+        photoPosition = formElementIndex;
+        break;
+      case 'text_label': {
+        const config = block.config as { text: string; style: string };
+        sections.push({
+          text: config.text,
+          style: config.style,
+          beforeFieldIndex: formElementIndex,
+        });
+        break;
+      }
+      // status_badge, entity_list handled as fixed form elements
+      // timeline, map_snippet, action_buttons, divider omitted
+    }
+  }
+
+  for (const node of layout.blocks) {
+    if (isLayoutRow(node)) {
+      const rowFieldIds: string[] = [];
+      for (const child of node.children) {
+        if (child.type === 'field_display') {
+          const config = child.config as FieldDisplayConfig;
+          const field = fieldMap.get(config.fieldId);
+          if (field) {
+            fields.push(field);
+            rowFieldIds.push(field.id);
+            formElementIndex++;
+          }
+        } else {
+          processBlock(child);
+        }
+      }
+      if (rowFieldIds.length >= 2) {
+        rows.push({ fieldIds: rowFieldIds });
+      }
+    } else {
+      processBlock(node);
+    }
+  }
+
+  return { fields, rows, sections, photoPosition };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/form-derivation.test.ts`
+Expected: PASS — all 5 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/layout/form-derivation.ts src/lib/layout/__tests__/form-derivation.test.ts
+git commit -m "feat: add form derivation logic to auto-generate form layout from detail layout"
+```
+
+---
+
+## Task 11: Server Actions for Layout Save
+
+**Files:**
+- Create: `src/app/admin/properties/[slug]/types/layout-actions.ts`
+- Create: `src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSupabase = {
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => mockSupabase,
+}));
+
+vi.mock('@/lib/permissions', () => ({
+  getTenantContext: vi.fn().mockResolvedValue({ orgId: 'org1' }),
+}));
+
+// Import after mocks
+const { saveTypeWithLayout } = await import('../layout-actions');
+
+describe('saveTypeWithLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const result = await saveTypeWithLayout({
+      itemTypeId: 't1',
+      layout: { version: 1, blocks: [{ id: 'b1', type: 'divider', config: {} }], spacing: 'comfortable', peekBlockCount: 1 },
+      newFields: [],
+    });
+    expect(result).toEqual({ error: 'Not authenticated' });
+  });
+
+  it('returns error for invalid layout', async () => {
+    const result = await saveTypeWithLayout({
+      itemTypeId: 't1',
+      layout: { version: 1, blocks: [], spacing: 'comfortable', peekBlockCount: 0 } as any,
+      newFields: [],
+    });
+    expect(result).toEqual(expect.objectContaining({ error: expect.stringContaining('Invalid layout') }));
+  });
+
+  it('saves layout and creates new fields', async () => {
+    const updateMock = vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) });
+    const insertMock = vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ data: [{ id: 'new-f1' }], error: null }) });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'item_types') return { update: updateMock };
+      if (table === 'custom_fields') return { insert: insertMock };
+      return {};
+    });
+
+    const result = await saveTypeWithLayout({
+      itemTypeId: 't1',
+      layout: {
+        version: 1,
+        blocks: [{ id: 'b1', type: 'status_badge', config: {} }],
+        spacing: 'comfortable',
+        peekBlockCount: 1,
+      },
+      newFields: [
+        { name: 'Species', field_type: 'dropdown', options: ['Robin'], required: true, sort_order: 0 },
+      ],
+    });
+    expect(result).toEqual(expect.objectContaining({ success: true }));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement server actions**
+
+```typescript
+// src/app/admin/properties/[slug]/types/layout-actions.ts
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { getTenantContext } from '@/lib/permissions';
+import { typeLayoutSchema } from '@/lib/layout/schemas';
+import type { TypeLayout } from '@/lib/layout/types';
+
+interface NewField {
+  name: string;
+  field_type: string;
+  options: string[] | null;
+  required: boolean;
+  sort_order: number;
+}
+
+interface SaveTypeWithLayoutInput {
+  itemTypeId: string;
+  layout: TypeLayout;
+  newFields: NewField[];
+}
+
+export async function saveTypeWithLayout(input: SaveTypeWithLayoutInput) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
+
+  // Validate layout
+  const parsed = typeLayoutSchema.safeParse(input.layout);
+  if (!parsed.success) {
+    return { error: `Invalid layout: ${parsed.error.issues[0]?.message ?? 'validation failed'}` };
+  }
+
+  // Create any new fields first
+  const createdFieldIds: string[] = [];
+  if (input.newFields.length > 0) {
+    const { data: newFieldRows, error: fieldError } = await supabase
+      .from('custom_fields')
+      .insert(
+        input.newFields.map((f) => ({
+          item_type_id: input.itemTypeId,
+          name: f.name,
+          field_type: f.field_type,
+          options: f.options,
+          required: f.required,
+          sort_order: f.sort_order,
+          org_id: tenant.orgId,
+        })),
+      )
+      .select();
+
+    if (fieldError) return { error: `Failed to create fields: ${fieldError.message}` };
+    if (newFieldRows) {
+      createdFieldIds.push(...newFieldRows.map((r: { id: string }) => r.id));
+    }
+  }
+
+  // Save layout on item_type
+  const { error: layoutError } = await supabase
+    .from('item_types')
+    .update({ layout: parsed.data })
+    .eq('id', input.itemTypeId);
+
+  if (layoutError) return { error: `Failed to save layout: ${layoutError.message}` };
+
+  return { success: true, createdFieldIds };
+}
+
+export async function deleteLayout(itemTypeId: string) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const { error } = await supabase
+    .from('item_types')
+    .update({ layout: null })
+    .eq('id', itemTypeId);
+
+  if (error) return { error: `Failed to delete layout: ${error.message}` };
+  return { success: true };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts`
+Expected: PASS — all 3 tests pass. Adjust mocks if the import paths or patterns differ slightly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/types/layout-actions.ts src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts
+git commit -m "feat: add server actions for saving and deleting item type layouts"
+```
+
+---
+
+## Task 12: Layout Builder — Core Components
+
+This is the largest task. It creates the builder UI: palette, sortable block list, inline config panels, and the main orchestrator.
+
+**Files:**
+- Create: `src/components/layout/builder/BlockPalette.tsx`
+- Create: `src/components/layout/builder/BlockListItem.tsx`
+- Create: `src/components/layout/builder/BlockConfigPanel.tsx`
+- Create: `src/components/layout/builder/InlineFieldCreator.tsx`
+- Create: `src/components/layout/builder/SpacingPicker.tsx`
+- Create: `src/components/layout/builder/PeekBoundary.tsx`
+- Create: `src/components/layout/builder/BlockList.tsx`
+- Create: `src/components/layout/builder/RowEditor.tsx`
+- Create: `src/components/layout/builder/LayoutBuilder.tsx`
+
+Due to the size of this task, each sub-component is a step. The builder uses `@dnd-kit/sortable` for reordering and manages all layout state internally, calling a save action on "Done."
+
+- [ ] **Step 1: Create BlockPalette**
+
+```tsx
+// src/components/layout/builder/BlockPalette.tsx
+'use client';
+
+import type { BlockType } from '@/lib/layout/types';
+
+interface PaletteItem {
+  type: BlockType | 'row';
+  icon: string;
+  label: string;
+}
+
+const PALETTE_ITEMS: PaletteItem[] = [
+  { type: 'field_display', icon: '📊', label: 'Field' },
+  { type: 'photo_gallery', icon: '📷', label: 'Photo' },
+  { type: 'status_badge', icon: '🏷', label: 'Status' },
+  { type: 'entity_list', icon: '🔗', label: 'Entities' },
+  { type: 'timeline', icon: '📋', label: 'Timeline' },
+  { type: 'text_label', icon: '✏️', label: 'Text' },
+  { type: 'divider', icon: '➖', label: 'Divider' },
+  { type: 'map_snippet', icon: '📍', label: 'Map' },
+  { type: 'action_buttons', icon: '🔘', label: 'Actions' },
+  { type: 'row', icon: '⬜', label: 'Row' },
+];
+
+interface Props {
+  onAdd: (type: BlockType | 'row') => void;
+}
+
+export default function BlockPalette({ onAdd }: Props) {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-hide">
+      {PALETTE_ITEMS.map((item) => (
+        <button
+          key={item.type}
+          onClick={() => onAdd(item.type)}
+          className="flex-shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-full border border-sage-light bg-white hover:bg-sage-light/50 text-sm font-medium text-forest-dark transition-colors min-h-[44px]"
+        >
+          <span>{item.icon}</span>
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create InlineFieldCreator**
+
+```tsx
+// src/components/layout/builder/InlineFieldCreator.tsx
+'use client';
+
+import { useState } from 'react';
+import type { FieldType } from '@/lib/types';
+
+interface NewFieldData {
+  name: string;
+  field_type: FieldType;
+  options: string[];
+  required: boolean;
+}
+
+interface Props {
+  onCreateField: (field: NewFieldData) => void;
+  onCancel: () => void;
+}
+
+export default function InlineFieldCreator({ onCreateField, onCancel }: Props) {
+  const [name, setName] = useState('');
+  const [fieldType, setFieldType] = useState<FieldType>('text');
+  const [options, setOptions] = useState('');
+  const [required, setRequired] = useState(false);
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onCreateField({
+      name: name.trim(),
+      field_type: fieldType,
+      options: fieldType === 'dropdown' ? options.split(',').map((o) => o.trim()).filter(Boolean) : [],
+      required,
+    });
+  };
+
+  return (
+    <div className="space-y-3 p-3 bg-sage-light/30 rounded-lg border border-sage-light">
+      <div>
+        <label className="label">Field Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="input-field"
+          placeholder="e.g., Target Species"
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label className="label">Type</label>
+        <div className="flex gap-1">
+          {(['text', 'number', 'dropdown', 'date'] as FieldType[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setFieldType(t)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                fieldType === t
+                  ? 'bg-forest text-white'
+                  : 'bg-white border border-sage-light text-forest-dark hover:bg-sage-light/50'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {fieldType === 'dropdown' && (
+        <div>
+          <label className="label">Options (comma-separated)</label>
+          <input
+            type="text"
+            value={options}
+            onChange={(e) => setOptions(e.target.value)}
+            className="input-field"
+            placeholder="Robin, Wren, Blue Tit"
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="field-required"
+          checked={required}
+          onChange={(e) => setRequired(e.target.checked)}
+          className="rounded"
+        />
+        <label htmlFor="field-required" className="text-sm text-forest-dark">Required</label>
+      </div>
+
+      <div className="flex gap-2">
+        <button onClick={handleSubmit} className="btn-primary text-sm" disabled={!name.trim()}>
+          Create Field
+        </button>
+        <button onClick={onCancel} className="btn-secondary text-sm">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create BlockConfigPanel**
+
+```tsx
+// src/components/layout/builder/BlockConfigPanel.tsx
+'use client';
+
+import type { LayoutBlock, BlockConfig, FieldDisplayConfig, PhotoGalleryConfig, TimelineConfig, TextLabelConfig, EntityListConfig } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import InlineFieldCreator from './InlineFieldCreator';
+import { useState } from 'react';
+
+interface Props {
+  block: LayoutBlock;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+}
+
+export default function BlockConfigPanel({ block, customFields, entityTypes, onConfigChange, onCreateField }: Props) {
+  const [showFieldCreator, setShowFieldCreator] = useState(false);
+
+  switch (block.type) {
+    case 'field_display': {
+      const config = block.config as FieldDisplayConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="label">Field</label>
+            <select
+              value={config.fieldId}
+              onChange={(e) => onConfigChange(block.id, { ...config, fieldId: e.target.value })}
+              className="input-field"
+            >
+              <option value="">Select a field...</option>
+              {customFields.map((f) => (
+                <option key={f.id} value={f.id}>{f.name}</option>
+              ))}
+            </select>
+          </div>
+          {!showFieldCreator && (
+            <button
+              onClick={() => setShowFieldCreator(true)}
+              className="text-sm text-forest font-medium hover:underline"
+            >
+              + Create New Field
+            </button>
+          )}
+          {showFieldCreator && (
+            <InlineFieldCreator
+              onCreateField={(field) => {
+                onCreateField(field);
+                setShowFieldCreator(false);
+              }}
+              onCancel={() => setShowFieldCreator(false)}
+            />
+          )}
+          <div>
+            <label className="label">Size</label>
+            <div className="flex gap-1">
+              {(['compact', 'normal', 'large'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => onConfigChange(block.id, { ...config, size: s })}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    config.size === s ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.showLabel}
+              onChange={(e) => onConfigChange(block.id, { ...config, showLabel: e.target.checked })}
+              className="rounded"
+            />
+            <span className="text-sm text-forest-dark">Show label</span>
+          </label>
+        </div>
+      );
+    }
+
+    case 'photo_gallery': {
+      const config = block.config as PhotoGalleryConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="label">Style</label>
+            <div className="flex gap-1">
+              {(['hero', 'grid', 'carousel'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => onConfigChange(block.id, { ...config, style: s })}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    config.style === s ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <label className="label">Max Photos: {config.maxPhotos}</label>
+            <input
+              type="range"
+              min={1}
+              max={20}
+              value={config.maxPhotos}
+              onChange={(e) => onConfigChange(block.id, { ...config, maxPhotos: Number(e.target.value) })}
+              className="w-full"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    case 'timeline': {
+      const config = block.config as TimelineConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.showUpdates}
+              onChange={(e) => onConfigChange(block.id, { ...config, showUpdates: e.target.checked })}
+              className="rounded"
+            />
+            <span className="text-sm">Show updates</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.showScheduled}
+              onChange={(e) => onConfigChange(block.id, { ...config, showScheduled: e.target.checked })}
+              className="rounded"
+            />
+            <span className="text-sm">Show scheduled</span>
+          </label>
+          <div>
+            <label className="label">Max items: {config.maxItems}</label>
+            <input
+              type="range"
+              min={1}
+              max={50}
+              value={config.maxItems}
+              onChange={(e) => onConfigChange(block.id, { ...config, maxItems: Number(e.target.value) })}
+              className="w-full"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    case 'text_label': {
+      const config = block.config as TextLabelConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="label">Text</label>
+            <input
+              type="text"
+              value={config.text}
+              onChange={(e) => onConfigChange(block.id, { ...config, text: e.target.value })}
+              className="input-field"
+            />
+          </div>
+          <div>
+            <label className="label">Style</label>
+            <div className="flex gap-1">
+              {(['heading', 'subheading', 'body', 'caption'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => onConfigChange(block.id, { ...config, style: s })}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    config.style === s ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    case 'entity_list': {
+      const config = block.config as EntityListConfig;
+      return (
+        <div className="space-y-2 pt-2">
+          <label className="label">Show entity types</label>
+          {entityTypes.map((et) => (
+            <label key={et.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={config.entityTypeIds.length === 0 || config.entityTypeIds.includes(et.id)}
+                onChange={(e) => {
+                  const ids = config.entityTypeIds.length === 0
+                    ? entityTypes.map((t) => t.id).filter((id) => id !== et.id || e.target.checked)
+                    : e.target.checked
+                      ? [...config.entityTypeIds, et.id]
+                      : config.entityTypeIds.filter((id) => id !== et.id);
+                  onConfigChange(block.id, { ...config, entityTypeIds: ids });
+                }}
+                className="rounded"
+              />
+              <span className="text-sm">{et.icon} {et.name}</span>
+            </label>
+          ))}
+        </div>
+      );
+    }
+
+    default:
+      return (
+        <p className="text-xs text-sage italic pt-2">No configuration needed</p>
+      );
+  }
+}
+```
+
+- [ ] **Step 4: Create SpacingPicker**
+
+```tsx
+// src/components/layout/builder/SpacingPicker.tsx
+'use client';
+
+import type { SpacingPreset } from '@/lib/layout/types';
+
+interface Props {
+  value: SpacingPreset;
+  onChange: (value: SpacingPreset) => void;
+}
+
+const options: { value: SpacingPreset; label: string; description: string }[] = [
+  { value: 'compact', label: 'Compact', description: 'Dense, data-heavy' },
+  { value: 'comfortable', label: 'Comfortable', description: 'Balanced' },
+  { value: 'spacious', label: 'Spacious', description: 'Airy, photo-forward' },
+];
+
+export default function SpacingPicker({ value, onChange }: Props) {
+  return (
+    <div className="flex gap-1">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={`flex-1 px-2 py-2 rounded-md text-xs font-medium text-center transition-colors ${
+            value === opt.value
+              ? 'bg-forest text-white'
+              : 'bg-white border border-sage-light text-forest-dark hover:bg-sage-light/50'
+          }`}
+          title={opt.description}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Create PeekBoundary**
+
+```tsx
+// src/components/layout/builder/PeekBoundary.tsx
+'use client';
+
+interface Props {
+  peekBlockCount: number;
+  totalBlocks: number;
+  onChange: (count: number) => void;
+}
+
+export default function PeekBoundary({ peekBlockCount, totalBlocks, onChange }: Props) {
+  if (totalBlocks <= 1) return null;
+
+  return (
+    <div className="flex items-center gap-2 py-2">
+      <div className="flex-1 border-t-2 border-dashed border-forest/30" />
+      <span className="text-[10px] font-medium text-forest/60 whitespace-nowrap">
+        Visible on first tap
+      </span>
+      <select
+        value={peekBlockCount}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="text-xs border border-sage-light rounded px-1 py-0.5"
+      >
+        {Array.from({ length: totalBlocks }, (_, i) => i + 1).map((n) => (
+          <option key={n} value={n}>{n} block{n > 1 ? 's' : ''}</option>
+        ))}
+      </select>
+      <div className="flex-1 border-t-2 border-dashed border-forest/30" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Create BlockListItem**
+
+```tsx
+// src/components/layout/builder/BlockListItem.tsx
+'use client';
+
+import { useState } from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { LayoutBlock } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import BlockConfigPanel from './BlockConfigPanel';
+import type { BlockConfig } from '@/lib/layout/types';
+import { GripVertical, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+
+const BLOCK_LABELS: Record<string, string> = {
+  field_display: 'Field',
+  photo_gallery: 'Photo Gallery',
+  status_badge: 'Status Badge',
+  entity_list: 'Entities',
+  text_label: 'Text',
+  divider: 'Divider',
+  action_buttons: 'Actions',
+  map_snippet: 'Map',
+  timeline: 'Timeline',
+};
+
+interface Props {
+  block: LayoutBlock;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  fieldName?: string;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDelete: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}
+
+export default function BlockListItem({
+  block,
+  customFields,
+  entityTypes,
+  fieldName,
+  onConfigChange,
+  onDelete,
+  onCreateField,
+  isExpanded,
+  onToggleExpand,
+}: Props) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: block.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const label = block.type === 'field_display' && fieldName
+    ? fieldName
+    : BLOCK_LABELS[block.type] ?? block.type;
+
+  return (
+    <div ref={setNodeRef} style={style} className="border border-sage-light rounded-lg bg-white">
+      {/* Header row */}
+      <div className="flex items-center min-h-[48px]">
+        <button
+          {...attributes}
+          {...listeners}
+          className="p-3 cursor-grab active:cursor-grabbing touch-none"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="w-4 h-4 text-sage" />
+        </button>
+        <button
+          onClick={onToggleExpand}
+          className="flex-1 flex items-center gap-2 py-2 text-left"
+        >
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-sage" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-sage" />
+          )}
+          <span className="text-sm font-medium text-forest-dark">{label}</span>
+        </button>
+        {showDeleteConfirm ? (
+          <div className="flex items-center gap-1 pr-2">
+            <button onClick={() => onDelete(block.id)} className="text-xs text-red-600 font-medium px-2 py-1">
+              Delete
+            </button>
+            <button onClick={() => setShowDeleteConfirm(false)} className="text-xs text-sage px-2 py-1">
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="p-3 text-sage hover:text-red-500 transition-colors"
+            aria-label="Delete block"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Config panel (accordion) */}
+      {isExpanded && (
+        <div className="px-3 pb-3 border-t border-sage-light/50">
+          <BlockConfigPanel
+            block={block}
+            customFields={customFields}
+            entityTypes={entityTypes}
+            onConfigChange={onConfigChange}
+            onCreateField={onCreateField}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Create BlockList with @dnd-kit**
+
+```tsx
+// src/components/layout/builder/BlockList.tsx
+'use client';
+
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import type { LayoutNode, LayoutBlock, BlockConfig } from '@/lib/layout/types';
+import { isLayoutRow } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import BlockListItem from './BlockListItem';
+import RowEditor from './RowEditor';
+import PeekBoundary from './PeekBoundary';
+import { useState } from 'react';
+
+interface Props {
+  nodes: LayoutNode[];
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  peekBlockCount: number;
+  onReorder: (activeId: string, overId: string) => void;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDeleteBlock: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  onPeekCountChange: (count: number) => void;
+  onRowChange: (rowId: string, update: Partial<{ gap: string; distribution: string | number[] }>) => void;
+  onAddToRow: (rowId: string, blockType: string) => void;
+  onRemoveFromRow: (rowId: string, blockId: string) => void;
+}
+
+export default function BlockList({
+  nodes,
+  customFields,
+  entityTypes,
+  peekBlockCount,
+  onReorder,
+  onConfigChange,
+  onDeleteBlock,
+  onCreateField,
+  onPeekCountChange,
+  onRowChange,
+  onAddToRow,
+  onRemoveFromRow,
+}: Props) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      onReorder(String(active.id), String(over.id));
+    }
+  };
+
+  const fieldMap = new Map(customFields.map((f) => [f.id, f]));
+  const nodeIds = nodes.map((n) => n.id);
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={nodeIds} strategy={verticalListSortingStrategy}>
+        <div className="flex flex-col gap-2">
+          {nodes.map((node, index) => (
+            <div key={node.id}>
+              {index === peekBlockCount && (
+                <PeekBoundary
+                  peekBlockCount={peekBlockCount}
+                  totalBlocks={nodes.length}
+                  onChange={onPeekCountChange}
+                />
+              )}
+              {isLayoutRow(node) ? (
+                <RowEditor
+                  row={node}
+                  customFields={customFields}
+                  entityTypes={entityTypes}
+                  fieldMap={fieldMap}
+                  expandedId={expandedId}
+                  onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
+                  onConfigChange={onConfigChange}
+                  onDeleteBlock={onDeleteBlock}
+                  onCreateField={onCreateField}
+                  onRowChange={onRowChange}
+                  onAddToRow={onAddToRow}
+                  onRemoveFromRow={onRemoveFromRow}
+                />
+              ) : (
+                <BlockListItem
+                  block={node}
+                  customFields={customFields}
+                  entityTypes={entityTypes}
+                  fieldName={
+                    node.type === 'field_display'
+                      ? fieldMap.get((node.config as { fieldId: string }).fieldId)?.name
+                      : undefined
+                  }
+                  onConfigChange={onConfigChange}
+                  onDelete={onDeleteBlock}
+                  onCreateField={onCreateField}
+                  isExpanded={expandedId === node.id}
+                  onToggleExpand={() => setExpandedId(expandedId === node.id ? null : node.id)}
+                />
+              )}
+            </div>
+          ))}
+          {nodes.length > 0 && peekBlockCount >= nodes.length && (
+            <PeekBoundary
+              peekBlockCount={peekBlockCount}
+              totalBlocks={nodes.length}
+              onChange={onPeekCountChange}
+            />
+          )}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+```
+
+- [ ] **Step 8: Create RowEditor**
+
+```tsx
+// src/components/layout/builder/RowEditor.tsx
+'use client';
+
+import type { LayoutRow, BlockConfig } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import BlockListItem from './BlockListItem';
+import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface Props {
+  row: LayoutRow;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  fieldMap: Map<string, CustomField>;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDeleteBlock: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  onRowChange: (rowId: string, update: Partial<{ gap: string; distribution: string | number[] }>) => void;
+  onAddToRow: (rowId: string, blockType: string) => void;
+  onRemoveFromRow: (rowId: string, blockId: string) => void;
+}
+
+export default function RowEditor({
+  row,
+  customFields,
+  entityTypes,
+  fieldMap,
+  expandedId,
+  onToggleExpand,
+  onConfigChange,
+  onDeleteBlock,
+  onCreateField,
+  onRowChange,
+  onAddToRow,
+  onRemoveFromRow,
+}: Props) {
+  const [showRowConfig, setShowRowConfig] = useState(false);
+
+  return (
+    <div className="border-2 border-dashed border-sage rounded-lg p-2 space-y-2">
+      {/* Row header */}
+      <div className="flex items-center justify-between min-h-[44px]">
+        <button
+          onClick={() => setShowRowConfig(!showRowConfig)}
+          className="flex items-center gap-2 text-sm font-medium text-forest-dark"
+        >
+          {showRowConfig ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          Row ({row.children.length} columns, {typeof row.distribution === 'string' ? row.distribution : 'custom'})
+        </button>
+        <button
+          onClick={() => onDeleteBlock(row.id)}
+          className="p-2 text-sage hover:text-red-500"
+          aria-label="Delete row"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Row config */}
+      {showRowConfig && (
+        <div className="space-y-2 px-2 pb-2 border-b border-sage-light">
+          <div>
+            <label className="label">Distribution</label>
+            <div className="flex gap-1">
+              {(['equal', 'auto'] as const).map((d) => (
+                <button
+                  key={d}
+                  onClick={() => onRowChange(row.id, { distribution: d })}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium ${
+                    row.distribution === d ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {d.charAt(0).toUpperCase() + d.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <label className="label">Gap</label>
+            <div className="flex gap-1">
+              {(['tight', 'normal', 'loose'] as const).map((g) => (
+                <button
+                  key={g}
+                  onClick={() => onRowChange(row.id, { gap: g })}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium ${
+                    row.gap === g ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {g.charAt(0).toUpperCase() + g.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Children */}
+      <div className="pl-3 border-l-2 border-sage-light space-y-2">
+        {row.children.map((child) => (
+          <BlockListItem
+            key={child.id}
+            block={child}
+            customFields={customFields}
+            entityTypes={entityTypes}
+            fieldName={
+              child.type === 'field_display'
+                ? fieldMap.get((child.config as { fieldId: string }).fieldId)?.name
+                : undefined
+            }
+            onConfigChange={onConfigChange}
+            onDelete={(id) => onRemoveFromRow(row.id, id)}
+            onCreateField={onCreateField}
+            isExpanded={expandedId === child.id}
+            onToggleExpand={() => onToggleExpand(child.id)}
+          />
+        ))}
+        {row.children.length < 4 && (
+          <button
+            onClick={() => onAddToRow(row.id, 'field_display')}
+            className="w-full py-2 border-2 border-dashed border-sage-light rounded-lg text-xs text-sage font-medium hover:border-forest hover:text-forest transition-colors min-h-[44px]"
+          >
+            + Add to row
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9: Create the main LayoutBuilder orchestrator**
+
+This is the largest single component. It manages all layout state and delegates rendering to sub-components.
+
+```tsx
+// src/components/layout/builder/LayoutBuilder.tsx
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { nanoid } from 'nanoid';
+import { arrayMove } from '@dnd-kit/sortable';
+import type { TypeLayout, LayoutNode, LayoutBlock, LayoutRow, BlockType, BlockConfig, SpacingPreset } from '@/lib/layout/types';
+import { isLayoutRow } from '@/lib/layout/types';
+import type { CustomField, EntityType, ItemType } from '@/lib/types';
+import { generateDefaultLayout } from '@/lib/layout/defaults';
+import { generateMockItem } from '@/lib/layout/mock-data';
+import BlockPalette from './BlockPalette';
+import BlockList from './BlockList';
+import SpacingPicker from './SpacingPicker';
+import LayoutRenderer from '../LayoutRenderer';
+import FormPreview from '../preview/FormPreview';
+
+interface Props {
+  itemType: ItemType;
+  initialLayout: TypeLayout | null;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  onSave: (layout: TypeLayout, newFields: { name: string; field_type: string; options: string[]; required: boolean }[]) => Promise<void>;
+  onCancel: () => void;
+}
+
+type PreviewTab = 'detail' | 'form';
+
+function getDefaultConfig(type: BlockType): BlockConfig {
+  switch (type) {
+    case 'field_display': return { fieldId: '', size: 'normal' as const, showLabel: true };
+    case 'photo_gallery': return { style: 'hero' as const, maxPhotos: 4 };
+    case 'timeline': return { showUpdates: true, showScheduled: false, maxItems: 5 };
+    case 'text_label': return { text: 'Section Title', style: 'heading' as const };
+    case 'entity_list': return { entityTypeIds: [] };
+    default: return {};
+  }
+}
+
+export default function LayoutBuilder({ itemType, initialLayout, customFields, entityTypes, onSave, onCancel }: Props) {
+  const [layout, setLayout] = useState<TypeLayout>(
+    () => initialLayout ?? generateDefaultLayout(customFields),
+  );
+  const [pendingFields, setPendingFields] = useState<{ name: string; field_type: string; options: string[]; required: boolean; tempId: string }[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [activeTab, setActiveTab] = useState<'build' | 'detail' | 'form'>('build');
+  const [previewTab, setPreviewTab] = useState<PreviewTab>('detail');
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  // Combine real fields + pending fields for preview
+  const allFields: CustomField[] = [
+    ...customFields,
+    ...pendingFields.map((f, i) => ({
+      id: f.tempId,
+      item_type_id: itemType.id,
+      name: f.name,
+      field_type: f.field_type as CustomField['field_type'],
+      options: f.options.length > 0 ? f.options : null,
+      required: f.required,
+      sort_order: customFields.length + i,
+      org_id: itemType.org_id,
+    })),
+  ];
+
+  const mockItem = generateMockItem(itemType, allFields);
+
+  const handleAddBlock = useCallback((type: BlockType | 'row') => {
+    setLayout((prev) => {
+      if (type === 'row') {
+        const newRow: LayoutRow = {
+          id: nanoid(10),
+          type: 'row',
+          children: [
+            { id: nanoid(10), type: 'status_badge', config: {} },
+            { id: nanoid(10), type: 'status_badge', config: {} },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        };
+        return { ...prev, blocks: [...prev.blocks, newRow] };
+      }
+      const newBlock: LayoutBlock = {
+        id: nanoid(10),
+        type: type,
+        config: getDefaultConfig(type),
+      };
+      return { ...prev, blocks: [...prev.blocks, newBlock] };
+    });
+  }, []);
+
+  const handleReorder = useCallback((activeId: string, overId: string) => {
+    setLayout((prev) => {
+      const oldIndex = prev.blocks.findIndex((b) => b.id === activeId);
+      const newIndex = prev.blocks.findIndex((b) => b.id === overId);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      return { ...prev, blocks: arrayMove(prev.blocks, oldIndex, newIndex) };
+    });
+  }, []);
+
+  const handleConfigChange = useCallback((blockId: string, config: BlockConfig) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) => {
+        if (node.id === blockId && !isLayoutRow(node)) {
+          return { ...node, config };
+        }
+        if (isLayoutRow(node)) {
+          return {
+            ...node,
+            children: node.children.map((c) =>
+              c.id === blockId ? { ...c, config } : c,
+            ),
+          };
+        }
+        return node;
+      }),
+    }));
+  }, []);
+
+  const handleDeleteBlock = useCallback((blockId: string) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.filter((b) => b.id !== blockId),
+    }));
+  }, []);
+
+  const handleCreateField = useCallback((field: { name: string; field_type: string; options: string[]; required: boolean }) => {
+    const tempId = `temp-${nanoid(10)}`;
+    setPendingFields((prev) => [...prev, { ...field, tempId }]);
+    // Auto-update the last field_display block that has no fieldId
+    setLayout((prev) => {
+      const blocks = [...prev.blocks];
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const node = blocks[i];
+        if (!isLayoutRow(node) && node.type === 'field_display' && !(node.config as { fieldId: string }).fieldId) {
+          blocks[i] = { ...node, config: { ...(node.config as object), fieldId: tempId } as BlockConfig };
+          return { ...prev, blocks };
+        }
+      }
+      return prev;
+    });
+  }, []);
+
+  const handlePeekCountChange = useCallback((count: number) => {
+    setLayout((prev) => ({ ...prev, peekBlockCount: count }));
+  }, []);
+
+  const handleSpacingChange = useCallback((spacing: SpacingPreset) => {
+    setLayout((prev) => ({ ...prev, spacing }));
+  }, []);
+
+  const handleRowChange = useCallback((rowId: string, update: Partial<{ gap: string; distribution: string | number[] }>) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) =>
+        node.id === rowId && isLayoutRow(node) ? { ...node, ...update } : node,
+      ),
+    }));
+  }, []);
+
+  const handleAddToRow = useCallback((rowId: string, blockType: string) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) => {
+        if (node.id === rowId && isLayoutRow(node) && node.children.length < 4) {
+          return {
+            ...node,
+            children: [
+              ...node.children,
+              { id: nanoid(10), type: blockType as BlockType, config: getDefaultConfig(blockType as BlockType) },
+            ],
+          };
+        }
+        return node;
+      }),
+    }));
+  }, []);
+
+  const handleRemoveFromRow = useCallback((rowId: string, blockId: string) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) => {
+        if (node.id === rowId && isLayoutRow(node)) {
+          const remaining = node.children.filter((c) => c.id !== blockId);
+          // If only 1 child remains, unwrap the row
+          if (remaining.length <= 1) {
+            return remaining[0] ?? node; // Replace row with single child
+          }
+          return { ...node, children: remaining };
+        }
+        return node;
+      }).filter((node) => {
+        // Remove row if it was replaced by a single child above (handled via map)
+        return true;
+      }),
+    }));
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(layout, pendingFields.map(({ tempId, ...rest }) => rest));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Build panel content
+  const buildContent = (
+    <div className="space-y-4">
+      <BlockPalette onAdd={handleAddBlock} />
+      <SpacingPicker value={layout.spacing} onChange={handleSpacingChange} />
+      <BlockList
+        nodes={layout.blocks}
+        customFields={allFields}
+        entityTypes={entityTypes}
+        peekBlockCount={layout.peekBlockCount}
+        onReorder={handleReorder}
+        onConfigChange={handleConfigChange}
+        onDeleteBlock={handleDeleteBlock}
+        onCreateField={handleCreateField}
+        onPeekCountChange={handlePeekCountChange}
+        onRowChange={handleRowChange}
+        onAddToRow={handleAddToRow}
+        onRemoveFromRow={handleRemoveFromRow}
+      />
+    </div>
+  );
+
+  const detailPreview = (
+    <div className="bg-gray-100 rounded-xl p-3">
+      <div className="bg-white rounded-xl shadow-lg p-4 max-h-[70vh] overflow-y-auto">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xl">{itemType.icon}</span>
+          <h2 className="font-heading font-semibold text-forest-dark text-xl">{mockItem.name}</h2>
+        </div>
+        <LayoutRenderer
+          layout={layout}
+          item={mockItem}
+          mode="preview"
+          context="preview"
+          customFields={allFields}
+        />
+      </div>
+    </div>
+  );
+
+  const formPreviewContent = (
+    <FormPreview layout={layout} customFields={allFields} itemTypeName={itemType.name} />
+  );
+
+  // Mobile: full-screen with tabs
+  if (isMobile) {
+    return (
+      <div className="fixed inset-0 z-50 bg-white flex flex-col" style={{ height: '100dvh' }}>
+        {/* Sticky header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-sage-light">
+          <button onClick={onCancel} className="text-sm text-forest font-medium">
+            Cancel
+          </button>
+          <span className="text-sm font-semibold text-forest-dark">{itemType.name} Layout</span>
+          <button onClick={handleSave} disabled={saving} className="btn-primary text-sm px-4 py-1.5">
+            {saving ? 'Saving...' : 'Done'}
+          </button>
+        </div>
+
+        {/* Tab toggle */}
+        <div className="flex border-b border-sage-light">
+          {(['build', 'detail', 'form'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                activeTab === tab
+                  ? 'text-forest border-b-2 border-forest'
+                  : 'text-sage'
+              }`}
+            >
+              {tab === 'build' ? 'Build' : tab === 'detail' ? 'Detail' : 'Form'}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {activeTab === 'build' && buildContent}
+          {activeTab === 'detail' && detailPreview}
+          {activeTab === 'form' && formPreviewContent}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: side-by-side
+  return (
+    <div className="flex gap-6 min-h-[600px]">
+      {/* Builder panel */}
+      <div className="flex-[3] overflow-y-auto pr-4 border-r border-sage-light">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-heading font-semibold text-forest-dark">Layout Builder</h3>
+          <div className="flex gap-2">
+            <button onClick={onCancel} className="btn-secondary text-sm">Cancel</button>
+            <button onClick={handleSave} disabled={saving} className="btn-primary text-sm">
+              {saving ? 'Saving...' : 'Save Layout'}
+            </button>
+          </div>
+        </div>
+        {buildContent}
+      </div>
+
+      {/* Preview panel */}
+      <div className="flex-[2] overflow-y-auto">
+        <div className="flex gap-1 mb-3">
+          {(['detail', 'form'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setPreviewTab(tab)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium ${
+                previewTab === tab ? 'bg-forest text-white' : 'bg-sage-light text-forest-dark'
+              }`}
+            >
+              {tab === 'detail' ? 'Detail Preview' : 'Form Preview'}
+            </button>
+          ))}
+        </div>
+        {previewTab === 'detail' ? detailPreview : formPreviewContent}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 10: Verify the app compiles**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run type-check`
+Expected: No type errors. Fix any type mismatches.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/components/layout/builder/
+git commit -m "feat: add layout builder with drag-and-drop, inline config, and responsive design"
+```
+
+---
+
+## Task 13: Form Preview Component
+
+**Files:**
+- Create: `src/components/layout/preview/FormPreview.tsx`
+- Create: `src/components/layout/preview/DetailPreview.tsx`
+
+- [ ] **Step 1: Create FormPreview**
+
+```tsx
+// src/components/layout/preview/FormPreview.tsx
+'use client';
+
+import type { TypeLayout } from '@/lib/layout/types';
+import type { CustomField } from '@/lib/types';
+import { deriveFormFields } from '@/lib/layout/form-derivation';
+
+interface Props {
+  layout: TypeLayout;
+  customFields: CustomField[];
+  itemTypeName: string;
+}
+
+export default function FormPreview({ layout, customFields, itemTypeName }: Props) {
+  const derived = deriveFormFields(layout, customFields);
+
+  return (
+    <div className="bg-gray-100 rounded-xl p-3">
+      <div className="bg-white rounded-xl shadow-lg p-4 space-y-4">
+        <h3 className="font-heading font-semibold text-forest-dark text-lg">
+          Add {itemTypeName}
+        </h3>
+
+        {/* Fixed: Name */}
+        <div>
+          <label className="label">Name <span className="text-red-500">*</span></label>
+          <input type="text" className="input-field" placeholder={`e.g., ${itemTypeName} #1`} disabled />
+        </div>
+
+        {/* Fixed: Location */}
+        <div>
+          <label className="label">Location <span className="text-red-500">*</span></label>
+          <div className="h-24 bg-sage-light/50 rounded-lg flex items-center justify-center text-xs text-sage">
+            Location picker
+          </div>
+        </div>
+
+        {/* Layout-derived fields with sections */}
+        {derived.fields.map((field, index) => {
+          const section = derived.sections.find((s) => s.beforeFieldIndex === index);
+          const isInRow = derived.rows.some((r) => r.fieldIds.includes(field.id));
+
+          // Check if this is the start of a row
+          const row = derived.rows.find((r) => r.fieldIds[0] === field.id);
+          const rowFields = row ? row.fieldIds.map((id) => derived.fields.find((f) => f.id === id)).filter(Boolean) : null;
+
+          if (isInRow && !row) return null; // Will be rendered as part of the row
+
+          return (
+            <div key={field.id}>
+              {section && (
+                <p className="text-sm font-semibold text-forest-dark mt-2">{section.text}</p>
+              )}
+              {rowFields ? (
+                <div className="grid grid-cols-2 gap-3">
+                  {rowFields.map((rf) => rf && (
+                    <div key={rf.id}>
+                      <label className="label">
+                        {rf.name} {rf.required && <span className="text-red-500">*</span>}
+                      </label>
+                      {renderFieldInput(rf)}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div>
+                  <label className="label">
+                    {field.name} {field.required && <span className="text-red-500">*</span>}
+                  </label>
+                  {renderFieldInput(field)}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Photo uploader placeholder */}
+        <div>
+          <label className="label">Photos</label>
+          <div className="h-16 border-2 border-dashed border-sage-light rounded-lg flex items-center justify-center text-xs text-sage">
+            + Add photos
+          </div>
+        </div>
+
+        {/* Fixed: Submit */}
+        <div className="flex gap-2 pt-2">
+          <button className="btn-primary flex-1 opacity-60 cursor-default">Save</button>
+          <button className="btn-secondary flex-1 opacity-60 cursor-default">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderFieldInput(field: CustomField) {
+  switch (field.field_type) {
+    case 'dropdown':
+      return (
+        <select className="input-field" disabled>
+          <option>Select {field.name}...</option>
+          {field.options?.map((opt) => <option key={opt}>{opt}</option>)}
+        </select>
+      );
+    case 'number':
+      return <input type="number" className="input-field" placeholder="0" disabled />;
+    case 'date':
+      return <input type="date" className="input-field" disabled />;
+    default:
+      return <input type="text" className="input-field" placeholder={`Enter ${field.name.toLowerCase()}`} disabled />;
+  }
+}
+```
+
+- [ ] **Step 2: Create DetailPreview (wrapper component for the builder)**
+
+```tsx
+// src/components/layout/preview/DetailPreview.tsx
+'use client';
+
+import type { TypeLayout } from '@/lib/layout/types';
+import type { ItemWithDetails, CustomField } from '@/lib/types';
+import LayoutRenderer from '../LayoutRenderer';
+
+interface Props {
+  layout: TypeLayout;
+  mockItem: ItemWithDetails;
+  customFields: CustomField[];
+  itemTypeIcon: string;
+}
+
+export default function DetailPreview({ layout, mockItem, customFields, itemTypeIcon }: Props) {
+  return (
+    <div className="bg-gray-100 rounded-xl p-3">
+      {/* Simulated bottom sheet */}
+      <div className="bg-white rounded-t-2xl shadow-lg">
+        {/* Handle */}
+        <div className="flex justify-center py-3">
+          <div className="w-10 h-1 rounded-full bg-gray-300" />
+        </div>
+
+        {/* Peek boundary indicator */}
+        <div className="px-4 pb-4 max-h-[70vh] overflow-y-auto">
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-xl">{itemTypeIcon}</span>
+            <h2 className="font-heading font-semibold text-forest-dark text-xl">
+              {mockItem.name}
+            </h2>
+          </div>
+
+          {/* Layout content */}
+          <LayoutRenderer
+            layout={layout}
+            item={mockItem}
+            mode="preview"
+            context="preview"
+            customFields={customFields}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/layout/preview/
+git commit -m "feat: add detail and form preview components for layout builder"
+```
+
+---
+
+## Task 14: Admin Page Integration
+
+**Files:**
+- Modify: `src/app/admin/properties/[slug]/types/page.tsx`
+
+This task refactors the types admin page to add a Layout tab when editing an item type, integrating the LayoutBuilder component.
+
+- [ ] **Step 1: Read the current types page**
+
+Read `src/app/admin/properties/[slug]/types/page.tsx` to understand the full current structure before modifying.
+
+- [ ] **Step 2: Add layout builder integration to the types page**
+
+The key changes:
+1. When an item type is expanded, show tabs: Layout / Fields / Settings
+2. Layout tab renders the `LayoutBuilder` component
+3. Fields tab shows the existing `CustomFieldEditor`
+4. Settings tab shows the existing `ItemTypeEditor` controls (name, icon, color, delete)
+5. Import and call `saveTypeWithLayout` server action from the layout builder's onSave
+
+Add the following to the expanded item type section in the page:
+
+```tsx
+// Inside the expanded item type section, replace the inline editing with tabs:
+import LayoutBuilder from '@/components/layout/builder/LayoutBuilder';
+import { saveTypeWithLayout } from './layout-actions';
+
+// Add tab state:
+const [activeTab, setActiveTab] = useState<'layout' | 'fields' | 'settings'>('layout');
+
+// Tab bar:
+<div className="flex border-b border-sage-light mb-4">
+  {(['layout', 'fields', 'settings'] as const).map((tab) => (
+    <button
+      key={tab}
+      onClick={() => setActiveTab(tab)}
+      className={`px-4 py-2 text-sm font-medium ${
+        activeTab === tab
+          ? 'text-forest border-b-2 border-forest'
+          : 'text-sage hover:text-forest-dark'
+      }`}
+    >
+      {tab.charAt(0).toUpperCase() + tab.slice(1)}
+    </button>
+  ))}
+</div>
+
+// Tab content:
+{activeTab === 'layout' && (
+  <LayoutBuilder
+    itemType={type}
+    initialLayout={type.layout}
+    customFields={fieldsForType}
+    entityTypes={entityTypes}
+    onSave={async (layout, newFields) => {
+      const result = await saveTypeWithLayout({
+        itemTypeId: type.id,
+        layout,
+        newFields: newFields.map((f, i) => ({ ...f, sort_order: fieldsForType.length + i })),
+      });
+      if ('error' in result) throw new Error(result.error);
+      queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'types'] });
+    }}
+    onCancel={() => setActiveTab('settings')}
+  />
+)}
+{activeTab === 'fields' && <CustomFieldEditor ... />}
+{activeTab === 'settings' && <ItemTypeEditor ... />}
+```
+
+The exact integration depends on the current page structure. Read the file, identify the expanded type section, and add the tab system around the existing content. Keep all existing functionality intact — just reorganize it under tabs.
+
+- [ ] **Step 3: Verify the app compiles and renders**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run type-check && npm run build`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/types/page.tsx
+git commit -m "feat: integrate layout builder into item type admin page with tabs"
+```
+
+---
+
+## Task 15: Type Check + Build Verification
+
+- [ ] **Step 1: Run full type check**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run type-check`
+Expected: 0 errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run test`
+Expected: All tests pass (new + existing)
+
+- [ ] **Step 3: Run build**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Fix any issues found**
+
+If any tests fail or type errors exist, fix them in the relevant files.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve type errors and test failures from layout builder integration"
+```
+
+---
+
+## Task 16: Field Lifecycle — Deletion Cascade + Sync
+
+**Files:**
+- Create: `src/lib/layout/field-sync.ts`
+- Create: `src/lib/layout/__tests__/field-sync.test.ts`
+
+This task implements the critical field lifecycle logic: when a custom field is deleted, its corresponding layout block must be auto-removed. When a field is created via the Fields tab, the builder must show a notification.
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/lib/layout/__tests__/field-sync.test.ts
+import { describe, it, expect } from 'vitest';
+import { removeFieldFromLayout, findFieldsNotInLayout } from '../field-sync';
+import type { TypeLayout } from '../types';
+
+describe('removeFieldFromLayout', () => {
+  it('removes a field_display block referencing the deleted field', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+        { id: 'b3', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = removeFieldFromLayout(layout, 'f1');
+    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks.find((b) => b.type === 'field_display' && (b as any).config.fieldId === 'f1')).toBeUndefined();
+  });
+
+  it('removes a field_display from inside a row', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = removeFieldFromLayout(layout, 'f1');
+    // Row should still exist with 1 child — but rows need 2+ children, so it should unwrap
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0].type).toBe('field_display');
+  });
+
+  it('returns layout unchanged if field not referenced', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'status_badge', config: {} }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = removeFieldFromLayout(layout, 'f999');
+    expect(result.blocks).toHaveLength(1);
+  });
+});
+
+describe('findFieldsNotInLayout', () => {
+  it('finds fields not referenced by any field_display block', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const fieldIds = ['f1', 'f2', 'f3'];
+    const missing = findFieldsNotInLayout(layout, fieldIds);
+    expect(missing).toEqual(['f2', 'f3']);
+  });
+
+  it('checks inside rows too', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const missing = findFieldsNotInLayout(layout, ['f1', 'f2', 'f3']);
+    expect(missing).toEqual(['f3']);
+  });
+
+  it('returns empty array when all fields are in layout', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const missing = findFieldsNotInLayout(layout, ['f1']);
+    expect(missing).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/field-sync.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement field sync logic**
+
+```typescript
+// src/lib/layout/field-sync.ts
+import type { TypeLayout, LayoutNode, LayoutBlock, LayoutRow, FieldDisplayConfig } from './types';
+import { isLayoutRow } from './types';
+
+/**
+ * Remove all field_display blocks referencing a given fieldId.
+ * If a row is left with <2 children, unwrap it to a single block.
+ */
+export function removeFieldFromLayout(layout: TypeLayout, fieldId: string): TypeLayout {
+  const blocks: LayoutNode[] = [];
+
+  for (const node of layout.blocks) {
+    if (isLayoutRow(node)) {
+      const filtered = node.children.filter(
+        (c) => !(c.type === 'field_display' && (c.config as FieldDisplayConfig).fieldId === fieldId),
+      );
+      if (filtered.length === 0) continue; // Row fully emptied
+      if (filtered.length === 1) {
+        blocks.push(filtered[0]); // Unwrap single-child row
+      } else {
+        blocks.push({ ...node, children: filtered });
+      }
+    } else {
+      if (node.type === 'field_display' && (node.config as FieldDisplayConfig).fieldId === fieldId) {
+        continue; // Skip deleted field's block
+      }
+      blocks.push(node);
+    }
+  }
+
+  return { ...layout, blocks };
+}
+
+/**
+ * Find field IDs that are not referenced by any field_display block in the layout.
+ */
+export function findFieldsNotInLayout(layout: TypeLayout, fieldIds: string[]): string[] {
+  const inLayout = new Set<string>();
+
+  function scanBlock(block: LayoutBlock) {
+    if (block.type === 'field_display') {
+      inLayout.add((block.config as FieldDisplayConfig).fieldId);
+    }
+  }
+
+  for (const node of layout.blocks) {
+    if (isLayoutRow(node)) {
+      node.children.forEach(scanBlock);
+    } else {
+      scanBlock(node);
+    }
+  }
+
+  return fieldIds.filter((id) => !inLayout.has(id));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/field-sync.test.ts`
+Expected: PASS — all 6 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/layout/field-sync.ts src/lib/layout/__tests__/field-sync.test.ts
+git commit -m "feat: add field sync logic for layout deletion cascade and missing field detection"
+```
+
+---
+
+## Task 17: FAB Repositioning with Bottom Sheet State
+
+**Files:**
+- Modify: `src/components/map/MapView.tsx`
+
+The quick-add FAB must reposition above the bottom sheet in peek state and hide in half/full state.
+
+- [ ] **Step 1: Add sheetState prop to MapView**
+
+The parent of both `MapView` and `DetailPanel` needs to share `sheetState`. The simplest approach: lift `sheetState` up to the map page and pass it down.
+
+In `MapView.tsx`, add a prop:
+
+```typescript
+interface MapViewProps {
+  // ... existing props
+  sheetState?: 'peek' | 'half' | 'full' | null; // null = no sheet open
+}
+```
+
+- [ ] **Step 2: Conditionally position the FAB**
+
+Replace the existing FAB button in `MapView.tsx`:
+
+```tsx
+{/* Quick-add FAB — reposition based on bottom sheet state */}
+{sheetState !== 'half' && sheetState !== 'full' && (
+  <button
+    onClick={() => setQuickAddOpen(true)}
+    className={`fixed right-4 z-30 bg-green-600 hover:bg-green-700 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-3xl font-light transition-all duration-300 ${
+      sheetState === 'peek' ? 'bottom-[calc(25vh+1rem)]' : 'bottom-24'
+    }`}
+    aria-label="Quick add item"
+  >
+    +
+  </button>
+)}
+```
+
+- [ ] **Step 3: Wire sheetState from the parent page to MapView**
+
+In the parent page that renders both `MapView` and `DetailPanel`, add state:
+
+```typescript
+const [sheetState, setSheetState] = useState<'peek' | 'half' | 'full' | null>(null);
+```
+
+Pass to `MapView` as `sheetState={selectedItem ? sheetState : null}` and wire `DetailPanel`'s `onStateChange` to `setSheetState`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/map/MapView.tsx
+git commit -m "feat: reposition quick-add FAB based on bottom sheet state"
+```
+
+---
+
+## Task 18: Safe Area + Bottom Sheet Polish
+
+**Files:**
+- Modify: `src/components/ui/MultiSnapBottomSheet.tsx`
+
+- [ ] **Step 1: Add safe area insets**
+
+Update the sheet container's style in `MultiSnapBottomSheet.tsx`:
+
+```tsx
+style={{
+  height: `${height}px`,
+  paddingBottom: 'env(safe-area-inset-bottom)',
+}}
+```
+
+(Already present in Task 8 implementation — verify it's there.)
+
+- [ ] **Step 2: Add "swipe up for more" affordance**
+
+After the handle and before the content div, add a chevron indicator visible only in peek state:
+
+```tsx
+{/* Swipe affordance — visible in peek state */}
+{state === 'peek' && (
+  <div className="flex justify-center -mt-1 mb-1">
+    <svg className="w-4 h-4 text-gray-400 animate-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+    </svg>
+  </div>
+)}
+```
+
+- [ ] **Step 3: Add bottom fade gradient for scroll overflow**
+
+In the content div, add an overlay for the fade effect:
+
+```tsx
+<div className="relative" style={{ height: `calc(100% - 40px)` }}>
+  <div
+    ref={contentRef}
+    className="overflow-y-auto px-4 pb-4 h-full"
+  >
+    {children}
+  </div>
+  {/* Bottom fade gradient when content overflows */}
+  <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent" />
+</div>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ui/MultiSnapBottomSheet.tsx
+git commit -m "feat: add safe area insets, swipe affordance, and scroll fade to bottom sheet"
+```
+
+---
+
+## Task 19: Integration Tests
+
+**Files:**
+- Create: `src/lib/layout/__tests__/integration.test.ts`
+
+- [ ] **Step 1: Write integration tests covering end-to-end layout flows**
+
+```typescript
+// src/lib/layout/__tests__/integration.test.ts
+import { describe, it, expect } from 'vitest';
+import { typeLayoutSchema } from '../schemas';
+import { generateDefaultLayout } from '../defaults';
+import { generateMockItem } from '../mock-data';
+import { deriveFormFields } from '../form-derivation';
+import { removeFieldFromLayout, findFieldsNotInLayout } from '../field-sync';
+import type { CustomField, ItemType } from '@/lib/types';
+
+const itemType: ItemType = {
+  id: 't1',
+  name: 'Bird Box',
+  icon: '🏠',
+  color: '#5D7F3A',
+  sort_order: 0,
+  created_at: '2026-01-01',
+  org_id: 'o1',
+  layout: null,
+};
+
+const fields: CustomField[] = [
+  { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin', 'Wren'], required: true, sort_order: 0, org_id: 'o1' },
+  { id: 'f2', item_type_id: 't1', name: 'Install Date', field_type: 'date', options: null, required: false, sort_order: 1, org_id: 'o1' },
+  { id: 'f3', item_type_id: 't1', name: 'Height', field_type: 'number', options: null, required: false, sort_order: 2, org_id: 'o1' },
+];
+
+describe('Layout system integration', () => {
+  it('full lifecycle: generate → validate → mock → derive form → delete field', () => {
+    // 1. Generate default layout
+    const layout = generateDefaultLayout(fields);
+    expect(layout.blocks.length).toBeGreaterThan(3); // status + photo + 3 fields + actions
+
+    // 2. Validate generated layout
+    const validated = typeLayoutSchema.safeParse(layout);
+    expect(validated.success).toBe(true);
+
+    // 3. Generate mock item for preview
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe('Robin');
+    expect(mock.custom_field_values['f2']).toBeDefined();
+    expect(mock.custom_field_values['f3']).toBe(42);
+
+    // 4. Derive form fields
+    const form = deriveFormFields(layout, fields);
+    expect(form.fields).toHaveLength(3);
+    expect(form.fields[0].name).toBe('Species');
+    expect(form.fields[1].name).toBe('Install Date');
+    expect(form.fields[2].name).toBe('Height');
+
+    // 5. Delete a field — layout updates
+    const updated = removeFieldFromLayout(layout, 'f2');
+    expect(updated.blocks.length).toBe(layout.blocks.length - 1);
+
+    // 6. Validate updated layout still valid
+    const revalidated = typeLayoutSchema.safeParse(updated);
+    expect(revalidated.success).toBe(true);
+
+    // 7. Derive form after deletion — should have 2 fields
+    const formAfterDelete = deriveFormFields(updated, fields.filter((f) => f.id !== 'f2'));
+    expect(formAfterDelete.fields).toHaveLength(2);
+  });
+
+  it('backward compatibility: null layout handled gracefully', () => {
+    // Layout is null — form derivation and field sync should handle this
+    const emptyFields = findFieldsNotInLayout(
+      { version: 1, blocks: [], spacing: 'comfortable', peekBlockCount: 0 } as any,
+      ['f1', 'f2'],
+    );
+    // With an empty layout, all fields are "not in layout"
+    expect(emptyFields).toEqual(['f1', 'f2']);
+  });
+
+  it('field sync detects fields not in layout', () => {
+    const layout = generateDefaultLayout([fields[0]]); // Only Species
+    const missing = findFieldsNotInLayout(layout, ['f1', 'f2', 'f3']);
+    expect(missing).toEqual(['f2', 'f3']);
+  });
+
+  it('layout with rows validates and derives form correctly', () => {
+    const layoutWithRow = generateDefaultLayout(fields);
+    // Manually wrap first two fields in a row
+    const fieldBlocks = layoutWithRow.blocks.filter((b) => b.type === 'field_display');
+    const otherBlocks = layoutWithRow.blocks.filter((b) => b.type !== 'field_display');
+
+    const rowLayout = {
+      ...layoutWithRow,
+      blocks: [
+        ...otherBlocks.slice(0, -1), // everything except action_buttons
+        {
+          id: 'row1',
+          type: 'row' as const,
+          children: [fieldBlocks[0], fieldBlocks[1]],
+          gap: 'normal' as const,
+          distribution: 'equal' as const,
+        },
+        fieldBlocks[2],
+        otherBlocks[otherBlocks.length - 1], // action_buttons
+      ],
+    };
+
+    // Validates
+    const validated = typeLayoutSchema.safeParse(rowLayout);
+    expect(validated.success).toBe(true);
+
+    // Form derivation finds row
+    const form = deriveFormFields(rowLayout, fields);
+    expect(form.rows).toHaveLength(1);
+    expect(form.rows[0].fieldIds).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/layout/__tests__/integration.test.ts`
+Expected: PASS — all 4 tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/layout/__tests__/integration.test.ts
+git commit -m "test: add integration tests for full layout system lifecycle"
+```
+
+---
+
+## Notes for Implementation
+
+### Type Compatibility
+
+The `ItemWithDetails` type in `src/lib/types.ts` must include the `item_type` field with the `layout` property. Verify this by reading the type definition. If `ItemWithDetails` doesn't include `item_type.layout`, you'll need to update the Supabase query that fetches items to include the layout column.
+
+### Offline Sync
+
+The `layout` field on `item_types` is automatically included in the Dexie cache since it's part of the record. No Dexie schema version bump is needed — JSONB fields are stored as-is in IndexedDB. Verify by checking that `offlineStore.getItemTypes()` returns records with the `layout` field.
+
+### Mock Data Adjustment
+
+The `generateMockItem` function in Task 5 produces an `ItemWithDetails` object. The exact shape must match what `DetailPanel` and `LayoutRenderer` expect. If the shape diverges from the current `ItemWithDetails` type, adjust the mock. Check `src/lib/types.ts` for the canonical definition.
+
+### Entity Types in Builder
+
+The builder needs access to `EntityType[]` for the EntityListBlock config panel. The admin page should fetch entity types alongside item types. Check if the current page already queries entity types; if not, add a React Query call.

--- a/docs/superpowers/specs/2026-04-03-item-type-layout-builder-design.md
+++ b/docs/superpowers/specs/2026-04-03-item-type-layout-builder-design.md
@@ -1,0 +1,480 @@
+# Item Type Layout Builder
+
+**Date:** 2026-04-03
+**Status:** Draft
+
+## Problem
+
+The current ItemType system separates data definition (custom fields) from presentation (a fixed DetailPanel layout). Every item type renders identically regardless of its purpose. Admins define fields in one place and have no control over how items appear when tapped on the map. This limits the expressiveness of a system designed to be flexible and expandable.
+
+## Solution
+
+A layout-first type creation experience with a custom drag-and-drop builder. Admins compose a visual layout from a palette of blocks — adding custom fields inline as they build. A live preview renders the actual DetailPanel component with mock data so admins see exactly what end users will see. The layout is stored as JSON on the ItemType and interpreted at render time.
+
+## Design Principles
+
+- **Layout is the type.** The builder is the primary interface for defining what an item type captures and how it displays. Data structure follows layout, not the other way around.
+- **What you see is what they get.** The preview renders the same component used in production, with the same styling, spacing, and behavior. No approximations.
+- **Mobile-native editing.** The builder works on phones. Not "works if you squint" — genuinely usable with touch, with full-screen mode and touch-sized targets.
+- **Zero-config start.** New types begin with a sensible default layout. Existing types render as they always have until an admin opts in. Nothing breaks.
+- **Constrained creativity.** The block palette is intentionally limited to components that make sense in a detail view. No freeform HTML, no arbitrary nesting. Hard to build something ugly.
+
+---
+
+## Block Palette
+
+Nine block types, each purpose-built for item detail display:
+
+| Block | Description | Configuration |
+|-------|-------------|---------------|
+| **Field Display** | Shows a custom field's value with label | Field selection (existing or create new), size (compact / normal / large), show/hide label |
+| **Photo Gallery** | Item photos | Style (hero / grid / carousel), max photo count (1–20) |
+| **Status Badge** | Item status with color | Minimal — inherits status colors from the system |
+| **Entity List** | Linked entities grouped by type | Which entity types to include (checkboxes) |
+| **Timeline** | Updates, scheduled events, due dates on a vertical list | Show updates toggle, show scheduled toggle, max items |
+| **Text Label** | Static text or section headers | Text content, style (heading / subheading / body / caption) |
+| **Divider** | Visual separator | None — renders a horizontal rule with spacing |
+| **Map Snippet** | Small map showing item location | None — auto-centers on item coordinates |
+| **Action Buttons** | Edit item, add update | None — buttons determined by user permissions |
+
+### Block Empty States
+
+Each block handles missing data gracefully:
+
+- **Photo Gallery** with no photos: "No photos yet" placeholder (or hidden entirely — configurable via a "hide when empty" toggle on each block)
+- **Entity List** with no linked entities: hidden by default
+- **Timeline** with no updates: "No activity yet" message
+- **Field Display** with no value: shows field label with "—" or hidden (configurable)
+
+---
+
+## Layout JSON Schema
+
+Stored as a single JSONB column on `item_types`:
+
+```typescript
+interface TypeLayout {
+  version: 1;
+  blocks: LayoutBlock[];
+}
+
+interface LayoutBlock {
+  id: string;           // nanoid, unique within layout
+  type: BlockType;
+  config: BlockConfig;  // discriminated by type
+  hideWhenEmpty?: boolean;
+}
+
+type BlockType =
+  | 'field_display'
+  | 'photo_gallery'
+  | 'status_badge'
+  | 'entity_list'
+  | 'text_label'
+  | 'divider'
+  | 'action_buttons'
+  | 'map_snippet'
+  | 'timeline';
+```
+
+### Block Config Types
+
+```typescript
+interface FieldDisplayConfig {
+  fieldId: string;
+  size: 'compact' | 'normal' | 'large';
+  showLabel: boolean;
+}
+
+interface PhotoGalleryConfig {
+  style: 'hero' | 'grid' | 'carousel';
+  maxPhotos: number;
+}
+
+interface StatusBadgeConfig {}
+
+interface EntityListConfig {
+  entityTypeIds: string[];  // empty = show all
+}
+
+interface TimelineConfig {
+  showUpdates: boolean;
+  showScheduled: boolean;
+  maxItems: number;
+}
+
+interface TextLabelConfig {
+  text: string;
+  style: 'heading' | 'subheading' | 'body' | 'caption';
+}
+
+interface DividerConfig {}
+
+interface MapSnippetConfig {}
+
+interface ActionButtonsConfig {}
+```
+
+### Validation
+
+A Zod schema validates layout JSON on save:
+
+- Every block has a valid `type` and unique `id`
+- `field_display` blocks reference a `fieldId` that exists in the type's custom fields
+- Config values are within valid ranges (e.g., `maxPhotos` 1–20, `maxItems` 1–50)
+- At least one block exists (empty layouts are not saved — delete the layout instead)
+
+---
+
+## Layout Builder UI
+
+### Desktop Layout (≥768px)
+
+Two-panel side-by-side view within the ItemType admin page:
+
+```
+┌─────────────────────────────────┬──────────────────────────┐
+│          BUILDER                │        PREVIEW           │
+│                                 │                          │
+│  ┌─ Block Palette ───────────┐  │  ┌── DetailPanel ─────┐  │
+│  │ 📊 Field  📷 Photo  📍 Map│  │  │                     │  │
+│  │ 📋 Timeline  🏷 Status ...│  │  │  (live preview      │  │
+│  └───────────────────────────┘  │  │   with mock data,   │  │
+│                                 │  │   scrollable,        │  │
+│  ┌─ Block List ──────────────┐  │  │   actual component)  │  │
+│  │ ⠿ Status Badge        ✕  │  │  │                     │  │
+│  │ ⠿ Photo Gallery ▾    ✕  │  │  │                     │  │
+│  │   ┌─ Config ───────────┐  │  │  │                     │  │
+│  │   │ Style: [hero ▾]    │  │  │  │                     │  │
+│  │   │ Max:   [4    ]     │  │  │  │                     │  │
+│  │   └────────────────────┘  │  │  │                     │  │
+│  │ ⠿ Target Species      ✕  │  │  │                     │  │
+│  │ ⠿ Timeline            ✕  │  │  │                     │  │
+│  │ ⠿ Action Buttons      ✕  │  │  │                     │  │
+│  └───────────────────────────┘  │  └─────────────────────┘  │
+└─────────────────────────────────┴──────────────────────────┘
+```
+
+- Builder panel: ~60% width, scrollable independently
+- Preview panel: ~40% width, fixed position, scrollable content inside DetailPanel shell
+- Preview updates live as blocks are added, reordered, or configured
+
+### Mobile Layout (<768px) — Full-Screen Mode
+
+The builder opens as a **full-screen overlay** (100dvh × 100vw) to maximize workspace:
+
+```
+┌──────────────────────────────┐
+│  ← Bird Box Layout     Done  │  ← sticky header
+├──────────────────────────────┤
+│  [ Build ]  [ Preview ]      │  ← tab toggle
+├──────────────────────────────┤
+│                              │
+│  (active tab content,        │
+│   full remaining height,     │
+│   independently scrollable)  │
+│                              │
+└──────────────────────────────┘
+```
+
+**Build tab:**
+- Block palette as a horizontally scrollable row of pill buttons (icon + short label)
+- Block list fills remaining space, vertically scrollable
+- Tap a block to expand its config accordion-style (one open at a time)
+- Drag handles: 44×44px minimum touch target with clear grip affordance
+
+**Preview tab:**
+- Renders the DetailPanel at device width inside a container styled to match the real panel shell
+- Scrollable for long layouts
+- Subtle bottom-edge fade when content extends below the fold
+
+**Tab switching** preserves all state. Edits in Build are immediately visible when switching to Preview.
+
+### Block Palette Interaction
+
+- **Tap** a palette item to append the block to the end of the layout
+- The new block auto-scrolls into view and expands its config panel
+- For Field Display blocks, the config immediately shows the field picker / creator
+- Palette items are always available (no drag from palette — just tap to add, then reorder in the list)
+
+### Inline Block Configuration
+
+Blocks configure in-place via accordion expansion. This avoids modals (which feel heavy and lose context) and sidebars (which don't work on mobile). Each block type has a compact config UI:
+
+- **Field Display:** Segmented control for size, label toggle, field picker dropdown. The field picker has two sections: "Existing Fields" (list of current custom fields) and "+ Create New Field" (expands to name/type/options/required inputs)
+- **Photo Gallery:** Visual style picker (three thumbnail previews of hero/grid/carousel), stepper for max photos
+- **Timeline:** Toggle switches for updates and scheduled, stepper for max items
+- **Text Label:** Text input (single line for headings, multi-line for body), style picker as segmented control
+- **Entity List:** Checkbox list of available entity types with icons
+- **Status Badge / Divider / Map Snippet / Action Buttons:** "No configuration needed" message, or a single hideWhenEmpty toggle
+
+### Delete Confirmation
+
+Deleting a block shows an inline confirmation (not a modal):
+- For **Field Display** blocks: "Remove from layout only, or also delete the field and its data?" with two buttons
+- For all other blocks: block fades out with a 3-second "Undo" toast
+
+### Drag and Drop
+
+Using `@dnd-kit/sortable` for reordering:
+
+- **Desktop:** Grab drag handle, drag vertically, drop indicator shows insertion point
+- **Mobile:** Long-press drag handle (150ms) to initiate drag, haptic feedback if available, drop indicator shows between blocks
+- During drag: dragged block becomes semi-transparent, other blocks animate to make room
+- Scroll zones at top/bottom of the list auto-scroll when dragging near edges
+
+---
+
+## Layout-First Type Creation Flow
+
+### New ItemType
+
+1. **Identity screen** — name, icon picker (emoji grid), color picker (preset palette + custom hex). A single compact form. "Next" button.
+
+2. **Layout builder** — opens immediately with a starter layout:
+   ```
+   Status Badge
+   Photo Gallery (hero)
+   Action Buttons
+   ```
+   The admin builds from here. On mobile, this is the full-screen overlay. The starter layout gives immediate visual feedback in the preview — it's not a blank canvas.
+
+3. **Inline field creation** — when adding a Field Display block, the admin creates the custom field right there:
+   - Field name (text input)
+   - Field type (segmented control: Text / Number / Dropdown / Date)
+   - Options (comma-separated, shown only for Dropdown)
+   - Required toggle
+   - Creating the field adds it to local state and places the block — all fields and the layout are persisted together when the admin hits Save
+
+4. **Save** — one action saves the ItemType identity, all custom fields, and the layout JSON. Validated together before commit.
+
+### Editing an Existing ItemType
+
+The admin screen reorganizes into three tabs:
+
+| Tab | Purpose |
+|-----|---------|
+| **Layout** | The builder (primary tab) — includes inline field creation |
+| **Fields** | Direct table of custom fields — for power users, bulk edits, or managing fields that aren't in the layout |
+| **Settings** | Name, icon, color, danger zone (delete type) |
+
+The Layout tab is the default. Most admins never need the Fields tab.
+
+### Field Lifecycle
+
+| Action | Effect on Layout |
+|--------|-----------------|
+| Create field via builder | Field added to local state + `field_display` block appended to layout (all persisted together on save) |
+| Create field via Fields tab | `CustomField` row created, builder shows notification: "1 field not in layout" with quick-add button |
+| Delete field via Fields tab | Block referencing that field auto-removed from layout, toast notification |
+| Delete Field Display block | Prompt: "Remove from layout only" or "Delete field and all its data" |
+| Rename field via Fields tab | No layout impact (blocks reference by ID) |
+| Reorder fields via Fields tab | No layout impact (layout has its own ordering) |
+
+---
+
+## DetailPanel Rendering
+
+### Component Architecture
+
+```
+DetailPanel (shell — header, close button, panel chrome)
+  ├── Item name + type icon (always present, outside layout)
+  └── LayoutRenderer
+       ├── StatusBadgeBlock
+       ├── PhotoGalleryBlock
+       ├── FieldDisplayBlock
+       ├── TimelineBlock
+       ├── EntityListBlock
+       ├── TextLabelBlock
+       ├── DividerBlock
+       ├── MapSnippetBlock
+       └── ActionButtonsBlock
+```
+
+### LayoutRenderer Component
+
+```typescript
+interface LayoutRendererProps {
+  layout: TypeLayout;
+  item: ItemWithDetails;
+  mode: 'live' | 'preview';
+  customFields: CustomField[];
+}
+```
+
+- Iterates `layout.blocks` in order, renders the matching block component
+- Each block is wrapped in a React error boundary — one broken block doesn't crash the panel
+- `mode: 'preview'` passes mock data and suppresses network calls
+- `mode: 'live'` passes real item data and fetches timeline/entities as needed
+- Blocks with `hideWhenEmpty: true` check for data presence and render nothing if empty
+
+### Mock Data Generation
+
+For the preview, mock data is generated from the type's custom fields:
+
+| Field Type | Mock Value |
+|-----------|------------|
+| text | "Sample text" |
+| number | 42 |
+| dropdown | First option in the list |
+| date | Today's date |
+| url | "https://example.com" |
+
+Photos use placeholder images. Timeline shows 3 sample updates with realistic dates. Entity list shows 2 sample entities per type. Status defaults to "active."
+
+### Fallback Rendering
+
+- **`layout` is null:** DetailPanel renders with the current fixed layout (full backward compatibility)
+- **Layout references a deleted field:** Block is silently skipped (safety net — field deletion already cleans up the layout)
+- **Malformed layout JSON:** Falls back to legacy rendering, logs a warning
+- **Block component error:** Error boundary renders a muted "Unable to display" placeholder for that block
+
+### Scrollable Layouts
+
+Long layouts scroll naturally within the DetailPanel content area. The panel shell (header, close button) remains fixed. Both the preview and live DetailPanel use the same scroll behavior:
+
+- Content area scrolls independently
+- Subtle fade gradient at the bottom edge when more content exists below the fold
+- Scroll position resets to top when opening a different item
+
+---
+
+## Database Changes
+
+### Migration
+
+```sql
+ALTER TABLE item_types
+ADD COLUMN layout JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN item_types.layout IS
+  'JSON layout definition for the item detail panel. NULL = use default rendering.';
+```
+
+Single column addition. No new tables. No data backfill.
+
+### Why JSONB, Not a Separate Table
+
+- Layouts are always loaded and saved as a unit with the ItemType
+- No need to query individual blocks independently
+- No join overhead
+- Validated at the application layer via Zod before save
+- PostgreSQL JSONB supports indexing if ever needed
+
+### RLS / Permissions
+
+The `layout` column inherits existing RLS policies on `item_types`. Same org-scoping, same role requirements for editing. No new permission model needed.
+
+### Offline Storage
+
+The layout JSON is cached in the Dexie offline DB as part of the ItemType record. The `LayoutRenderer` works entirely with locally cached data — item data, custom field values, cached photos, cached updates. No new offline sync tables or logic.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Layout validation:** Zod schema accepts valid layouts, rejects malformed ones with clear error messages
+- **Default layout generation:** Given a set of custom fields, produces correct default blocks in expected order
+- **Field sync logic:** Adding a field shows notification; deleting a field removes block and produces toast; renaming has no effect on layout
+- **Mock data generation:** Each field type produces appropriate sample values
+
+### Component Tests
+
+- **Each block component:** Renders correctly with mock data, handles empty data, respects hideWhenEmpty
+- **LayoutRenderer:** Renders blocks in order, skips invalid blocks, error boundary contains crashes
+- **Builder interactions:** Add block, remove block, reorder, expand/collapse config, create field inline
+- **Mobile full-screen mode:** Opens/closes correctly, tab switching preserves state
+
+### Integration Tests
+
+- **Full creation flow:** Identity → builder → add blocks with fields → save → verify layout JSON + custom fields in database
+- **Edit flow:** Open existing type → modify layout → save → verify DetailPanel renders new layout
+- **Field deletion cascade:** Delete field → verify block removed → verify toast shown
+- **Backward compatibility:** Type with null layout renders with legacy DetailPanel
+- **Offline rendering:** Layout renders correctly from Dexie-cached data
+
+### Error Handling
+
+- **Save failure:** Toast with retry action, builder state preserved (no data loss)
+- **Drag/drop failure:** Block snaps back to original position
+- **Block render crash:** Error boundary shows placeholder, other blocks unaffected
+- **Timeline/entity fetch failure:** Block shows "Unable to load" with retry button
+- **Invalid field reference:** Block silently skipped in renderer, auto-cleaned on next layout save
+
+---
+
+## UX Details
+
+### Touch Targets
+
+All interactive elements meet 44×44px minimum touch target size per Apple HIG:
+- Drag handles: 44×44px with visible grip dots
+- Block palette pills: 44px height, horizontal padding for comfortable tap
+- Delete buttons: 44×44px (icon only, no small text links)
+- Toggle switches: native size (already compliant)
+- Accordion expand/collapse: entire block header row is tappable
+
+### Transitions & Feedback
+
+- **Adding a block:** Block slides in from right with 200ms ease-out, auto-scrolls into view
+- **Removing a block:** Block fades out over 150ms, list collapses smoothly
+- **Reordering:** Dragged block lifts with subtle shadow, other blocks animate to make room (200ms spring)
+- **Config expand/collapse:** Accordion animation 200ms ease-in-out, content height transitions
+- **Tab switching (mobile):** Crossfade 150ms, no jarring jump
+- **Preview updates:** Blocks in preview animate changes (not instant swap) — fade transition on content changes
+- **Save:** Button shows spinner, then checkmark on success, then returns to normal
+
+### Accessibility
+
+- Drag/drop has keyboard alternative: select block, use arrow keys to move up/down, Enter to confirm
+- Block palette items are focusable and keyboard-navigable
+- Screen readers announce block type and position ("Photo Gallery, block 2 of 5")
+- Config forms use proper label associations
+- Color contrast meets WCAG AA throughout
+
+### Empty States
+
+- **New type, first time in builder:** Starter layout is pre-populated (not blank). A subtle banner above the block list reads: "Drag to reorder. Tap + to add blocks. Tap a block to configure it."
+- **All blocks deleted:** Message with illustration: "Your layout is empty. Add blocks from the palette above to build the detail view." The preview shows just the item name and type icon.
+
+### Responsive Breakpoints
+
+| Width | Behavior |
+|-------|----------|
+| < 768px | Full-screen overlay, tabbed Build/Preview, single column |
+| 768–1024px | Side-by-side, builder 55% / preview 45% |
+| > 1024px | Side-by-side, builder 60% / preview 40%, more breathing room |
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Layout builder with 9 block types
+- Layout-first type creation flow
+- Live preview with mock data
+- Mobile full-screen editing
+- Inline field creation from builder
+- Field sync (add/delete notifications)
+- LayoutRenderer for DetailPanel
+- Backward-compatible fallback rendering
+- Database migration (single column)
+- Offline support (cached layout JSON)
+- Zod validation
+- `@dnd-kit/sortable` for drag/drop
+
+### Out of Scope (Future Consideration)
+
+- Layout templates / presets (start from a template instead of the starter layout)
+- Copy/duplicate layout between types
+- Layout version history or undo beyond session
+- Nested blocks or multi-column layouts within the detail panel
+- Conditional blocks (show block X only if field Y has value Z)
+- Custom CSS or theme overrides per type
+- Layout builder for UpdateTypes or EntityTypes
+- A/B testing of layouts
+- Layout analytics (which blocks get seen/interacted with)

--- a/docs/superpowers/specs/2026-04-03-item-type-layout-builder-design.md
+++ b/docs/superpowers/specs/2026-04-03-item-type-layout-builder-design.md
@@ -48,6 +48,38 @@ Each block handles missing data gracefully:
 
 ---
 
+## Layout Composition Model
+
+The layout system supports two composition modes:
+
+- **Vertical stacking** — blocks flow top to bottom (the default). Each block occupies the full width.
+- **Horizontal stacking** — a `row` container places 2–4 child blocks side by side, sharing the width equally or at configured ratios.
+
+Nesting is limited to **one level**: rows contain blocks, but rows cannot contain rows. This keeps the builder simple for non-technical users while enabling common patterns like:
+
+```
+┌──────────────────────────────┐
+│  Status Badge (full width)   │
+├──────────────────────────────┤
+│  Photo Gallery (full width)  │
+├──────────────┬───────────────┤
+│  Species     │  Installed    │  ← row with 2 fields
+│  (field)     │  (date field) │
+├──────────────┴───────────────┤
+│  Notes (full width field)    │
+├──────────────────────────────┤
+│  Timeline (full width)       │
+├──────────────────────────────┤
+│  Action Buttons              │
+└──────────────────────────────┘
+```
+
+### Responsive Row Behavior
+
+Rows are horizontal on screens ≥480px. On narrower screens, rows **automatically collapse to vertical stacking** — each child becomes full-width. This means admins design for desktop/tablet and mobile layouts work automatically. No separate mobile layout needed.
+
+---
+
 ## Layout JSON Schema
 
 Stored as a single JSONB column on `item_types`:
@@ -55,14 +87,28 @@ Stored as a single JSONB column on `item_types`:
 ```typescript
 interface TypeLayout {
   version: 1;
-  blocks: LayoutBlock[];
+  blocks: LayoutNode[];
+  spacing: SpacingPreset;  // controls global spacing rhythm
 }
+
+// A node is either a content block or a row container
+type LayoutNode = LayoutBlock | LayoutRow;
 
 interface LayoutBlock {
   id: string;           // nanoid, unique within layout
   type: BlockType;
   config: BlockConfig;  // discriminated by type
   hideWhenEmpty?: boolean;
+}
+
+interface LayoutRow {
+  id: string;
+  type: 'row';
+  children: LayoutBlock[];   // 2–4 blocks, no nested rows
+  gap: 'tight' | 'normal' | 'loose';
+  distribution: 'equal' | 'auto' | number[];  
+  // 'equal' = even split, 'auto' = content-driven,
+  // number[] = explicit ratios e.g. [2, 1] for 2/3 + 1/3
 }
 
 type BlockType =
@@ -75,6 +121,8 @@ type BlockType =
   | 'action_buttons'
   | 'map_snippet'
   | 'timeline';
+
+type SpacingPreset = 'compact' | 'comfortable' | 'spacious';
 ```
 
 ### Block Config Types
@@ -119,10 +167,12 @@ interface ActionButtonsConfig {}
 
 A Zod schema validates layout JSON on save:
 
-- Every block has a valid `type` and unique `id`
+- Every node has a valid `type` and unique `id`
+- `row` nodes contain 2–4 children, no nested rows
+- `row` distribution arrays sum correctly and match children count
 - `field_display` blocks reference a `fieldId` that exists in the type's custom fields
 - Config values are within valid ranges (e.g., `maxPhotos` 1–20, `maxItems` 1–50)
-- At least one block exists (empty layouts are not saved — delete the layout instead)
+- At least one node exists (empty layouts are not saved — delete the layout instead)
 
 ---
 
@@ -196,6 +246,25 @@ The builder opens as a **full-screen overlay** (100dvh × 100vw) to maximize wor
 - The new block auto-scrolls into view and expands its config panel
 - For Field Display blocks, the config immediately shows the field picker / creator
 - Palette items are always available (no drag from palette — just tap to add, then reorder in the list)
+- The palette includes a **Row** item (icon: columns/grid) — tapping it appends a row with 2 empty slots
+
+### Row Interaction
+
+Rows appear in the block list as a visually grouped container with an indented children area:
+
+```
+⠿ ┌ Row (2 columns, equal) ──────── ✕
+  │  ⠿ Species (field)          ✕
+  │  ⠿ Install Date (field)     ✕
+  │  [+ Add to row]
+  └────────────────────────────────
+```
+
+- **Adding blocks to a row:** Tap "+ Add to row" inside the row, or drag an existing block into the row area. Maximum 4 children per row.
+- **Row configuration:** Tap the row header to expand settings — column count (2–4), distribution (equal / auto / custom ratios via a simple slider), gap (tight / normal / loose)
+- **Converting to/from rows:** Select two adjacent blocks and tap "Group into row" from a contextual action. Ungroup a row by tapping "Unstack" in the row config — children become standalone vertical blocks.
+- **Drag behavior:** Blocks can be dragged into or out of rows. Drop indicators show whether the block will land inside the row or between top-level nodes.
+- **Mobile rows:** On the mobile builder, rows show children vertically with a visual grouping indicator (left border line). The preview tab shows how rows collapse on narrow screens.
 
 ### Inline Block Configuration
 
@@ -406,47 +475,104 @@ The layout JSON is cached in the Dexie offline DB as part of the ItemType record
 
 ---
 
-## UX Details
+## UX Design System & Guidelines
 
-### Touch Targets
+### Spacing System
 
-All interactive elements meet 44×44px minimum touch target size per Apple HIG:
-- Drag handles: 44×44px with visible grip dots
-- Block palette pills: 44px height, horizontal padding for comfortable tap
+The layout uses a consistent **4px base unit** spacing scale, applied via the `SpacingPreset` on the layout:
+
+| Preset | Block gap | Row internal gap | Section padding | Use case |
+|--------|-----------|-------------------|-----------------|----------|
+| `compact` | 8px (2 units) | 8px | 12px | Data-dense types with many fields |
+| `comfortable` | 12px (3 units) | 12px | 16px | Default — balanced readability |
+| `spacious` | 16px (4 units) | 16px | 20px | Photo-forward or minimal types |
+
+The spacing preset is a single toggle in the builder (three options with visual previews), not per-block configuration. Consistent rhythm matters more than per-element control.
+
+### Typography Scale
+
+Block text rendering follows a coherent type scale derived from the app's existing Tailwind config:
+
+| Style | Size | Weight | Line Height | Use case |
+|-------|------|--------|-------------|----------|
+| `heading` | 18px / 1.125rem | 600 (semibold) | 1.3 | Section headers within the detail panel |
+| `subheading` | 15px / 0.9375rem | 500 (medium) | 1.4 | Subsection labels, field group titles |
+| `body` | 14px / 0.875rem | 400 (regular) | 1.5 | Field values, descriptions, body text |
+| `caption` | 12px / 0.75rem | 400 (regular) | 1.4 | Timestamps, metadata, secondary info |
+| `field-label` | 12px / 0.75rem | 500 (medium) | 1.3 | Field labels above values, all-caps tracking |
+| `field-value-large` | 20px / 1.25rem | 600 (semibold) | 1.2 | Featured/hero field values (large size config) |
+
+Labels use muted color (`text-gray-500`) to create visual hierarchy against values in `text-gray-900`. This hierarchy is automatic — admins don't configure it.
+
+### Information Architecture
+
+The layout renderer enforces a sensible reading order and visual hierarchy:
+
+- **Primary context first:** Status, identity, and hero imagery at the top establish what the user is looking at
+- **Data in the middle:** Custom fields, entities, and detail content in the main body
+- **History and actions last:** Timeline and action buttons anchor the bottom
+
+The default starter layout follows this pattern. The builder doesn't enforce ordering (admins can arrange freely), but the defaults model good IA.
+
+**Visual grouping:** Rows implicitly create related-field groups. Adjacent Field Display blocks without a divider between them are rendered with tighter spacing (the `compact` gap) to signal they belong together. A Divider block creates a stronger visual break.
+
+### Touch Targets & Interaction Design
+
+All interactive elements meet **44×44px minimum touch target size** per Apple HIG and WCAG 2.5.5 (AAA):
+
+- Drag handles: 44×44px with visible grip dots, generous padding around the hit area
+- Block palette pills: 44px height, minimum 44px width, horizontal padding for comfortable tap
 - Delete buttons: 44×44px (icon only, no small text links)
 - Toggle switches: native size (already compliant)
-- Accordion expand/collapse: entire block header row is tappable
+- Accordion expand/collapse: entire block header row is tappable (full width, 48px min height)
+- Row "Add to row" button: full row width, 44px height
+- Spacing between adjacent tap targets: minimum 8px to prevent mis-taps
+
+**Fitts's Law considerations:**
+- "Done" / "Save" button in the sticky header is large and in a consistent position (top-right)
+- Block palette is pinned at top — always accessible without scrolling
+- Delete actions require intentional reach (positioned at row end, away from drag handle)
 
 ### Transitions & Feedback
 
 - **Adding a block:** Block slides in from right with 200ms ease-out, auto-scrolls into view
-- **Removing a block:** Block fades out over 150ms, list collapses smoothly
-- **Reordering:** Dragged block lifts with subtle shadow, other blocks animate to make room (200ms spring)
-- **Config expand/collapse:** Accordion animation 200ms ease-in-out, content height transitions
-- **Tab switching (mobile):** Crossfade 150ms, no jarring jump
-- **Preview updates:** Blocks in preview animate changes (not instant swap) — fade transition on content changes
-- **Save:** Button shows spinner, then checkmark on success, then returns to normal
+- **Removing a block:** Block fades out over 150ms, list collapses smoothly (no layout jump)
+- **Reordering:** Dragged block lifts with subtle shadow (2px translate-z), other blocks animate to make room (200ms spring easing)
+- **Config expand/collapse:** Accordion animation 200ms ease-in-out, content height animates (not display:none toggle)
+- **Tab switching (mobile):** Crossfade 150ms, scroll position preserved per tab
+- **Preview updates:** Blocks in preview cross-fade on content changes (150ms) — not instant swap
+- **Save:** Button shows spinner → checkmark (hold 600ms) → returns to normal
+- **Row collapse/expand on resize:** Smooth CSS transition, no JS reflow
+
+All animations respect `prefers-reduced-motion: reduce` — transitions become instant, no motion.
 
 ### Accessibility
 
-- Drag/drop has keyboard alternative: select block, use arrow keys to move up/down, Enter to confirm
-- Block palette items are focusable and keyboard-navigable
+- Drag/drop has keyboard alternative: Tab to select block, Space to pick up, Arrow keys to move, Space to drop, Escape to cancel
+- Block palette items are focusable and keyboard-navigable (arrow keys cycle, Enter adds)
 - Screen readers announce block type and position ("Photo Gallery, block 2 of 5")
-- Config forms use proper label associations
-- Color contrast meets WCAG AA throughout
+- Row children announced as "Species field, column 1 of 2 in row"
+- Config forms use proper `<label>` associations and `aria-describedby` for help text
+- Color contrast meets WCAG AA throughout (4.5:1 for text, 3:1 for interactive elements)
+- Focus indicators: visible 2px ring on all interactive elements, not just browser default
+- Error messages linked to inputs via `aria-errormessage`
 
 ### Empty States
 
-- **New type, first time in builder:** Starter layout is pre-populated (not blank). A subtle banner above the block list reads: "Drag to reorder. Tap + to add blocks. Tap a block to configure it."
+- **New type, first time in builder:** Starter layout is pre-populated (not blank). A subtle banner above the block list reads: "Drag to reorder. Tap + to add blocks. Tap a block to configure it." Banner dismisses permanently after first block interaction.
 - **All blocks deleted:** Message with illustration: "Your layout is empty. Add blocks from the palette above to build the detail view." The preview shows just the item name and type icon.
+- **Empty row:** Shows a dashed-border drop zone with "+ Add block" centered inside.
 
 ### Responsive Breakpoints
 
-| Width | Behavior |
-|-------|----------|
-| < 768px | Full-screen overlay, tabbed Build/Preview, single column |
-| 768–1024px | Side-by-side, builder 55% / preview 45% |
-| > 1024px | Side-by-side, builder 60% / preview 40%, more breathing room |
+| Width | Layout | Row behavior |
+|-------|--------|-------------|
+| < 480px | Full-screen overlay, tabbed Build/Preview | Rows collapse to vertical stacking |
+| 480–767px | Full-screen overlay, tabbed Build/Preview | Rows display horizontally |
+| 768–1024px | Side-by-side, builder 55% / preview 45% | Rows display horizontally |
+| > 1024px | Side-by-side, builder 60% / preview 40% | Rows display horizontally |
+
+The preview always renders at the width the end user will see — on mobile builder, the preview tab renders at device width. On desktop, the preview panel constrains to typical mobile/panel width to show the realistic view.
 
 ---
 
@@ -454,7 +580,9 @@ All interactive elements meet 44×44px minimum touch target size per Apple HIG:
 
 ### In Scope
 
-- Layout builder with 9 block types
+- Layout builder with 9 block types + row container
+- Vertical and horizontal composition (rows with 2–4 children, one level deep)
+- Responsive row collapse on narrow screens
 - Layout-first type creation flow
 - Live preview with mock data
 - Mobile full-screen editing
@@ -464,17 +592,21 @@ All interactive elements meet 44×44px minimum touch target size per Apple HIG:
 - Backward-compatible fallback rendering
 - Database migration (single column)
 - Offline support (cached layout JSON)
+- Spacing preset system (compact / comfortable / spacious)
+- Typography scale and visual hierarchy
 - Zod validation
 - `@dnd-kit/sortable` for drag/drop
+- WCAG AA accessibility compliance
 
 ### Out of Scope (Future Consideration)
 
 - Layout templates / presets (start from a template instead of the starter layout)
 - Copy/duplicate layout between types
 - Layout version history or undo beyond session
-- Nested blocks or multi-column layouts within the detail panel
+- Deeply nested layouts (rows in rows, columns in columns)
 - Conditional blocks (show block X only if field Y has value Z)
 - Custom CSS or theme overrides per type
 - Layout builder for UpdateTypes or EntityTypes
 - A/B testing of layouts
 - Layout analytics (which blocks get seen/interacted with)
+- Per-block spacing overrides (global preset only)

--- a/docs/superpowers/specs/2026-04-03-item-type-layout-builder-design.md
+++ b/docs/superpowers/specs/2026-04-03-item-type-layout-builder-design.md
@@ -34,7 +34,7 @@ Nine block types, each purpose-built for item detail display:
 | **Timeline** | Updates, scheduled events, due dates on a vertical list | Show updates toggle, show scheduled toggle, max items |
 | **Text Label** | Static text or section headers | Text content, style (heading / subheading / body / caption) |
 | **Divider** | Visual separator | None — renders a horizontal rule with spacing |
-| **Map Snippet** | Small map showing item location | None — auto-centers on item coordinates |
+| **Map Snippet** | Small map showing item location (desktop side panel only — auto-hidden on mobile where the map is visible behind the bottom sheet) | None — auto-centers on item coordinates |
 | **Action Buttons** | Edit item, add update | None — buttons determined by user permissions |
 
 ### Block Empty States
@@ -89,6 +89,7 @@ interface TypeLayout {
   version: 1;
   blocks: LayoutNode[];
   spacing: SpacingPreset;  // controls global spacing rhythm
+  peekBlockCount: number;  // how many top-level nodes to show in bottom sheet peek state (default: 2)
 }
 
 // A node is either a content block or a row container
@@ -206,8 +207,10 @@ Two-panel side-by-side view within the ItemType admin page:
 ```
 
 - Builder panel: ~60% width, scrollable independently
-- Preview panel: ~40% width, fixed position, scrollable content inside DetailPanel shell
-- Preview updates live as blocks are added, reordered, or configured
+- Preview panel: ~40% width, fixed position, with a tab bar at the top: **Detail Preview | Form Preview**
+- Detail Preview shows the bottom sheet simulation with peek line indicator
+- Form Preview shows the auto-generated add/edit form
+- Both previews update live as blocks are added, reordered, or configured
 
 ### Mobile Layout (<768px) — Full-Screen Mode
 
@@ -217,7 +220,7 @@ The builder opens as a **full-screen overlay** (100dvh × 100vw) to maximize wor
 ┌──────────────────────────────┐
 │  ← Bird Box Layout     Done  │  ← sticky header
 ├──────────────────────────────┤
-│  [ Build ]  [ Preview ]      │  ← tab toggle
+│ [ Build ] [ Detail ] [ Form ]│  ← tab toggle
 ├──────────────────────────────┤
 │                              │
 │  (active tab content,        │
@@ -230,15 +233,26 @@ The builder opens as a **full-screen overlay** (100dvh × 100vw) to maximize wor
 **Build tab:**
 - Block palette as a horizontally scrollable row of pill buttons (icon + short label)
 - Block list fills remaining space, vertically scrollable
+- A **peek boundary line** appears between blocks to show what's visible in the bottom sheet peek state (label: "Visible on first tap — swipe up for more"). This line is draggable to adjust `peekBlockCount`.
 - Tap a block to expand its config accordion-style (one open at a time)
 - Drag handles: 44×44px minimum touch target with clear grip affordance
 
-**Preview tab:**
-- Renders the DetailPanel at device width inside a container styled to match the real panel shell
+**Detail Preview tab:**
+- Renders the DetailPanel at device width inside a container styled to match the real bottom sheet shell (with handle, peek/half/full snap indicators)
+- Shows a simulated bottom sheet with the peek state visible by default — admin can swipe/tap to see half and full states
 - Scrollable for long layouts
 - Subtle bottom-edge fade when content extends below the fold
+- A dashed line in the preview marks the peek boundary so admins understand what's visible at first glance
 
-**Tab switching** preserves all state. Edits in Build are immediately visible when switching to Preview.
+**Form Preview tab:**
+- Renders the auto-generated Add Item form for this type
+- Form layout is derived from the detail layout: each `field_display` block becomes the corresponding input (text field, number input, dropdown, date picker), in the same order. Rows carry over — fields in a row appear side by side in the form.
+- Fixed form elements always present: name input (top), location picker, status selector, photo uploader, entity selector (if applicable), submit button (bottom)
+- Custom field inputs appear between location and status, matching the layout block order
+- The form preview is interactive — admins can tap into fields to see focus states, dropdowns, etc. but no data is saved
+- Shows both required indicators and placeholder text
+
+**Tab switching** preserves all state. Edits in Build are immediately visible when switching to either Preview tab.
 
 ### Block Palette Interaction
 
@@ -344,10 +358,50 @@ The Layout tab is the default. Most admins never need the Fields tab.
 
 ## DetailPanel Rendering
 
+### Mobile Bottom Sheet — Multi-Snap States
+
+The current BottomSheet has a single open/closed state. This must be upgraded to a **three-snap-point bottom sheet** following the pattern established by Google Maps, Apple Maps, and Airbnb:
+
+| State | Height | What's visible | Map visibility |
+|-------|--------|----------------|----------------|
+| **Peek** | ~25% of viewport | Item name, type icon, status badge, and the first `peekBlockCount` blocks from the layout (default 2). Enough to identify the item at a glance. | Map fully interactive, marker centered above the sheet |
+| **Half** | ~50% of viewport | More blocks visible, user can scroll within the half-height container | Map visible above, partially interactive |
+| **Full** | ~92% of viewport (safe area aware) | All blocks, full scroll | Map hidden behind sheet |
+
+**Transitions between states:**
+- **Swipe up** from peek → half → full (velocity-based snapping — a fast swipe skips half and goes to full)
+- **Swipe down** from full → half → peek → dismiss
+- **Tap the handle area** toggles between peek and half
+- **Scroll within content** — when content is scrolled to top and user pulls down, the sheet collapses rather than overscrolling. When in peek/half and user scrolls content, the sheet expands to accommodate.
+- Spring physics with 300ms duration, slight overshoot for natural feel
+
+**Peek state design:**
+The layout's `peekBlockCount` controls how many top-level nodes render in peek state. The default of 2 typically gives: Status Badge + Photo Gallery hero — enough visual identity without obscuring the map. The peek state always includes the item name and type icon (these are outside the layout, in the shell). A subtle "swipe up for more" affordance (chevron or fade) hints at additional content.
+
+**Safe areas:**
+- Bottom: accounts for home indicator on notched devices (env(safe-area-inset-bottom))
+- The quick-add FAB (currently `fixed bottom-24 right-4`) repositions above the sheet in peek state, hides in half/full state
+- Full state reserves 8% at top so the user can see they're still in the map context and can swipe down
+
+### Desktop Side Panel
+
+The side panel remains at 384px (`w-96`) width. At this width:
+- **Rows auto-collapse to vertical stacking** — the panel is narrower than the 480px row threshold, so all content stacks vertically. This is intentional: the side panel is a constrained context similar to mobile.
+- If a future need arises for wider panels, the row threshold is a single constant to adjust.
+
+The side panel does not use snap states — it opens fully with slide-in animation and scrolls internally.
+
+### Photo Gallery — Edge-to-Edge in Bottom Sheet
+
+When a `photo_gallery` block with `style: 'hero'` is the first or second block in the layout, it renders **edge-to-edge** (no horizontal padding) within the bottom sheet. This creates the visual pattern users expect from map apps — a hero image that bleeds to the panel edges, anchoring the visual identity of the item.
+
+In non-hero positions or with grid/carousel styles, photos render with standard padding.
+
 ### Component Architecture
 
 ```
-DetailPanel (shell — header, close button, panel chrome)
+DetailPanel (shell — bottom sheet on mobile, side panel on desktop)
+  ├── Handle / drag indicator (mobile only)
   ├── Item name + type icon (always present, outside layout)
   └── LayoutRenderer
        ├── StatusBadgeBlock
@@ -357,7 +411,7 @@ DetailPanel (shell — header, close button, panel chrome)
        ├── EntityListBlock
        ├── TextLabelBlock
        ├── DividerBlock
-       ├── MapSnippetBlock
+       ├── MapSnippetBlock (desktop only — auto-hidden on mobile)
        └── ActionButtonsBlock
 ```
 
@@ -368,15 +422,20 @@ interface LayoutRendererProps {
   layout: TypeLayout;
   item: ItemWithDetails;
   mode: 'live' | 'preview';
+  context: 'bottom-sheet' | 'side-panel' | 'preview';
+  sheetState?: 'peek' | 'half' | 'full';  // mobile only
   customFields: CustomField[];
 }
 ```
 
 - Iterates `layout.blocks` in order, renders the matching block component
+- In `peek` state, only renders the first `peekBlockCount` top-level nodes
+- In `half` / `full` / `side-panel`, renders all blocks
 - Each block is wrapped in a React error boundary — one broken block doesn't crash the panel
 - `mode: 'preview'` passes mock data and suppresses network calls
 - `mode: 'live'` passes real item data and fetches timeline/entities as needed
 - Blocks with `hideWhenEmpty: true` check for data presence and render nothing if empty
+- `context` controls platform-specific behavior (e.g., MapSnippet hidden in bottom-sheet context)
 
 ### Mock Data Generation
 
@@ -401,11 +460,62 @@ Photos use placeholder images. Timeline shows 3 sample updates with realistic da
 
 ### Scrollable Layouts
 
-Long layouts scroll naturally within the DetailPanel content area. The panel shell (header, close button) remains fixed. Both the preview and live DetailPanel use the same scroll behavior:
+Long layouts scroll naturally within the DetailPanel content area. The panel shell (handle, header) remains fixed. Both the preview and live DetailPanel use the same scroll behavior:
 
-- Content area scrolls independently
+- Content area scrolls independently within the current sheet/panel height
+- On mobile: scrolling at the top of content triggers sheet state change (up = expand, down = collapse) rather than rubber-banding
 - Subtle fade gradient at the bottom edge when more content exists below the fold
-- Scroll position resets to top when opening a different item
+- Scroll position resets to top when opening a different item or when sheet collapses to peek
+
+---
+
+## Auto-Generated Form Layout
+
+The Add/Edit Item form layout is **automatically derived** from the detail layout. Admins do not build the form separately — they build the detail view, and the form follows. The Form Preview tab in the builder shows the result.
+
+### Derivation Rules
+
+The form renderer walks the detail layout and translates display blocks to input blocks:
+
+| Detail Block | Form Equivalent |
+|-------------|-----------------|
+| `field_display` | Corresponding input for the field type (text input, number input, dropdown select, date picker) |
+| `photo_gallery` | Photo uploader (camera + gallery picker) |
+| `status_badge` | Status selector dropdown |
+| `entity_list` | Entity multi-select per entity type |
+| `text_label` | Rendered as-is (section header in form) |
+| `divider` | Rendered as-is (visual break in form) |
+| `timeline` | **Omitted** — no form equivalent (display-only) |
+| `map_snippet` | **Omitted** — location picker is a fixed form element |
+| `action_buttons` | **Omitted** — replaced by Submit/Cancel buttons |
+
+### Fixed Form Elements
+
+These elements are always present in the form regardless of layout, in fixed positions:
+
+1. **Item name** — always first (text input, required)
+2. **Location picker** — always second (map tap or GPS, required)
+3. *(layout-derived fields appear here, preserving block order and row grouping)*
+4. **Photo uploader** — after custom fields (unless a `photo_gallery` block exists in the layout, in which case it renders at that position)
+5. **Submit / Cancel buttons** — always last
+
+### Row Behavior in Forms
+
+Rows from the detail layout carry into the form. Two fields in a row render as side-by-side inputs on wider screens (≥480px) and stack vertically on narrow screens — matching the detail view's responsive behavior. This creates visual consistency between the form and the detail view.
+
+### Form-Specific Considerations
+
+- **Required indicators:** Fields marked as required show a red asterisk next to the label
+- **Validation:** Runs on blur and on submit. Errors appear below the input with red text.
+- **Field order matches detail layout:** If an admin puts "Species" before "Install Date" in the detail view, the form inputs appear in the same order
+- **No separate form layout storage:** The form is derived at render time from the detail layout JSON. No additional database column.
+
+### Why Auto-Generated (Not Separately Designed)
+
+- **Cognitive load:** Non-technical admins would struggle to maintain two separate layouts
+- **Consistency:** The form and detail view stay in sync automatically — adding a field to the detail layout adds the input to the form
+- **Scope:** A separate form builder doubles the builder complexity for marginal benefit
+- **Future path:** If custom form layouts are needed later, a `formLayout` field can be added to the JSON schema. Null = auto-generate (backward compatible).
 
 ---
 
@@ -565,12 +675,12 @@ All animations respect `prefers-reduced-motion: reduce` — transitions become i
 
 ### Responsive Breakpoints
 
-| Width | Layout | Row behavior |
-|-------|--------|-------------|
-| < 480px | Full-screen overlay, tabbed Build/Preview | Rows collapse to vertical stacking |
-| 480–767px | Full-screen overlay, tabbed Build/Preview | Rows display horizontally |
-| 768–1024px | Side-by-side, builder 55% / preview 45% | Rows display horizontally |
-| > 1024px | Side-by-side, builder 60% / preview 40% | Rows display horizontally |
+| Width | Builder layout | Preview | Row behavior |
+|-------|---------------|---------|-------------|
+| < 480px | Full-screen overlay, tabbed Build/Detail/Form | Simulated bottom sheet with peek line | Rows collapse to vertical stacking |
+| 480–767px | Full-screen overlay, tabbed Build/Detail/Form | Simulated bottom sheet with peek line | Rows display horizontally |
+| 768–1024px | Side-by-side, builder 55% / preview 45% | Tabbed Detail/Form in preview panel | Rows display horizontally |
+| > 1024px | Side-by-side, builder 60% / preview 40% | Tabbed Detail/Form in preview panel | Rows display horizontally |
 
 The preview always renders at the width the end user will see — on mobile builder, the preview tab renders at device width. On desktop, the preview panel constrains to typical mobile/panel width to show the realistic view.
 
@@ -584,11 +694,15 @@ The preview always renders at the width the end user will see — on mobile buil
 - Vertical and horizontal composition (rows with 2–4 children, one level deep)
 - Responsive row collapse on narrow screens
 - Layout-first type creation flow
-- Live preview with mock data
-- Mobile full-screen editing
+- **Multi-snap bottom sheet** (peek / half / full) with configurable peek boundary
+- **Auto-generated form layout** with Form Preview tab in builder
+- Live detail and form previews with mock data
+- Mobile full-screen editing with three tabs (Build / Detail / Form)
 - Inline field creation from builder
 - Field sync (add/delete notifications)
 - LayoutRenderer for DetailPanel
+- FormRenderer derived from detail layout
+- Edge-to-edge hero photo rendering in bottom sheet
 - Backward-compatible fallback rendering
 - Database migration (single column)
 - Offline support (cached layout JSON)
@@ -607,6 +721,7 @@ The preview always renders at the width the end user will see — on mobile buil
 - Conditional blocks (show block X only if field Y has value Z)
 - Custom CSS or theme overrides per type
 - Layout builder for UpdateTypes or EntityTypes
+- Custom form layout builder (separate from detail layout — currently auto-generated)
 - A/B testing of layouts
 - Layout analytics (which blocks get seen/interacted with)
 - Per-block spacing overrides (global preset only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.64",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@formkit/auto-animate": "^0.9.0",
         "@heroicons/react": "^2.2.0",
         "@puckeditor/core": "^0.21.1",
@@ -37,6 +40,7 @@
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.7.0",
+        "nanoid": "^5.1.7",
         "next": "^14.2.0",
         "papaparse": "^5.5.3",
         "proj4": "^2.20.4",
@@ -423,6 +427,18 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@dnd-kit/collision": {
       "version": "0.1.21",
       "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.1.21.tgz",
@@ -432,6 +448,22 @@
         "@dnd-kit/abstract": "^0.1.21",
         "@dnd-kit/geometry": "^0.1.21",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/dom": {
@@ -467,6 +499,20 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@dnd-kit/state": {
       "version": "0.1.21",
       "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.1.21.tgz",
@@ -475,6 +521,18 @@
       "dependencies": {
         "@preact/signals-core": "^1.10.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -9239,9 +9297,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
       "funding": [
         {
           "type": "github",
@@ -9250,10 +9308,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/napi-postinstall": {
@@ -9328,6 +9386,24 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -10029,6 +10105,24 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.64",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@formkit/auto-animate": "^0.9.0",
     "@heroicons/react": "^2.2.0",
     "@puckeditor/core": "^0.21.1",
@@ -50,6 +53,7 @@
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "lucide-react": "^1.7.0",
+    "nanoid": "^5.1.7",
     "next": "^14.2.0",
     "papaparse": "^5.5.3",
     "proj4": "^2.20.4",

--- a/src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts
+++ b/src/app/admin/properties/[slug]/types/__tests__/layout-actions.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSupabase = {
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => mockSupabase,
+}));
+
+vi.mock('@/lib/tenant/server', () => ({
+  getTenantContext: vi.fn().mockResolvedValue({ orgId: 'org1' }),
+}));
+
+import { saveTypeWithLayout, deleteLayout } from '../layout-actions';
+
+describe('saveTypeWithLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const result = await saveTypeWithLayout({
+      itemTypeId: 't1',
+      layout: { version: 1, blocks: [{ id: 'b1', type: 'divider', config: {} }], spacing: 'comfortable', peekBlockCount: 1 },
+      newFields: [],
+    });
+    expect(result).toEqual({ error: 'Not authenticated' });
+  });
+
+  it('returns error for invalid layout', async () => {
+    const result = await saveTypeWithLayout({
+      itemTypeId: 't1',
+      layout: { version: 1, blocks: [], spacing: 'comfortable', peekBlockCount: 0 } as any,
+      newFields: [],
+    });
+    expect(result).toEqual(expect.objectContaining({ error: expect.stringContaining('Invalid layout') }));
+  });
+
+  it('saves layout and creates new fields', async () => {
+    const updateMock = vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) });
+    const insertMock = vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ data: [{ id: 'new-f1' }], error: null }) });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'item_types') return { update: updateMock };
+      if (table === 'custom_fields') return { insert: insertMock };
+      return {};
+    });
+
+    const result = await saveTypeWithLayout({
+      itemTypeId: 't1',
+      layout: {
+        version: 1,
+        blocks: [{ id: 'b1', type: 'status_badge', config: {} }],
+        spacing: 'comfortable',
+        peekBlockCount: 1,
+      },
+      newFields: [
+        { name: 'Species', field_type: 'dropdown', options: ['Robin'], required: true, sort_order: 0 },
+      ],
+    });
+    expect(result).toEqual(expect.objectContaining({ success: true }));
+  });
+});
+
+describe('deleteLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const result = await deleteLayout('t1');
+    expect(result).toEqual({ error: 'Not authenticated' });
+  });
+
+  it('deletes layout successfully', async () => {
+    const eqMock = vi.fn().mockReturnValue({ error: null });
+    const updateMock = vi.fn().mockReturnValue({ eq: eqMock });
+    mockSupabase.from.mockReturnValue({ update: updateMock });
+
+    const result = await deleteLayout('t1');
+    expect(result).toEqual({ success: true });
+    expect(updateMock).toHaveBeenCalledWith({ layout: null });
+    expect(eqMock).toHaveBeenCalledWith('id', 't1');
+  });
+});

--- a/src/app/admin/properties/[slug]/types/layout-actions.ts
+++ b/src/app/admin/properties/[slug]/types/layout-actions.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { getTenantContext } from '@/lib/tenant/server';
+import { typeLayoutSchema } from '@/lib/layout/schemas';
+import type { TypeLayout } from '@/lib/layout/types';
+
+interface NewField {
+  name: string;
+  field_type: string;
+  options: string[] | null;
+  required: boolean;
+  sort_order: number;
+}
+
+interface SaveTypeWithLayoutInput {
+  itemTypeId: string;
+  layout: TypeLayout;
+  newFields: NewField[];
+}
+
+export async function saveTypeWithLayout(input: SaveTypeWithLayoutInput) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
+
+  // Validate layout
+  const parsed = typeLayoutSchema.safeParse(input.layout);
+  if (!parsed.success) {
+    return { error: `Invalid layout: ${parsed.error.issues[0]?.message ?? 'validation failed'}` };
+  }
+
+  // Create any new fields first
+  const createdFieldIds: string[] = [];
+  if (input.newFields.length > 0) {
+    const { data: newFieldRows, error: fieldError } = await supabase
+      .from('custom_fields')
+      .insert(
+        input.newFields.map((f) => ({
+          item_type_id: input.itemTypeId,
+          name: f.name,
+          field_type: f.field_type,
+          options: f.options,
+          required: f.required,
+          sort_order: f.sort_order,
+          org_id: tenant.orgId,
+        })),
+      )
+      .select();
+
+    if (fieldError) return { error: `Failed to create fields: ${fieldError.message}` };
+    if (newFieldRows) {
+      createdFieldIds.push(...newFieldRows.map((r: { id: string }) => r.id));
+    }
+  }
+
+  // Save layout on item_type
+  const { error: layoutError } = await supabase
+    .from('item_types')
+    .update({ layout: parsed.data })
+    .eq('id', input.itemTypeId);
+
+  if (layoutError) return { error: `Failed to save layout: ${layoutError.message}` };
+
+  return { success: true, createdFieldIds };
+}
+
+export async function deleteLayout(itemTypeId: string) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const { error } = await supabase
+    .from('item_types')
+    .update({ layout: null })
+    .eq('id', itemTypeId);
+
+  if (error) return { error: `Failed to delete layout: ${error.message}` };
+  return { success: true };
+}

--- a/src/app/admin/properties/[slug]/types/page.tsx
+++ b/src/app/admin/properties/[slug]/types/page.tsx
@@ -4,9 +4,11 @@ import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import type { ItemType } from '@/lib/types';
+import type { ItemType, CustomField, EntityType } from '@/lib/types';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import ItemTypeEditor from '@/components/admin/ItemTypeEditor';
+import LayoutBuilder from '@/components/layout/builder/LayoutBuilder';
+import { saveTypeWithLayout } from './layout-actions';
 
 export default function TypesPage() {
   const queryClient = useQueryClient();
@@ -19,18 +21,23 @@ export default function TypesPage() {
   const [newColor, setNewColor] = useState('#5D7F3A');
   const [addError, setAddError] = useState('');
   const [adding, setAdding] = useState(false);
+  const [activeTab, setActiveTab] = useState<'layout' | 'fields' | 'settings'>('layout');
 
   const { data, isLoading: loading } = useQuery({
     queryKey: ['admin', 'property', slug, 'types'],
     queryFn: async () => {
       const supabase = createClient();
 
-      const [typeRes, itemRes] = await Promise.all([
+      const [typeRes, itemRes, fieldRes, entityRes] = await Promise.all([
         supabase.from('item_types').select('*').order('sort_order', { ascending: true }),
         supabase.from('items').select('id, item_type_id'),
+        supabase.from('custom_fields').select('*').order('sort_order', { ascending: true }),
+        supabase.from('entity_types').select('*').order('sort_order', { ascending: true }),
       ]);
 
       const itemTypes: ItemType[] = typeRes.data ?? [];
+      const customFields: CustomField[] = fieldRes.data ?? [];
+      const entityTypes: EntityType[] = entityRes.data ?? [];
 
       // Count items per type
       const itemCounts: Record<string, number> = {};
@@ -40,12 +47,14 @@ export default function TypesPage() {
         }
       }
 
-      return { itemTypes, itemCounts };
+      return { itemTypes, itemCounts, customFields, entityTypes };
     },
   });
 
   const itemTypes = data?.itemTypes ?? [];
   const itemCounts = data?.itemCounts ?? {};
+  const customFields = data?.customFields ?? [];
+  const entityTypes = data?.entityTypes ?? [];
 
   async function handleAddType(e: React.FormEvent) {
     e.preventDefault();
@@ -166,19 +175,68 @@ export default function TypesPage() {
       {/* Item type list */}
       <div className="space-y-3">
         {itemTypes.map((type, index) => (
-          <ItemTypeEditor
-            key={type.id}
-            itemType={type}
-            itemCount={itemCounts[type.id] || 0}
-            isExpanded={expandedId === type.id}
-            onToggleExpand={() => setExpandedId(expandedId === type.id ? null : type.id)}
-            onSave={(updates) => handleSaveType(type.id, updates)}
-            onDelete={() => handleDeleteType(type.id)}
-            onMoveUp={() => handleReorder(type.id, 'up')}
-            onMoveDown={() => handleReorder(type.id, 'down')}
-            isFirst={index === 0}
-            isLast={index === itemTypes.length - 1}
-          />
+          <div key={type.id}>
+            <ItemTypeEditor
+              itemType={type}
+              itemCount={itemCounts[type.id] || 0}
+              isExpanded={expandedId === type.id}
+              onToggleExpand={() => setExpandedId(expandedId === type.id ? null : type.id)}
+              onSave={(updates) => handleSaveType(type.id, updates)}
+              onDelete={() => handleDeleteType(type.id)}
+              onMoveUp={() => handleReorder(type.id, 'up')}
+              onMoveDown={() => handleReorder(type.id, 'down')}
+              isFirst={index === 0}
+              isLast={index === itemTypes.length - 1}
+            />
+            {expandedId === type.id && (
+              <div className="card mt-2">
+                <div className="flex border-b border-sage-light mb-4">
+                  {(['layout', 'fields', 'settings'] as const).map((tab) => (
+                    <button
+                      key={tab}
+                      onClick={() => setActiveTab(tab)}
+                      className={`px-4 py-2 text-sm font-medium ${
+                        activeTab === tab
+                          ? 'text-forest border-b-2 border-forest'
+                          : 'text-sage hover:text-forest-dark'
+                      }`}
+                    >
+                      {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                    </button>
+                  ))}
+                </div>
+                {activeTab === 'layout' && (
+                  <LayoutBuilder
+                    itemType={type}
+                    initialLayout={type.layout}
+                    customFields={customFields.filter((f) => f.item_type_id === type.id)}
+                    entityTypes={entityTypes}
+                    onSave={async (layout, newFields) => {
+                      const fieldsForType = customFields.filter((f) => f.item_type_id === type.id);
+                      const result = await saveTypeWithLayout({
+                        itemTypeId: type.id,
+                        layout,
+                        newFields: newFields.map((f, i) => ({
+                          ...f,
+                          options: f.options.length > 0 ? f.options : null,
+                          sort_order: fieldsForType.length + i,
+                        })),
+                      });
+                      if (result && 'error' in result) throw new Error(result.error);
+                      queryClient.invalidateQueries({ queryKey: ['admin', 'property', slug, 'types'] });
+                    }}
+                    onCancel={() => setActiveTab('settings')}
+                  />
+                )}
+                {activeTab === 'fields' && (
+                  <p className="text-sage text-sm py-4">Custom fields are managed within the type editor above.</p>
+                )}
+                {activeTab === 'settings' && (
+                  <p className="text-sage text-sm py-4">Settings are managed within the type editor above.</p>
+                )}
+              </div>
+            )}
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/item/DetailPanel.tsx
+++ b/src/components/item/DetailPanel.tsx
@@ -18,9 +18,10 @@ interface DetailPanelProps {
   isAuthenticated?: boolean;
   canEditItem?: boolean;
   canAddUpdate?: boolean;
+  onSheetStateChange?: (state: SheetState | null) => void;
 }
 
-export default function DetailPanel({ item, onClose, isAuthenticated, canEditItem, canAddUpdate }: DetailPanelProps) {
+export default function DetailPanel({ item, onClose, isAuthenticated, canEditItem, canAddUpdate, onSheetStateChange }: DetailPanelProps) {
   const [isMobile, setIsMobile] = useState(false);
   const [sheetState, setSheetState] = useState<SheetState>('peek');
 
@@ -32,8 +33,13 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   }, []);
 
   useEffect(() => {
-    if (item) setSheetState('peek');
-  }, [item?.id]);
+    if (item) {
+      setSheetState('peek');
+      onSheetStateChange?.('peek');
+    } else {
+      onSheetStateChange?.(null);
+    }
+  }, [item?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { position } = useUserLocation();
 
@@ -208,7 +214,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   // Mobile: bottom sheet
   if (isMobile) {
     return (
-      <MultiSnapBottomSheet isOpen={!!item} onClose={onClose} onStateChange={setSheetState} initialState="peek">
+      <MultiSnapBottomSheet isOpen={!!item} onClose={onClose} onStateChange={(s) => { setSheetState(s); onSheetStateChange?.(s); }} initialState="peek">
         {content}
       </MultiSnapBottomSheet>
     );

--- a/src/components/item/DetailPanel.tsx
+++ b/src/components/item/DetailPanel.tsx
@@ -3,13 +3,14 @@
 import type { ItemWithDetails } from '@/lib/types';
 import StatusBadge from './StatusBadge';
 import UpdateTimeline from './UpdateTimeline';
-import BottomSheet from '@/components/ui/BottomSheet';
+import MultiSnapBottomSheet, { type SheetState } from '@/components/ui/MultiSnapBottomSheet';
 import { formatDate } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { useUserLocation } from '@/lib/location/provider';
 import { getDistanceToItem, formatDistance } from '@/lib/location/utils';
 import Link from 'next/link';
 import PhotoViewer from '@/components/ui/PhotoViewer';
+import LayoutRenderer from '@/components/layout/LayoutRenderer';
 
 interface DetailPanelProps {
   item: ItemWithDetails | null;
@@ -21,6 +22,7 @@ interface DetailPanelProps {
 
 export default function DetailPanel({ item, onClose, isAuthenticated, canEditItem, canAddUpdate }: DetailPanelProps) {
   const [isMobile, setIsMobile] = useState(false);
+  const [sheetState, setSheetState] = useState<SheetState>('peek');
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
@@ -29,13 +31,55 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
     return () => window.removeEventListener('resize', check);
   }, []);
 
+  useEffect(() => {
+    if (item) setSheetState('peek');
+  }, [item?.id]);
+
   const { position } = useUserLocation();
 
   if (!item) return null;
 
   const distance = getDistanceToItem(position, item);
+  const layout = item.item_type?.layout ?? null;
 
-  const content = (
+  const content = layout ? (
+    <div>
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            {item.item_type && <span className="text-xl">{item.item_type.icon}</span>}
+            <h2 className="font-heading font-semibold text-forest-dark text-xl">
+              {item.name}
+            </h2>
+          </div>
+          {distance != null && (
+            <span className="text-xs text-forest">
+              {formatDistance(distance)} away
+            </span>
+          )}
+        </div>
+        {!isMobile && (
+          <button
+            onClick={onClose}
+            className="ml-2 p-1 rounded-lg text-sage hover:bg-sage-light transition-colors"
+            aria-label="Close panel"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+      <LayoutRenderer
+        layout={layout}
+        item={item}
+        mode="live"
+        context={isMobile ? 'bottom-sheet' : 'side-panel'}
+        sheetState={isMobile ? sheetState : undefined}
+        customFields={item.custom_fields ?? []}
+      />
+    </div>
+  ) : (
     <div>
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">
@@ -164,9 +208,9 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   // Mobile: bottom sheet
   if (isMobile) {
     return (
-      <BottomSheet isOpen={!!item} onClose={onClose}>
+      <MultiSnapBottomSheet isOpen={!!item} onClose={onClose} onStateChange={setSheetState} initialState="peek">
         {content}
-      </BottomSheet>
+      </MultiSnapBottomSheet>
     );
   }
 

--- a/src/components/layout/BlockErrorBoundary.tsx
+++ b/src/components/layout/BlockErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Props {
+  blockType: string;
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class BlockErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn(`[BlockErrorBoundary] Error in block type "${this.props.blockType}":`, error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <p className="text-sm text-sage italic">Unable to display this block</p>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/layout/LayoutRenderer.tsx
+++ b/src/components/layout/LayoutRenderer.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import type { TypeLayout, LayoutNode, LayoutBlock } from '@/lib/layout/types';
+import type { ItemWithDetails, CustomField } from '@/lib/types';
+import { isLayoutRow } from '@/lib/layout/types';
+import { SPACING } from '@/lib/layout/spacing';
+import BlockErrorBoundary from './BlockErrorBoundary';
+import StatusBadgeBlock from './blocks/StatusBadgeBlock';
+import FieldDisplayBlock from './blocks/FieldDisplayBlock';
+import PhotoGalleryBlock from './blocks/PhotoGalleryBlock';
+import TextLabelBlock from './blocks/TextLabelBlock';
+import DividerBlock from './blocks/DividerBlock';
+import ActionButtonsBlock from './blocks/ActionButtonsBlock';
+import MapSnippetBlock from './blocks/MapSnippetBlock';
+import EntityListBlock from './blocks/EntityListBlock';
+import TimelineBlock from './blocks/TimelineBlock';
+import RowBlock from './blocks/RowBlock';
+import type { EntityDisplay } from './blocks/EntityListBlock';
+
+export interface LayoutRendererProps {
+  layout: TypeLayout;
+  item: ItemWithDetails;
+  mode: 'live' | 'preview';
+  context: 'bottom-sheet' | 'side-panel' | 'preview';
+  sheetState?: 'peek' | 'half' | 'full';
+  customFields: CustomField[];
+}
+
+function renderBlock(
+  node: LayoutNode,
+  index: number,
+  props: LayoutRendererProps
+): React.ReactNode {
+  const { item, mode, context, customFields } = props;
+
+  if (isLayoutRow(node)) {
+    const children = node.children.map((child, childIndex) =>
+      renderBlock(child, childIndex, props)
+    );
+    return (
+      <BlockErrorBoundary key={node.id} blockType="row">
+        <RowBlock row={node}>{children as React.ReactNode[]}</RowBlock>
+      </BlockErrorBoundary>
+    );
+  }
+
+  const block = node as LayoutBlock;
+
+  // hideWhenEmpty: check for data presence before rendering
+  if (block.hideWhenEmpty) {
+    if (block.type === 'field_display') {
+      const config = block.config as import('@/lib/layout/types').FieldDisplayConfig;
+      const value = item.custom_field_values[config.fieldId];
+      if (value === null || value === undefined) return null;
+    }
+  }
+
+  const rendered = renderBlockContent(block, index, props);
+  if (rendered === null) return null;
+
+  return (
+    <BlockErrorBoundary key={block.id} blockType={block.type}>
+      {rendered}
+    </BlockErrorBoundary>
+  );
+}
+
+function renderBlockContent(
+  block: LayoutBlock,
+  index: number,
+  props: LayoutRendererProps
+): React.ReactNode {
+  const { item, mode, context, customFields } = props;
+
+  switch (block.type) {
+    case 'status_badge': {
+      return <StatusBadgeBlock status={item.status} />;
+    }
+
+    case 'field_display': {
+      const config = block.config as import('@/lib/layout/types').FieldDisplayConfig;
+      const field = customFields.find((f) => f.id === config.fieldId);
+      const value = item.custom_field_values[config.fieldId];
+      return <FieldDisplayBlock config={config} field={field} value={value} />;
+    }
+
+    case 'photo_gallery': {
+      const config = block.config as import('@/lib/layout/types').PhotoGalleryConfig;
+      const isEdgeToEdge =
+        context === 'bottom-sheet' && config.style === 'hero' && index <= 1;
+      return (
+        <PhotoGalleryBlock
+          config={config}
+          photos={item.photos}
+          isEdgeToEdge={isEdgeToEdge}
+        />
+      );
+    }
+
+    case 'text_label': {
+      const config = block.config as import('@/lib/layout/types').TextLabelConfig;
+      return <TextLabelBlock config={config} />;
+    }
+
+    case 'divider': {
+      return <DividerBlock />;
+    }
+
+    case 'action_buttons': {
+      return (
+        <ActionButtonsBlock
+          itemId={item.id}
+          canEdit={true}
+          canAddUpdate={true}
+          mode={mode}
+        />
+      );
+    }
+
+    case 'map_snippet': {
+      return (
+        <MapSnippetBlock
+          latitude={item.latitude}
+          longitude={item.longitude}
+          context={context}
+        />
+      );
+    }
+
+    case 'entity_list': {
+      const config = block.config as import('@/lib/layout/types').EntityListConfig;
+      const entities: EntityDisplay[] = item.entities.map((e) => ({
+        id: e.id,
+        name: e.name,
+        entity_type: {
+          id: e.entity_type.id,
+          name: e.entity_type.name,
+          icon: e.entity_type.icon,
+        },
+      }));
+      return <EntityListBlock config={config} entities={entities} />;
+    }
+
+    case 'timeline': {
+      const config = block.config as import('@/lib/layout/types').TimelineConfig;
+      const updates = item.updates.map((u) => ({
+        id: u.id,
+        item_id: u.item_id,
+        update_type_id: u.update_type_id,
+        content: u.content,
+        update_date: u.update_date,
+        created_at: u.created_at,
+        created_by: u.created_by,
+        org_id: u.org_id,
+        property_id: u.property_id,
+        custom_field_values: u.custom_field_values,
+      }));
+      return <TimelineBlock config={config} updates={updates} />;
+    }
+
+    default:
+      return null;
+  }
+}
+
+export default function LayoutRenderer(props: LayoutRendererProps) {
+  const { layout, sheetState, context } = props;
+  const spacing = SPACING[layout.spacing];
+
+  // Determine which blocks to render
+  const isPeek = sheetState === 'peek' && context === 'bottom-sheet';
+  const nodes = isPeek
+    ? layout.blocks.slice(0, layout.peekBlockCount)
+    : layout.blocks;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.blockGap }}>
+      {nodes.map((node, index) => renderBlock(node, index, props))}
+    </div>
+  );
+}

--- a/src/components/layout/__tests__/LayoutRenderer.test.tsx
+++ b/src/components/layout/__tests__/LayoutRenderer.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { TypeLayout, LayoutNode } from '@/lib/layout/types';
+import type { ItemWithDetails, CustomField } from '@/lib/types';
+
+// Mock all block components
+vi.mock('@/components/layout/BlockErrorBoundary', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/layout/blocks/StatusBadgeBlock', () => ({
+  default: () => <div data-testid="block-status_badge" />,
+}));
+
+vi.mock('@/components/layout/blocks/FieldDisplayBlock', () => ({
+  default: ({ field }: { field?: { name: string } }) => (
+    <div data-testid="block-field_display">{field?.name}</div>
+  ),
+}));
+
+vi.mock('@/components/layout/blocks/PhotoGalleryBlock', () => ({
+  default: () => <div data-testid="block-photo_gallery" />,
+}));
+
+vi.mock('@/components/layout/blocks/TextLabelBlock', () => ({
+  default: () => <div data-testid="block-text_label" />,
+}));
+
+vi.mock('@/components/layout/blocks/DividerBlock', () => ({
+  default: () => <div data-testid="block-divider" />,
+}));
+
+vi.mock('@/components/layout/blocks/ActionButtonsBlock', () => ({
+  default: () => <div data-testid="block-action_buttons" />,
+}));
+
+vi.mock('@/components/layout/blocks/MapSnippetBlock', () => ({
+  default: () => <div data-testid="block-map_snippet" />,
+}));
+
+vi.mock('@/components/layout/blocks/EntityListBlock', () => ({
+  default: () => <div data-testid="block-entity_list" />,
+}));
+
+vi.mock('@/components/layout/blocks/TimelineBlock', () => ({
+  default: () => <div data-testid="block-timeline" />,
+}));
+
+vi.mock('@/components/layout/blocks/RowBlock', () => ({
+  default: ({ children }: { children: React.ReactNode[] }) => (
+    <div data-testid="block-row">{children}</div>
+  ),
+}));
+
+import LayoutRenderer from '../LayoutRenderer';
+
+// =====================
+// Shared test data helpers
+// =====================
+
+function makeBlock(type: string, id = `block-${type}`): LayoutNode {
+  return {
+    id,
+    type: type as any,
+    config: {} as any,
+  };
+}
+
+function makeLayout(blocks: LayoutNode[], peekBlockCount = 2): TypeLayout {
+  return {
+    version: 1,
+    blocks,
+    spacing: 'comfortable',
+    peekBlockCount,
+  };
+}
+
+const baseItem: ItemWithDetails = {
+  id: 'item-1',
+  name: 'Test Item',
+  description: null,
+  latitude: 40.0,
+  longitude: -75.0,
+  item_type_id: 'type-1',
+  custom_field_values: {},
+  status: 'active',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  created_by: null,
+  org_id: 'org-1',
+  property_id: 'prop-1',
+  item_type: {
+    id: 'type-1',
+    name: 'Birdhouse',
+    icon: '🏠',
+    color: '#green',
+    sort_order: 0,
+    layout: null,
+    created_at: '2024-01-01T00:00:00Z',
+    org_id: 'org-1',
+  },
+  updates: [],
+  photos: [],
+  custom_fields: [],
+  entities: [],
+};
+
+const baseCustomFields: CustomField[] = [
+  {
+    id: 'field-1',
+    item_type_id: 'type-1',
+    name: 'Species',
+    field_type: 'text',
+    options: null,
+    required: false,
+    sort_order: 0,
+    org_id: 'org-1',
+  },
+];
+
+// =====================
+// Tests
+// =====================
+
+describe('LayoutRenderer', () => {
+  it('renders blocks in order (3 blocks → 3 elements)', () => {
+    const layout = makeLayout([
+      makeBlock('status_badge', 'b1'),
+      makeBlock('text_label', 'b2'),
+      makeBlock('divider', 'b3'),
+    ]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="live"
+        context="side-panel"
+        customFields={[]}
+      />
+    );
+
+    expect(screen.getByTestId('block-status_badge')).toBeDefined();
+    expect(screen.getByTestId('block-text_label')).toBeDefined();
+    expect(screen.getByTestId('block-divider')).toBeDefined();
+  });
+
+  it('renders field_display and passes field data via customFields', () => {
+    const layout = makeLayout([
+      {
+        id: 'fd-1',
+        type: 'field_display',
+        config: { fieldId: 'field-1', size: 'normal', showLabel: true },
+      },
+    ]);
+
+    const item: ItemWithDetails = {
+      ...baseItem,
+      custom_field_values: { 'field-1': 'Oak' },
+    };
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={item}
+        mode="live"
+        context="side-panel"
+        customFields={baseCustomFields}
+      />
+    );
+
+    const block = screen.getByTestId('block-field_display');
+    expect(block).toBeDefined();
+    // The mock renders field.name — "Species" — inside the block
+    expect(block.textContent).toBe('Species');
+  });
+
+  it('renders rows with children', () => {
+    const layout = makeLayout([
+      {
+        id: 'row-1',
+        type: 'row',
+        gap: 'normal',
+        distribution: 'equal',
+        children: [
+          makeBlock('status_badge', 'b1') as any,
+          makeBlock('divider', 'b2') as any,
+        ],
+      },
+    ]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="live"
+        context="side-panel"
+        customFields={[]}
+      />
+    );
+
+    const row = screen.getByTestId('block-row');
+    expect(row).toBeDefined();
+    // Children should be inside the row
+    expect(screen.getByTestId('block-status_badge')).toBeDefined();
+    expect(screen.getByTestId('block-divider')).toBeDefined();
+  });
+
+  it('limits blocks in peek state (3 blocks, peekBlockCount=2 → only 2 rendered)', () => {
+    const layout = makeLayout(
+      [
+        makeBlock('status_badge', 'b1'),
+        makeBlock('text_label', 'b2'),
+        makeBlock('divider', 'b3'),
+      ],
+      2 // peekBlockCount
+    );
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="live"
+        context="bottom-sheet"
+        sheetState="peek"
+        customFields={[]}
+      />
+    );
+
+    expect(screen.getByTestId('block-status_badge')).toBeDefined();
+    expect(screen.getByTestId('block-text_label')).toBeDefined();
+    expect(screen.queryByTestId('block-divider')).toBeNull();
+  });
+
+  it('renders all blocks in full state', () => {
+    const layout = makeLayout(
+      [
+        makeBlock('status_badge', 'b1'),
+        makeBlock('text_label', 'b2'),
+        makeBlock('divider', 'b3'),
+      ],
+      1 // peekBlockCount — would limit to 1 if peek
+    );
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="live"
+        context="bottom-sheet"
+        sheetState="full"
+        customFields={[]}
+      />
+    );
+
+    expect(screen.getByTestId('block-status_badge')).toBeDefined();
+    expect(screen.getByTestId('block-text_label')).toBeDefined();
+    expect(screen.getByTestId('block-divider')).toBeDefined();
+  });
+
+  it('skips blocks with unknown type gracefully', () => {
+    const layout = makeLayout([
+      makeBlock('status_badge', 'b1'),
+      makeBlock('unknown_type_xyz', 'b2'),
+      makeBlock('divider', 'b3'),
+    ]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="live"
+        context="side-panel"
+        customFields={[]}
+      />
+    );
+
+    expect(screen.getByTestId('block-status_badge')).toBeDefined();
+    expect(screen.getByTestId('block-divider')).toBeDefined();
+    // unknown block renders nothing — no error thrown
+  });
+});

--- a/src/components/layout/blocks/ActionButtonsBlock.tsx
+++ b/src/components/layout/blocks/ActionButtonsBlock.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+interface ActionButtonsBlockProps {
+  itemId: string;
+  canEdit: boolean;
+  canAddUpdate: boolean;
+  mode: 'live' | 'preview';
+}
+
+export default function ActionButtonsBlock({ itemId, canEdit, canAddUpdate, mode }: ActionButtonsBlockProps) {
+  if (mode === 'preview') {
+    return (
+      <div className="flex flex-wrap gap-2 opacity-60">
+        {canEdit && (
+          <button disabled className="btn-secondary text-sm cursor-not-allowed">
+            Edit
+          </button>
+        )}
+        {canAddUpdate && (
+          <button disabled className="btn-primary text-sm cursor-not-allowed">
+            Add Update
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {canEdit && (
+        <Link href={`/manage/edit/${itemId}`} className="btn-secondary text-sm">
+          Edit
+        </Link>
+      )}
+      {canAddUpdate && (
+        <Link href={`/manage/update?item=${itemId}`} className="btn-primary text-sm">
+          Add Update
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/blocks/DividerBlock.tsx
+++ b/src/components/layout/blocks/DividerBlock.tsx
@@ -1,0 +1,3 @@
+export default function DividerBlock() {
+  return <hr className="border-sage-light" />;
+}

--- a/src/components/layout/blocks/EntityListBlock.tsx
+++ b/src/components/layout/blocks/EntityListBlock.tsx
@@ -1,0 +1,56 @@
+import type { EntityListConfig } from '@/lib/layout/types';
+
+export interface EntityDisplay {
+  id: string;
+  name: string;
+  entity_type: {
+    id: string;
+    name: string;
+    icon: string;
+  };
+}
+
+interface EntityListBlockProps {
+  config: EntityListConfig;
+  entities: EntityDisplay[];
+}
+
+export default function EntityListBlock({ config, entities }: EntityListBlockProps) {
+  const filtered = config.entityTypeIds.length > 0
+    ? entities.filter((e) => config.entityTypeIds.includes(e.entity_type.id))
+    : entities;
+
+  if (filtered.length === 0) return null;
+
+  // Group by entity type
+  const grouped = new Map<string, { type: EntityDisplay['entity_type']; items: EntityDisplay[] }>();
+  for (const entity of filtered) {
+    const key = entity.entity_type.id;
+    if (!grouped.has(key)) {
+      grouped.set(key, { type: entity.entity_type, items: [] });
+    }
+    grouped.get(key)!.items.push(entity);
+  }
+
+  return (
+    <div className="space-y-2">
+      {Array.from(grouped.values()).map(({ type, items }) => (
+        <div key={type.id}>
+          <p className="text-xs font-medium text-sage uppercase tracking-wide mb-1">
+            {type.icon} {type.name}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {items.map((entity) => (
+              <span
+                key={entity.id}
+                className="inline-flex items-center bg-forest/10 text-forest-dark text-xs px-2 py-0.5 rounded-full"
+              >
+                {entity.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/blocks/FieldDisplayBlock.tsx
+++ b/src/components/layout/blocks/FieldDisplayBlock.tsx
@@ -1,0 +1,42 @@
+import type { CustomField } from '@/lib/types';
+import type { FieldDisplayConfig } from '@/lib/layout/types';
+import { formatDate } from '@/lib/utils';
+
+interface FieldDisplayBlockProps {
+  config: FieldDisplayConfig;
+  field: CustomField | undefined;
+  value: unknown;
+}
+
+const sizeClasses: Record<FieldDisplayConfig['size'], string> = {
+  compact: 'text-sm',
+  normal: 'text-sm',
+  large: 'text-xl font-semibold leading-tight',
+};
+
+function formatValue(field: CustomField, value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (field.field_type === 'date') {
+    return formatDate(String(value));
+  }
+  return String(value);
+}
+
+export default function FieldDisplayBlock({ config, field, value }: FieldDisplayBlockProps) {
+  if (!field) return null;
+
+  const displayValue = (value === null || value === undefined)
+    ? '—'
+    : formatValue(field, value);
+
+  return (
+    <div>
+      {config.showLabel && (
+        <p className="text-xs font-medium text-sage uppercase tracking-wide mb-0.5">
+          {field.name}
+        </p>
+      )}
+      <p className={sizeClasses[config.size]}>{displayValue}</p>
+    </div>
+  );
+}

--- a/src/components/layout/blocks/MapSnippetBlock.tsx
+++ b/src/components/layout/blocks/MapSnippetBlock.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+interface MapSnippetBlockProps {
+  latitude: number;
+  longitude: number;
+  context: 'bottom-sheet' | 'side-panel' | 'preview';
+}
+
+const MapSnippetInner = dynamic(() => import('./MapSnippetInner'), { ssr: false });
+
+export default function MapSnippetBlock({ latitude, longitude, context }: MapSnippetBlockProps) {
+  if (context === 'bottom-sheet') return null;
+
+  return (
+    <div className="h-32 rounded-lg border border-sage-light overflow-hidden">
+      <MapSnippetInner latitude={latitude} longitude={longitude} />
+    </div>
+  );
+}

--- a/src/components/layout/blocks/MapSnippetInner.tsx
+++ b/src/components/layout/blocks/MapSnippetInner.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+
+// Fix default marker icon for Next.js/webpack
+const defaultIcon = L.icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+});
+
+interface MapSnippetInnerProps {
+  latitude: number;
+  longitude: number;
+}
+
+export default function MapSnippetInner({ latitude, longitude }: MapSnippetInnerProps) {
+  return (
+    <MapContainer
+      center={[latitude, longitude]}
+      zoom={15}
+      zoomControl={false}
+      dragging={false}
+      scrollWheelZoom={false}
+      doubleClickZoom={false}
+      touchZoom={false}
+      style={{ height: '100%', width: '100%' }}
+    >
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+      />
+      <Marker position={[latitude, longitude]} icon={defaultIcon} />
+    </MapContainer>
+  );
+}

--- a/src/components/layout/blocks/PhotoGalleryBlock.tsx
+++ b/src/components/layout/blocks/PhotoGalleryBlock.tsx
@@ -1,0 +1,21 @@
+import type { Photo } from '@/lib/types';
+import type { PhotoGalleryConfig } from '@/lib/layout/types';
+import PhotoViewer from '@/components/ui/PhotoViewer';
+
+interface PhotoGalleryBlockProps {
+  config: PhotoGalleryConfig;
+  photos: Photo[];
+  isEdgeToEdge?: boolean;
+}
+
+export default function PhotoGalleryBlock({ config, photos, isEdgeToEdge }: PhotoGalleryBlockProps) {
+  if (!photos || photos.length === 0) return null;
+
+  const limited = photos.slice(0, config.maxPhotos);
+
+  return (
+    <div className={isEdgeToEdge ? '-mx-4' : undefined}>
+      <PhotoViewer photos={limited} />
+    </div>
+  );
+}

--- a/src/components/layout/blocks/RowBlock.tsx
+++ b/src/components/layout/blocks/RowBlock.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import type { LayoutRow } from '@/lib/layout/types';
+
+interface RowBlockProps {
+  row: LayoutRow;
+  children: ReactNode[];
+  containerWidth?: number;
+}
+
+export const ROW_COLLAPSE_BREAKPOINT = 480;
+
+const gapClasses: Record<LayoutRow['gap'], string> = {
+  tight: 'gap-2',
+  normal: 'gap-3',
+  loose: 'gap-4',
+};
+
+function getGridTemplateColumns(distribution: LayoutRow['distribution'], count: number): string {
+  if (distribution === 'equal') {
+    return `repeat(${count}, 1fr)`;
+  }
+  if (distribution === 'auto') {
+    return `repeat(${count}, auto)`;
+  }
+  // number[] — fractional widths
+  return (distribution as number[]).map((n) => `${n}fr`).join(' ');
+}
+
+export default function RowBlock({ row, children, containerWidth }: RowBlockProps) {
+  const isCollapsed = containerWidth !== undefined && containerWidth < ROW_COLLAPSE_BREAKPOINT;
+
+  if (isCollapsed) {
+    return (
+      <div className={`flex flex-col ${gapClasses[row.gap]}`}>
+        {children}
+      </div>
+    );
+  }
+
+  const gridTemplateColumns = getGridTemplateColumns(row.distribution, children.length);
+
+  return (
+    <div
+      className={`grid ${gapClasses[row.gap]}`}
+      style={{ gridTemplateColumns }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/blocks/StatusBadgeBlock.tsx
+++ b/src/components/layout/blocks/StatusBadgeBlock.tsx
@@ -1,0 +1,10 @@
+import type { ItemStatus } from '@/lib/types';
+import StatusBadge from '@/components/item/StatusBadge';
+
+interface StatusBadgeBlockProps {
+  status: ItemStatus;
+}
+
+export default function StatusBadgeBlock({ status }: StatusBadgeBlockProps) {
+  return <StatusBadge status={status} />;
+}

--- a/src/components/layout/blocks/TextLabelBlock.tsx
+++ b/src/components/layout/blocks/TextLabelBlock.tsx
@@ -1,0 +1,16 @@
+import type { TextLabelConfig } from '@/lib/layout/types';
+
+interface TextLabelBlockProps {
+  config: TextLabelConfig;
+}
+
+const styleClasses: Record<TextLabelConfig['style'], string> = {
+  heading: 'text-lg font-semibold text-forest-dark leading-snug',
+  subheading: 'text-[15px] font-medium text-forest-dark leading-snug',
+  body: 'text-sm text-forest-dark/80 leading-relaxed',
+  caption: 'text-xs text-sage leading-snug',
+};
+
+export default function TextLabelBlock({ config }: TextLabelBlockProps) {
+  return <p className={styleClasses[config.style]}>{config.text}</p>;
+}

--- a/src/components/layout/blocks/TimelineBlock.tsx
+++ b/src/components/layout/blocks/TimelineBlock.tsx
@@ -1,0 +1,20 @@
+import type { ItemUpdate } from '@/lib/types';
+import type { TimelineConfig } from '@/lib/layout/types';
+import UpdateTimeline from '@/components/item/UpdateTimeline';
+
+interface TimelineBlockProps {
+  config: TimelineConfig;
+  updates: ItemUpdate[];
+}
+
+export default function TimelineBlock({ config, updates }: TimelineBlockProps) {
+  if (!config.showUpdates) return null;
+
+  const limited = updates.slice(0, config.maxItems);
+
+  if (limited.length === 0) {
+    return <p className="text-sm text-sage italic">No activity yet</p>;
+  }
+
+  return <UpdateTimeline updates={limited} />;
+}

--- a/src/components/layout/blocks/__tests__/blocks.test.tsx
+++ b/src/components/layout/blocks/__tests__/blocks.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Mock child components
+vi.mock('@/components/item/StatusBadge', () => ({
+  default: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+vi.mock('@/components/item/UpdateTimeline', () => ({
+  default: ({ updates }: { updates: unknown[] }) => (
+    <div data-testid="update-timeline">
+      {updates.map((u: any) => (
+        <div key={u.id} data-testid="timeline-item">{u.content}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ui/PhotoViewer', () => ({
+  default: ({ photos }: { photos: unknown[] }) => (
+    <div data-testid="photo-viewer">{photos.length} photos</div>
+  ),
+}));
+
+import StatusBadgeBlock from '../StatusBadgeBlock';
+import FieldDisplayBlock from '../FieldDisplayBlock';
+import TextLabelBlock from '../TextLabelBlock';
+import DividerBlock from '../DividerBlock';
+import EntityListBlock from '../EntityListBlock';
+import TimelineBlock from '../TimelineBlock';
+import type { CustomField } from '@/lib/types';
+import type { FieldDisplayConfig, TextLabelConfig, EntityListConfig, TimelineConfig } from '@/lib/layout/types';
+
+// =====================
+// StatusBadgeBlock
+// =====================
+describe('StatusBadgeBlock', () => {
+  it('renders the StatusBadge with given status', () => {
+    render(<StatusBadgeBlock status="active" />);
+    const badge = screen.getByTestId('status-badge');
+    expect(badge).toBeDefined();
+    expect(badge.textContent).toBe('active');
+  });
+
+  it('passes damaged status through', () => {
+    render(<StatusBadgeBlock status="damaged" />);
+    expect(screen.getByTestId('status-badge').textContent).toBe('damaged');
+  });
+});
+
+// =====================
+// FieldDisplayBlock
+// =====================
+describe('FieldDisplayBlock', () => {
+  const field: CustomField = {
+    id: 'field-1',
+    item_type_id: 'type-1',
+    name: 'Species',
+    field_type: 'text',
+    options: null,
+    required: false,
+    sort_order: 0,
+    org_id: 'org-1',
+  };
+
+  const baseConfig: FieldDisplayConfig = {
+    fieldId: 'field-1',
+    size: 'normal',
+    showLabel: true,
+  };
+
+  it('renders label and value', () => {
+    render(<FieldDisplayBlock config={baseConfig} field={field} value="Oak" />);
+    expect(screen.getByText('Species')).toBeDefined();
+    expect(screen.getByText('Oak')).toBeDefined();
+  });
+
+  it('hides label when showLabel is false', () => {
+    const config = { ...baseConfig, showLabel: false };
+    render(<FieldDisplayBlock config={config} field={field} value="Oak" />);
+    expect(screen.queryByText('Species')).toBeNull();
+    expect(screen.getByText('Oak')).toBeDefined();
+  });
+
+  it('shows dash for null value', () => {
+    render(<FieldDisplayBlock config={baseConfig} field={field} value={null} />);
+    expect(screen.getByText('—')).toBeDefined();
+  });
+
+  it('shows dash for undefined value', () => {
+    render(<FieldDisplayBlock config={baseConfig} field={field} value={undefined} />);
+    expect(screen.getByText('—')).toBeDefined();
+  });
+
+  it('returns null when field is undefined', () => {
+    const { container } = render(
+      <FieldDisplayBlock config={baseConfig} field={undefined} value="Oak" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('applies large size class', () => {
+    const config = { ...baseConfig, size: 'large' as const, showLabel: false };
+    const { container } = render(<FieldDisplayBlock config={config} field={field} value="Oak" />);
+    const p = container.querySelector('p');
+    expect(p?.className).toContain('text-xl');
+    expect(p?.className).toContain('font-semibold');
+  });
+
+  it('formats date fields using formatDate', () => {
+    const dateField: CustomField = { ...field, field_type: 'date' };
+    render(<FieldDisplayBlock config={baseConfig} field={dateField} value="2024-03-15" />);
+    // formatDate uses toLocaleDateString — just check the raw ISO string is not shown
+    expect(screen.queryByText('2024-03-15')).toBeNull();
+    // formatted date should include the year 2024 and the word March
+    expect(screen.getByText(/March.*2024/)).toBeDefined();
+  });
+});
+
+// =====================
+// TextLabelBlock
+// =====================
+describe('TextLabelBlock', () => {
+  it('renders heading with correct class', () => {
+    const config: TextLabelConfig = { text: 'Hello World', style: 'heading' };
+    const { container } = render(<TextLabelBlock config={config} />);
+    const p = container.querySelector('p');
+    expect(p?.textContent).toBe('Hello World');
+    expect(p?.className).toContain('text-lg');
+    expect(p?.className).toContain('font-semibold');
+  });
+
+  it('renders caption with correct class', () => {
+    const config: TextLabelConfig = { text: 'A note', style: 'caption' };
+    const { container } = render(<TextLabelBlock config={config} />);
+    const p = container.querySelector('p');
+    expect(p?.className).toContain('text-xs');
+    expect(p?.className).toContain('text-sage');
+  });
+
+  it('renders subheading style', () => {
+    const config: TextLabelConfig = { text: 'Sub', style: 'subheading' };
+    const { container } = render(<TextLabelBlock config={config} />);
+    const p = container.querySelector('p');
+    expect(p?.className).toContain('font-medium');
+  });
+
+  it('renders body style', () => {
+    const config: TextLabelConfig = { text: 'Body text', style: 'body' };
+    const { container } = render(<TextLabelBlock config={config} />);
+    const p = container.querySelector('p');
+    expect(p?.className).toContain('leading-relaxed');
+  });
+});
+
+// =====================
+// DividerBlock
+// =====================
+describe('DividerBlock', () => {
+  it('renders an hr element', () => {
+    const { container } = render(<DividerBlock />);
+    const hr = container.querySelector('hr');
+    expect(hr).toBeDefined();
+    expect(hr?.className).toContain('border-sage-light');
+  });
+});
+
+// =====================
+// EntityListBlock
+// =====================
+describe('EntityListBlock', () => {
+  const trees = [
+    { id: 'e1', name: 'White Oak', entity_type: { id: 'et1', name: 'Tree', icon: '🌳' } },
+    { id: 'e2', name: 'Red Maple', entity_type: { id: 'et1', name: 'Tree', icon: '🌳' } },
+  ];
+
+  const birds = [
+    { id: 'e3', name: 'Robin', entity_type: { id: 'et2', name: 'Bird', icon: '🐦' } },
+  ];
+
+  const allEntities = [...trees, ...birds];
+
+  it('renders grouped entities with type label', () => {
+    const config: EntityListConfig = { entityTypeIds: [] };
+    render(<EntityListBlock config={config} entities={allEntities} />);
+    expect(screen.getByText('White Oak')).toBeDefined();
+    expect(screen.getByText('Red Maple')).toBeDefined();
+    expect(screen.getByText('Robin')).toBeDefined();
+    // type labels
+    expect(screen.getByText(/Tree/)).toBeDefined();
+    expect(screen.getByText(/Bird/)).toBeDefined();
+  });
+
+  it('filters by entityTypeIds', () => {
+    const config: EntityListConfig = { entityTypeIds: ['et1'] };
+    render(<EntityListBlock config={config} entities={allEntities} />);
+    expect(screen.getByText('White Oak')).toBeDefined();
+    expect(screen.getByText('Red Maple')).toBeDefined();
+    expect(screen.queryByText('Robin')).toBeNull();
+  });
+
+  it('returns null when no entities match filter', () => {
+    const config: EntityListConfig = { entityTypeIds: ['nonexistent'] };
+    const { container } = render(<EntityListBlock config={config} entities={allEntities} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null for empty entities array with no filter', () => {
+    const config: EntityListConfig = { entityTypeIds: [] };
+    const { container } = render(<EntityListBlock config={config} entities={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// =====================
+// TimelineBlock
+// =====================
+describe('TimelineBlock', () => {
+  const makeUpdate = (id: string, content: string) => ({
+    id,
+    item_id: 'item-1',
+    update_type_id: 'ut-1',
+    content,
+    update_date: '2024-01-01T00:00:00Z',
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: null,
+    org_id: 'org-1',
+    property_id: 'prop-1',
+    custom_field_values: {},
+  });
+
+  const updates = [
+    makeUpdate('u1', 'First update'),
+    makeUpdate('u2', 'Second update'),
+    makeUpdate('u3', 'Third update'),
+  ];
+
+  const baseConfig: TimelineConfig = {
+    showUpdates: true,
+    showScheduled: false,
+    maxItems: 10,
+  };
+
+  it('renders the UpdateTimeline with updates', () => {
+    render(<TimelineBlock config={baseConfig} updates={updates} />);
+    expect(screen.getByTestId('update-timeline')).toBeDefined();
+    expect(screen.getAllByTestId('timeline-item')).toHaveLength(3);
+  });
+
+  it('shows empty message when no updates', () => {
+    render(<TimelineBlock config={baseConfig} updates={[]} />);
+    expect(screen.getByText('No activity yet')).toBeDefined();
+    expect(screen.queryByTestId('update-timeline')).toBeNull();
+  });
+
+  it('returns null when showUpdates is false', () => {
+    const config = { ...baseConfig, showUpdates: false };
+    const { container } = render(<TimelineBlock config={config} updates={updates} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('limits updates to maxItems', () => {
+    const config = { ...baseConfig, maxItems: 2 };
+    render(<TimelineBlock config={config} updates={updates} />);
+    expect(screen.getAllByTestId('timeline-item')).toHaveLength(2);
+  });
+});

--- a/src/components/layout/builder/BlockConfigPanel.tsx
+++ b/src/components/layout/builder/BlockConfigPanel.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import type { LayoutBlock, BlockConfig, FieldDisplayConfig, PhotoGalleryConfig, TimelineConfig, TextLabelConfig, EntityListConfig } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import InlineFieldCreator from './InlineFieldCreator';
+import { useState } from 'react';
+
+interface Props {
+  block: LayoutBlock;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+}
+
+export default function BlockConfigPanel({ block, customFields, entityTypes, onConfigChange, onCreateField }: Props) {
+  const [showFieldCreator, setShowFieldCreator] = useState(false);
+
+  switch (block.type) {
+    case 'field_display': {
+      const config = block.config as FieldDisplayConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="label">Field</label>
+            <select
+              value={config.fieldId}
+              onChange={(e) => onConfigChange(block.id, { ...config, fieldId: e.target.value })}
+              className="input-field"
+            >
+              <option value="">Select a field...</option>
+              {customFields.map((f) => (
+                <option key={f.id} value={f.id}>{f.name}</option>
+              ))}
+            </select>
+          </div>
+          {!showFieldCreator && (
+            <button
+              onClick={() => setShowFieldCreator(true)}
+              className="text-sm text-forest font-medium hover:underline"
+            >
+              + Create New Field
+            </button>
+          )}
+          {showFieldCreator && (
+            <InlineFieldCreator
+              onCreateField={(field) => {
+                onCreateField(field);
+                setShowFieldCreator(false);
+              }}
+              onCancel={() => setShowFieldCreator(false)}
+            />
+          )}
+          <div>
+            <label className="label">Size</label>
+            <div className="flex gap-1">
+              {(['compact', 'normal', 'large'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => onConfigChange(block.id, { ...config, size: s })}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    config.size === s ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.showLabel}
+              onChange={(e) => onConfigChange(block.id, { ...config, showLabel: e.target.checked })}
+              className="rounded"
+            />
+            <span className="text-sm text-forest-dark">Show label</span>
+          </label>
+        </div>
+      );
+    }
+
+    case 'photo_gallery': {
+      const config = block.config as PhotoGalleryConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="label">Style</label>
+            <div className="flex gap-1">
+              {(['hero', 'grid', 'carousel'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => onConfigChange(block.id, { ...config, style: s })}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    config.style === s ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <label className="label">Max Photos: {config.maxPhotos}</label>
+            <input
+              type="range"
+              min={1}
+              max={20}
+              value={config.maxPhotos}
+              onChange={(e) => onConfigChange(block.id, { ...config, maxPhotos: Number(e.target.value) })}
+              className="w-full"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    case 'timeline': {
+      const config = block.config as TimelineConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.showUpdates}
+              onChange={(e) => onConfigChange(block.id, { ...config, showUpdates: e.target.checked })}
+              className="rounded"
+            />
+            <span className="text-sm">Show updates</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.showScheduled}
+              onChange={(e) => onConfigChange(block.id, { ...config, showScheduled: e.target.checked })}
+              className="rounded"
+            />
+            <span className="text-sm">Show scheduled</span>
+          </label>
+          <div>
+            <label className="label">Max items: {config.maxItems}</label>
+            <input
+              type="range"
+              min={1}
+              max={50}
+              value={config.maxItems}
+              onChange={(e) => onConfigChange(block.id, { ...config, maxItems: Number(e.target.value) })}
+              className="w-full"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    case 'text_label': {
+      const config = block.config as TextLabelConfig;
+      return (
+        <div className="space-y-3 pt-2">
+          <div>
+            <label className="label">Text</label>
+            <input
+              type="text"
+              value={config.text}
+              onChange={(e) => onConfigChange(block.id, { ...config, text: e.target.value })}
+              className="input-field"
+            />
+          </div>
+          <div>
+            <label className="label">Style</label>
+            <div className="flex gap-1">
+              {(['heading', 'subheading', 'body', 'caption'] as const).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => onConfigChange(block.id, { ...config, style: s })}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    config.style === s ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    case 'entity_list': {
+      const config = block.config as EntityListConfig;
+      return (
+        <div className="space-y-2 pt-2">
+          <label className="label">Show entity types</label>
+          {entityTypes.map((et) => (
+            <label key={et.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={config.entityTypeIds.length === 0 || config.entityTypeIds.includes(et.id)}
+                onChange={(e) => {
+                  const ids = config.entityTypeIds.length === 0
+                    ? entityTypes.map((t) => t.id).filter((id) => id !== et.id || e.target.checked)
+                    : e.target.checked
+                      ? [...config.entityTypeIds, et.id]
+                      : config.entityTypeIds.filter((id) => id !== et.id);
+                  onConfigChange(block.id, { ...config, entityTypeIds: ids });
+                }}
+                className="rounded"
+              />
+              <span className="text-sm">{et.icon} {et.name}</span>
+            </label>
+          ))}
+        </div>
+      );
+    }
+
+    default:
+      return (
+        <p className="text-xs text-sage italic pt-2">No configuration needed</p>
+      );
+  }
+}

--- a/src/components/layout/builder/BlockList.tsx
+++ b/src/components/layout/builder/BlockList.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import type { LayoutNode, LayoutBlock, LayoutRow, BlockConfig } from '@/lib/layout/types';
+import { isLayoutRow } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import BlockListItem from './BlockListItem';
+import RowEditor from './RowEditor';
+import PeekBoundary from './PeekBoundary';
+import { useState } from 'react';
+
+interface Props {
+  nodes: LayoutNode[];
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  peekBlockCount: number;
+  onReorder: (activeId: string, overId: string) => void;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDeleteBlock: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  onPeekCountChange: (count: number) => void;
+  onRowChange: (rowId: string, update: Partial<Pick<LayoutRow, 'gap' | 'distribution'>>) => void;
+  onAddToRow: (rowId: string, blockType: string) => void;
+  onRemoveFromRow: (rowId: string, blockId: string) => void;
+}
+
+export default function BlockList({
+  nodes,
+  customFields,
+  entityTypes,
+  peekBlockCount,
+  onReorder,
+  onConfigChange,
+  onDeleteBlock,
+  onCreateField,
+  onPeekCountChange,
+  onRowChange,
+  onAddToRow,
+  onRemoveFromRow,
+}: Props) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      onReorder(String(active.id), String(over.id));
+    }
+  };
+
+  const fieldMap = new Map(customFields.map((f) => [f.id, f]));
+  const nodeIds = nodes.map((n) => n.id);
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={nodeIds} strategy={verticalListSortingStrategy}>
+        <div className="flex flex-col gap-2">
+          {nodes.map((node, index) => (
+            <div key={node.id}>
+              {index === peekBlockCount && (
+                <PeekBoundary
+                  peekBlockCount={peekBlockCount}
+                  totalBlocks={nodes.length}
+                  onChange={onPeekCountChange}
+                />
+              )}
+              {isLayoutRow(node) ? (
+                <RowEditor
+                  row={node}
+                  customFields={customFields}
+                  entityTypes={entityTypes}
+                  fieldMap={fieldMap}
+                  expandedId={expandedId}
+                  onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
+                  onConfigChange={onConfigChange}
+                  onDeleteBlock={onDeleteBlock}
+                  onCreateField={onCreateField}
+                  onRowChange={onRowChange}
+                  onAddToRow={onAddToRow}
+                  onRemoveFromRow={onRemoveFromRow}
+                />
+              ) : (
+                <BlockListItem
+                  block={node}
+                  customFields={customFields}
+                  entityTypes={entityTypes}
+                  fieldName={
+                    node.type === 'field_display'
+                      ? fieldMap.get((node.config as { fieldId: string }).fieldId)?.name
+                      : undefined
+                  }
+                  onConfigChange={onConfigChange}
+                  onDelete={onDeleteBlock}
+                  onCreateField={onCreateField}
+                  isExpanded={expandedId === node.id}
+                  onToggleExpand={() => setExpandedId(expandedId === node.id ? null : node.id)}
+                />
+              )}
+            </div>
+          ))}
+          {nodes.length > 0 && peekBlockCount >= nodes.length && (
+            <PeekBoundary
+              peekBlockCount={peekBlockCount}
+              totalBlocks={nodes.length}
+              onChange={onPeekCountChange}
+            />
+          )}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/src/components/layout/builder/BlockListItem.tsx
+++ b/src/components/layout/builder/BlockListItem.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { LayoutBlock } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import BlockConfigPanel from './BlockConfigPanel';
+import type { BlockConfig } from '@/lib/layout/types';
+import { GripVertical, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+
+const BLOCK_LABELS: Record<string, string> = {
+  field_display: 'Field',
+  photo_gallery: 'Photo Gallery',
+  status_badge: 'Status Badge',
+  entity_list: 'Entities',
+  text_label: 'Text',
+  divider: 'Divider',
+  action_buttons: 'Actions',
+  map_snippet: 'Map',
+  timeline: 'Timeline',
+};
+
+interface Props {
+  block: LayoutBlock;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  fieldName?: string;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDelete: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}
+
+export default function BlockListItem({
+  block,
+  customFields,
+  entityTypes,
+  fieldName,
+  onConfigChange,
+  onDelete,
+  onCreateField,
+  isExpanded,
+  onToggleExpand,
+}: Props) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: block.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const label = block.type === 'field_display' && fieldName
+    ? fieldName
+    : BLOCK_LABELS[block.type] ?? block.type;
+
+  return (
+    <div ref={setNodeRef} style={style} className="border border-sage-light rounded-lg bg-white">
+      {/* Header row */}
+      <div className="flex items-center min-h-[48px]">
+        <button
+          {...attributes}
+          {...listeners}
+          className="p-3 cursor-grab active:cursor-grabbing touch-none"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="w-4 h-4 text-sage" />
+        </button>
+        <button
+          onClick={onToggleExpand}
+          className="flex-1 flex items-center gap-2 py-2 text-left"
+        >
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-sage" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-sage" />
+          )}
+          <span className="text-sm font-medium text-forest-dark">{label}</span>
+        </button>
+        {showDeleteConfirm ? (
+          <div className="flex items-center gap-1 pr-2">
+            <button onClick={() => onDelete(block.id)} className="text-xs text-red-600 font-medium px-2 py-1">
+              Delete
+            </button>
+            <button onClick={() => setShowDeleteConfirm(false)} className="text-xs text-sage px-2 py-1">
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="p-3 text-sage hover:text-red-500 transition-colors"
+            aria-label="Delete block"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Config panel (accordion) */}
+      {isExpanded && (
+        <div className="px-3 pb-3 border-t border-sage-light/50">
+          <BlockConfigPanel
+            block={block}
+            customFields={customFields}
+            entityTypes={entityTypes}
+            onConfigChange={onConfigChange}
+            onCreateField={onCreateField}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/builder/BlockPalette.tsx
+++ b/src/components/layout/builder/BlockPalette.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { BlockType } from '@/lib/layout/types';
+
+interface PaletteItem {
+  type: BlockType | 'row';
+  icon: string;
+  label: string;
+}
+
+const PALETTE_ITEMS: PaletteItem[] = [
+  { type: 'field_display', icon: '📊', label: 'Field' },
+  { type: 'photo_gallery', icon: '📷', label: 'Photo' },
+  { type: 'status_badge', icon: '🏷', label: 'Status' },
+  { type: 'entity_list', icon: '🔗', label: 'Entities' },
+  { type: 'timeline', icon: '📋', label: 'Timeline' },
+  { type: 'text_label', icon: '✏️', label: 'Text' },
+  { type: 'divider', icon: '➖', label: 'Divider' },
+  { type: 'map_snippet', icon: '📍', label: 'Map' },
+  { type: 'action_buttons', icon: '🔘', label: 'Actions' },
+  { type: 'row', icon: '⬜', label: 'Row' },
+];
+
+interface Props {
+  onAdd: (type: BlockType | 'row') => void;
+}
+
+export default function BlockPalette({ onAdd }: Props) {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 -mx-1 px-1 scrollbar-hide">
+      {PALETTE_ITEMS.map((item) => (
+        <button
+          key={item.type}
+          onClick={() => onAdd(item.type)}
+          className="flex-shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-full border border-sage-light bg-white hover:bg-sage-light/50 text-sm font-medium text-forest-dark transition-colors min-h-[44px]"
+        >
+          <span>{item.icon}</span>
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/builder/InlineFieldCreator.tsx
+++ b/src/components/layout/builder/InlineFieldCreator.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import type { FieldType } from '@/lib/types';
+
+interface NewFieldData {
+  name: string;
+  field_type: FieldType;
+  options: string[];
+  required: boolean;
+}
+
+interface Props {
+  onCreateField: (field: NewFieldData) => void;
+  onCancel: () => void;
+}
+
+export default function InlineFieldCreator({ onCreateField, onCancel }: Props) {
+  const [name, setName] = useState('');
+  const [fieldType, setFieldType] = useState<FieldType>('text');
+  const [options, setOptions] = useState('');
+  const [required, setRequired] = useState(false);
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onCreateField({
+      name: name.trim(),
+      field_type: fieldType,
+      options: fieldType === 'dropdown' ? options.split(',').map((o) => o.trim()).filter(Boolean) : [],
+      required,
+    });
+  };
+
+  return (
+    <div className="space-y-3 p-3 bg-sage-light/30 rounded-lg border border-sage-light">
+      <div>
+        <label className="label">Field Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="input-field"
+          placeholder="e.g., Target Species"
+          autoFocus
+        />
+      </div>
+
+      <div>
+        <label className="label">Type</label>
+        <div className="flex gap-1">
+          {(['text', 'number', 'dropdown', 'date'] as FieldType[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setFieldType(t)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                fieldType === t
+                  ? 'bg-forest text-white'
+                  : 'bg-white border border-sage-light text-forest-dark hover:bg-sage-light/50'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {fieldType === 'dropdown' && (
+        <div>
+          <label className="label">Options (comma-separated)</label>
+          <input
+            type="text"
+            value={options}
+            onChange={(e) => setOptions(e.target.value)}
+            className="input-field"
+            placeholder="Robin, Wren, Blue Tit"
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="field-required"
+          checked={required}
+          onChange={(e) => setRequired(e.target.checked)}
+          className="rounded"
+        />
+        <label htmlFor="field-required" className="text-sm text-forest-dark">Required</label>
+      </div>
+
+      <div className="flex gap-2">
+        <button onClick={handleSubmit} className="btn-primary text-sm" disabled={!name.trim()}>
+          Create Field
+        </button>
+        <button onClick={onCancel} className="btn-secondary text-sm">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/builder/LayoutBuilder.tsx
+++ b/src/components/layout/builder/LayoutBuilder.tsx
@@ -194,8 +194,6 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
           return { ...node, children: remaining };
         }
         return node;
-      }).filter(() => {
-        return true;
       }),
     }));
   }, []);

--- a/src/components/layout/builder/LayoutBuilder.tsx
+++ b/src/components/layout/builder/LayoutBuilder.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { nanoid } from 'nanoid';
+import { arrayMove } from '@dnd-kit/sortable';
+import type { TypeLayout, LayoutNode, LayoutBlock, LayoutRow, BlockType, BlockConfig, SpacingPreset } from '@/lib/layout/types';
+import { isLayoutRow } from '@/lib/layout/types';
+import type { CustomField, EntityType, ItemType } from '@/lib/types';
+import { generateDefaultLayout } from '@/lib/layout/defaults';
+import { generateMockItem } from '@/lib/layout/mock-data';
+import BlockPalette from './BlockPalette';
+import BlockList from './BlockList';
+import SpacingPicker from './SpacingPicker';
+import LayoutRenderer from '../LayoutRenderer';
+import FormPreview from '../preview/FormPreview';
+
+interface Props {
+  itemType: ItemType;
+  initialLayout: TypeLayout | null;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  onSave: (layout: TypeLayout, newFields: { name: string; field_type: string; options: string[]; required: boolean }[]) => Promise<void>;
+  onCancel: () => void;
+}
+
+type PreviewTab = 'detail' | 'form';
+
+function getDefaultConfig(type: BlockType): BlockConfig {
+  switch (type) {
+    case 'field_display': return { fieldId: '', size: 'normal' as const, showLabel: true };
+    case 'photo_gallery': return { style: 'hero' as const, maxPhotos: 4 };
+    case 'timeline': return { showUpdates: true, showScheduled: false, maxItems: 5 };
+    case 'text_label': return { text: 'Section Title', style: 'heading' as const };
+    case 'entity_list': return { entityTypeIds: [] };
+    default: return {};
+  }
+}
+
+export default function LayoutBuilder({ itemType, initialLayout, customFields, entityTypes, onSave, onCancel }: Props) {
+  const [layout, setLayout] = useState<TypeLayout>(
+    () => initialLayout ?? generateDefaultLayout(customFields),
+  );
+  const [pendingFields, setPendingFields] = useState<{ name: string; field_type: string; options: string[]; required: boolean; tempId: string }[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [activeTab, setActiveTab] = useState<'build' | 'detail' | 'form'>('build');
+  const [previewTab, setPreviewTab] = useState<PreviewTab>('detail');
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  // Combine real fields + pending fields for preview
+  const allFields: CustomField[] = [
+    ...customFields,
+    ...pendingFields.map((f, i) => ({
+      id: f.tempId,
+      item_type_id: itemType.id,
+      name: f.name,
+      field_type: f.field_type as CustomField['field_type'],
+      options: f.options.length > 0 ? f.options : null,
+      required: f.required,
+      sort_order: customFields.length + i,
+      org_id: itemType.org_id,
+    })),
+  ];
+
+  const mockItem = generateMockItem(itemType, allFields);
+
+  const handleAddBlock = useCallback((type: BlockType | 'row') => {
+    setLayout((prev) => {
+      if (type === 'row') {
+        const newRow: LayoutRow = {
+          id: nanoid(10),
+          type: 'row',
+          children: [
+            { id: nanoid(10), type: 'status_badge', config: {} },
+            { id: nanoid(10), type: 'status_badge', config: {} },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        };
+        return { ...prev, blocks: [...prev.blocks, newRow] };
+      }
+      const newBlock: LayoutBlock = {
+        id: nanoid(10),
+        type: type,
+        config: getDefaultConfig(type),
+      };
+      return { ...prev, blocks: [...prev.blocks, newBlock] };
+    });
+  }, []);
+
+  const handleReorder = useCallback((activeId: string, overId: string) => {
+    setLayout((prev) => {
+      const oldIndex = prev.blocks.findIndex((b) => b.id === activeId);
+      const newIndex = prev.blocks.findIndex((b) => b.id === overId);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      return { ...prev, blocks: arrayMove(prev.blocks, oldIndex, newIndex) };
+    });
+  }, []);
+
+  const handleConfigChange = useCallback((blockId: string, config: BlockConfig) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) => {
+        if (node.id === blockId && !isLayoutRow(node)) {
+          return { ...node, config };
+        }
+        if (isLayoutRow(node)) {
+          return {
+            ...node,
+            children: node.children.map((c) =>
+              c.id === blockId ? { ...c, config } : c,
+            ),
+          };
+        }
+        return node;
+      }),
+    }));
+  }, []);
+
+  const handleDeleteBlock = useCallback((blockId: string) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.filter((b) => b.id !== blockId),
+    }));
+  }, []);
+
+  const handleCreateField = useCallback((field: { name: string; field_type: string; options: string[]; required: boolean }) => {
+    const tempId = `temp-${nanoid(10)}`;
+    setPendingFields((prev) => [...prev, { ...field, tempId }]);
+    // Auto-update the last field_display block that has no fieldId
+    setLayout((prev) => {
+      const blocks = [...prev.blocks];
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const node = blocks[i];
+        if (!isLayoutRow(node) && node.type === 'field_display' && !(node.config as { fieldId: string }).fieldId) {
+          blocks[i] = { ...node, config: { ...(node.config as object), fieldId: tempId } as BlockConfig };
+          return { ...prev, blocks };
+        }
+      }
+      return prev;
+    });
+  }, []);
+
+  const handlePeekCountChange = useCallback((count: number) => {
+    setLayout((prev) => ({ ...prev, peekBlockCount: count }));
+  }, []);
+
+  const handleSpacingChange = useCallback((spacing: SpacingPreset) => {
+    setLayout((prev) => ({ ...prev, spacing }));
+  }, []);
+
+  const handleRowChange = useCallback((rowId: string, update: Partial<Pick<LayoutRow, 'gap' | 'distribution'>>) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) =>
+        node.id === rowId && isLayoutRow(node) ? { ...node, ...update } : node,
+      ),
+    }));
+  }, []);
+
+  const handleAddToRow = useCallback((rowId: string, blockType: string) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) => {
+        if (node.id === rowId && isLayoutRow(node) && node.children.length < 4) {
+          return {
+            ...node,
+            children: [
+              ...node.children,
+              { id: nanoid(10), type: blockType as BlockType, config: getDefaultConfig(blockType as BlockType) },
+            ],
+          };
+        }
+        return node;
+      }),
+    }));
+  }, []);
+
+  const handleRemoveFromRow = useCallback((rowId: string, blockId: string) => {
+    setLayout((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((node) => {
+        if (node.id === rowId && isLayoutRow(node)) {
+          const remaining = node.children.filter((c) => c.id !== blockId);
+          if (remaining.length <= 1) {
+            return remaining[0] ?? node;
+          }
+          return { ...node, children: remaining };
+        }
+        return node;
+      }).filter(() => {
+        return true;
+      }),
+    }));
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(layout, pendingFields.map(({ tempId, ...rest }) => rest));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Build panel content
+  const buildContent = (
+    <div className="space-y-4">
+      <BlockPalette onAdd={handleAddBlock} />
+      <SpacingPicker value={layout.spacing} onChange={handleSpacingChange} />
+      <BlockList
+        nodes={layout.blocks}
+        customFields={allFields}
+        entityTypes={entityTypes}
+        peekBlockCount={layout.peekBlockCount}
+        onReorder={handleReorder}
+        onConfigChange={handleConfigChange}
+        onDeleteBlock={handleDeleteBlock}
+        onCreateField={handleCreateField}
+        onPeekCountChange={handlePeekCountChange}
+        onRowChange={handleRowChange}
+        onAddToRow={handleAddToRow}
+        onRemoveFromRow={handleRemoveFromRow}
+      />
+    </div>
+  );
+
+  const detailPreview = (
+    <div className="bg-gray-100 rounded-xl p-3">
+      <div className="bg-white rounded-xl shadow-lg p-4 max-h-[70vh] overflow-y-auto">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xl">{itemType.icon}</span>
+          <h2 className="font-heading font-semibold text-forest-dark text-xl">{mockItem.name}</h2>
+        </div>
+        <LayoutRenderer
+          layout={layout}
+          item={mockItem}
+          mode="preview"
+          context="preview"
+          customFields={allFields}
+        />
+      </div>
+    </div>
+  );
+
+  const formPreviewContent = (
+    <FormPreview layout={layout} customFields={allFields} itemTypeName={itemType.name} />
+  );
+
+  // Mobile: full-screen with tabs
+  if (isMobile) {
+    return (
+      <div className="fixed inset-0 z-50 bg-white flex flex-col" style={{ height: '100dvh' }}>
+        {/* Sticky header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-sage-light">
+          <button onClick={onCancel} className="text-sm text-forest font-medium">
+            Cancel
+          </button>
+          <span className="text-sm font-semibold text-forest-dark">{itemType.name} Layout</span>
+          <button onClick={handleSave} disabled={saving} className="btn-primary text-sm px-4 py-1.5">
+            {saving ? 'Saving...' : 'Done'}
+          </button>
+        </div>
+
+        {/* Tab toggle */}
+        <div className="flex border-b border-sage-light">
+          {(['build', 'detail', 'form'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                activeTab === tab
+                  ? 'text-forest border-b-2 border-forest'
+                  : 'text-sage'
+              }`}
+            >
+              {tab === 'build' ? 'Build' : tab === 'detail' ? 'Detail' : 'Form'}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {activeTab === 'build' && buildContent}
+          {activeTab === 'detail' && detailPreview}
+          {activeTab === 'form' && formPreviewContent}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: side-by-side
+  return (
+    <div className="flex gap-6 min-h-[600px]">
+      {/* Builder panel */}
+      <div className="flex-[3] overflow-y-auto pr-4 border-r border-sage-light">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-heading font-semibold text-forest-dark">Layout Builder</h3>
+          <div className="flex gap-2">
+            <button onClick={onCancel} className="btn-secondary text-sm">Cancel</button>
+            <button onClick={handleSave} disabled={saving} className="btn-primary text-sm">
+              {saving ? 'Saving...' : 'Save Layout'}
+            </button>
+          </div>
+        </div>
+        {buildContent}
+      </div>
+
+      {/* Preview panel */}
+      <div className="flex-[2] overflow-y-auto">
+        <div className="flex gap-1 mb-3">
+          {(['detail', 'form'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setPreviewTab(tab)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium ${
+                previewTab === tab ? 'bg-forest text-white' : 'bg-sage-light text-forest-dark'
+              }`}
+            >
+              {tab === 'detail' ? 'Detail Preview' : 'Form Preview'}
+            </button>
+          ))}
+        </div>
+        {previewTab === 'detail' ? detailPreview : formPreviewContent}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/builder/PeekBoundary.tsx
+++ b/src/components/layout/builder/PeekBoundary.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+interface Props {
+  peekBlockCount: number;
+  totalBlocks: number;
+  onChange: (count: number) => void;
+}
+
+export default function PeekBoundary({ peekBlockCount, totalBlocks, onChange }: Props) {
+  if (totalBlocks <= 1) return null;
+
+  return (
+    <div className="flex items-center gap-2 py-2">
+      <div className="flex-1 border-t-2 border-dashed border-forest/30" />
+      <span className="text-[10px] font-medium text-forest/60 whitespace-nowrap">
+        Visible on first tap
+      </span>
+      <select
+        value={peekBlockCount}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="text-xs border border-sage-light rounded px-1 py-0.5"
+      >
+        {Array.from({ length: totalBlocks }, (_, i) => i + 1).map((n) => (
+          <option key={n} value={n}>{n} block{n > 1 ? 's' : ''}</option>
+        ))}
+      </select>
+      <div className="flex-1 border-t-2 border-dashed border-forest/30" />
+    </div>
+  );
+}

--- a/src/components/layout/builder/RowEditor.tsx
+++ b/src/components/layout/builder/RowEditor.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { LayoutRow, BlockConfig, BlockType } from '@/lib/layout/types';
+import type { CustomField, EntityType } from '@/lib/types';
+import BlockListItem from './BlockListItem';
+import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface Props {
+  row: LayoutRow;
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  fieldMap: Map<string, CustomField>;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDeleteBlock: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  onRowChange: (rowId: string, update: Partial<Pick<LayoutRow, 'gap' | 'distribution'>>) => void;
+  onAddToRow: (rowId: string, blockType: string) => void;
+  onRemoveFromRow: (rowId: string, blockId: string) => void;
+}
+
+export default function RowEditor({
+  row,
+  customFields,
+  entityTypes,
+  fieldMap,
+  expandedId,
+  onToggleExpand,
+  onConfigChange,
+  onDeleteBlock,
+  onCreateField,
+  onRowChange,
+  onAddToRow,
+  onRemoveFromRow,
+}: Props) {
+  const [showRowConfig, setShowRowConfig] = useState(false);
+
+  return (
+    <div className="border-2 border-dashed border-sage rounded-lg p-2 space-y-2">
+      {/* Row header */}
+      <div className="flex items-center justify-between min-h-[44px]">
+        <button
+          onClick={() => setShowRowConfig(!showRowConfig)}
+          className="flex items-center gap-2 text-sm font-medium text-forest-dark"
+        >
+          {showRowConfig ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          Row ({row.children.length} columns, {typeof row.distribution === 'string' ? row.distribution : 'custom'})
+        </button>
+        <button
+          onClick={() => onDeleteBlock(row.id)}
+          className="p-2 text-sage hover:text-red-500"
+          aria-label="Delete row"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Row config */}
+      {showRowConfig && (
+        <div className="space-y-2 px-2 pb-2 border-b border-sage-light">
+          <div>
+            <label className="label">Distribution</label>
+            <div className="flex gap-1">
+              {(['equal', 'auto'] as const).map((d) => (
+                <button
+                  key={d}
+                  onClick={() => onRowChange(row.id, { distribution: d })}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium ${
+                    row.distribution === d ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {d.charAt(0).toUpperCase() + d.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <label className="label">Gap</label>
+            <div className="flex gap-1">
+              {(['tight', 'normal', 'loose'] as const).map((g) => (
+                <button
+                  key={g}
+                  onClick={() => onRowChange(row.id, { gap: g })}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium ${
+                    row.gap === g ? 'bg-forest text-white' : 'bg-white border border-sage-light'
+                  }`}
+                >
+                  {g.charAt(0).toUpperCase() + g.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Children */}
+      <div className="pl-3 border-l-2 border-sage-light space-y-2">
+        {row.children.map((child) => (
+          <BlockListItem
+            key={child.id}
+            block={child}
+            customFields={customFields}
+            entityTypes={entityTypes}
+            fieldName={
+              child.type === 'field_display'
+                ? fieldMap.get((child.config as { fieldId: string }).fieldId)?.name
+                : undefined
+            }
+            onConfigChange={onConfigChange}
+            onDelete={(id) => onRemoveFromRow(row.id, id)}
+            onCreateField={onCreateField}
+            isExpanded={expandedId === child.id}
+            onToggleExpand={() => onToggleExpand(child.id)}
+          />
+        ))}
+        {row.children.length < 4 && (
+          <button
+            onClick={() => onAddToRow(row.id, 'field_display')}
+            className="w-full py-2 border-2 border-dashed border-sage-light rounded-lg text-xs text-sage font-medium hover:border-forest hover:text-forest transition-colors min-h-[44px]"
+          >
+            + Add to row
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/builder/RowEditor.tsx
+++ b/src/components/layout/builder/RowEditor.tsx
@@ -36,6 +36,15 @@ export default function RowEditor({
   onRemoveFromRow,
 }: Props) {
   const [showRowConfig, setShowRowConfig] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showAddPicker, setShowAddPicker] = useState(false);
+
+  const ADD_TYPES: { type: BlockType; label: string }[] = [
+    { type: 'field_display', label: 'Field' },
+    { type: 'status_badge', label: 'Status' },
+    { type: 'text_label', label: 'Text' },
+    { type: 'divider', label: 'Divider' },
+  ];
 
   return (
     <div className="border-2 border-dashed border-sage rounded-lg p-2 space-y-2">
@@ -48,13 +57,24 @@ export default function RowEditor({
           {showRowConfig ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
           Row ({row.children.length} columns, {typeof row.distribution === 'string' ? row.distribution : 'custom'})
         </button>
-        <button
-          onClick={() => onDeleteBlock(row.id)}
-          className="p-2 text-sage hover:text-red-500"
-          aria-label="Delete row"
-        >
-          <Trash2 className="w-4 h-4" />
-        </button>
+        {showDeleteConfirm ? (
+          <div className="flex items-center gap-1 pr-2">
+            <button onClick={() => onDeleteBlock(row.id)} className="text-xs text-red-600 font-medium px-2 py-1">
+              Delete
+            </button>
+            <button onClick={() => setShowDeleteConfirm(false)} className="text-xs text-sage px-2 py-1">
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="p-2 text-sage hover:text-red-500"
+            aria-label="Delete row"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
       </div>
 
       {/* Row config */}
@@ -116,12 +136,32 @@ export default function RowEditor({
           />
         ))}
         {row.children.length < 4 && (
-          <button
-            onClick={() => onAddToRow(row.id, 'field_display')}
-            className="w-full py-2 border-2 border-dashed border-sage-light rounded-lg text-xs text-sage font-medium hover:border-forest hover:text-forest transition-colors min-h-[44px]"
-          >
-            + Add to row
-          </button>
+          showAddPicker ? (
+            <div className="flex gap-1 flex-wrap">
+              {ADD_TYPES.map((t) => (
+                <button
+                  key={t.type}
+                  onClick={() => { onAddToRow(row.id, t.type); setShowAddPicker(false); }}
+                  className="px-3 py-1.5 rounded-md text-xs font-medium bg-white border border-sage-light hover:bg-sage-light/50 transition-colors"
+                >
+                  {t.label}
+                </button>
+              ))}
+              <button
+                onClick={() => setShowAddPicker(false)}
+                className="px-3 py-1.5 rounded-md text-xs text-sage"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowAddPicker(true)}
+              className="w-full py-2 border-2 border-dashed border-sage-light rounded-lg text-xs text-sage font-medium hover:border-forest hover:text-forest transition-colors min-h-[44px]"
+            >
+              + Add to row
+            </button>
+          )
         )}
       </div>
     </div>

--- a/src/components/layout/builder/SpacingPicker.tsx
+++ b/src/components/layout/builder/SpacingPicker.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { SpacingPreset } from '@/lib/layout/types';
+
+interface Props {
+  value: SpacingPreset;
+  onChange: (value: SpacingPreset) => void;
+}
+
+const options: { value: SpacingPreset; label: string; description: string }[] = [
+  { value: 'compact', label: 'Compact', description: 'Dense, data-heavy' },
+  { value: 'comfortable', label: 'Comfortable', description: 'Balanced' },
+  { value: 'spacious', label: 'Spacious', description: 'Airy, photo-forward' },
+];
+
+export default function SpacingPicker({ value, onChange }: Props) {
+  return (
+    <div className="flex gap-1">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={`flex-1 px-2 py-2 rounded-md text-xs font-medium text-center transition-colors ${
+            value === opt.value
+              ? 'bg-forest text-white'
+              : 'bg-white border border-sage-light text-forest-dark hover:bg-sage-light/50'
+          }`}
+          title={opt.description}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/preview/DetailPreview.tsx
+++ b/src/components/layout/preview/DetailPreview.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { TypeLayout } from '@/lib/layout/types';
+import type { ItemWithDetails, CustomField } from '@/lib/types';
+import LayoutRenderer from '../LayoutRenderer';
+
+interface Props {
+  layout: TypeLayout;
+  mockItem: ItemWithDetails;
+  customFields: CustomField[];
+  itemTypeIcon: string;
+}
+
+export default function DetailPreview({ layout, mockItem, customFields, itemTypeIcon }: Props) {
+  return (
+    <div className="bg-gray-100 rounded-xl p-3">
+      {/* Simulated bottom sheet */}
+      <div className="bg-white rounded-t-2xl shadow-lg">
+        {/* Handle */}
+        <div className="flex justify-center py-3">
+          <div className="w-10 h-1 rounded-full bg-gray-300" />
+        </div>
+
+        {/* Peek boundary indicator */}
+        <div className="px-4 pb-4 max-h-[70vh] overflow-y-auto">
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-xl">{itemTypeIcon}</span>
+            <h2 className="font-heading font-semibold text-forest-dark text-xl">
+              {mockItem.name}
+            </h2>
+          </div>
+
+          {/* Layout content */}
+          <LayoutRenderer
+            layout={layout}
+            item={mockItem}
+            mode="preview"
+            context="preview"
+            customFields={customFields}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/preview/FormPreview.tsx
+++ b/src/components/layout/preview/FormPreview.tsx
@@ -2,6 +2,7 @@
 
 import type { TypeLayout } from '@/lib/layout/types';
 import type { CustomField } from '@/lib/types';
+import { deriveFormFields } from '@/lib/layout/form-derivation';
 
 interface Props {
   layout: TypeLayout;
@@ -9,12 +10,101 @@ interface Props {
   itemTypeName: string;
 }
 
-export default function FormPreview({ itemTypeName }: Props) {
+export default function FormPreview({ layout, customFields, itemTypeName }: Props) {
+  const derived = deriveFormFields(layout, customFields);
+
   return (
     <div className="bg-gray-100 rounded-xl p-3">
-      <div className="bg-white rounded-xl shadow-lg p-4 text-center text-sage text-sm">
-        Form preview for {itemTypeName} — coming in Task 13
+      <div className="bg-white rounded-xl shadow-lg p-4 space-y-4">
+        <h3 className="font-heading font-semibold text-forest-dark text-lg">
+          Add {itemTypeName}
+        </h3>
+
+        {/* Fixed: Name */}
+        <div>
+          <label className="label">Name <span className="text-red-500">*</span></label>
+          <input type="text" className="input-field" placeholder={`e.g., ${itemTypeName} #1`} disabled />
+        </div>
+
+        {/* Fixed: Location */}
+        <div>
+          <label className="label">Location <span className="text-red-500">*</span></label>
+          <div className="h-24 bg-sage-light/50 rounded-lg flex items-center justify-center text-xs text-sage">
+            Location picker
+          </div>
+        </div>
+
+        {/* Layout-derived fields with sections */}
+        {derived.fields.map((field, index) => {
+          const section = derived.sections.find((s) => s.beforeFieldIndex === index);
+          const isInRow = derived.rows.some((r) => r.fieldIds.includes(field.id));
+
+          // Check if this is the start of a row
+          const row = derived.rows.find((r) => r.fieldIds[0] === field.id);
+          const rowFields = row ? row.fieldIds.map((id) => derived.fields.find((f) => f.id === id)).filter(Boolean) : null;
+
+          if (isInRow && !row) return null; // Will be rendered as part of the row
+
+          return (
+            <div key={field.id}>
+              {section && (
+                <p className="text-sm font-semibold text-forest-dark mt-2">{section.text}</p>
+              )}
+              {rowFields ? (
+                <div className="grid grid-cols-2 gap-3">
+                  {rowFields.map((rf) => rf && (
+                    <div key={rf.id}>
+                      <label className="label">
+                        {rf.name} {rf.required && <span className="text-red-500">*</span>}
+                      </label>
+                      {renderFieldInput(rf)}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div>
+                  <label className="label">
+                    {field.name} {field.required && <span className="text-red-500">*</span>}
+                  </label>
+                  {renderFieldInput(field)}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Photo uploader placeholder */}
+        <div>
+          <label className="label">Photos</label>
+          <div className="h-16 border-2 border-dashed border-sage-light rounded-lg flex items-center justify-center text-xs text-sage">
+            + Add photos
+          </div>
+        </div>
+
+        {/* Fixed: Submit */}
+        <div className="flex gap-2 pt-2">
+          <button className="btn-primary flex-1 opacity-60 cursor-default">Save</button>
+          <button className="btn-secondary flex-1 opacity-60 cursor-default">Cancel</button>
+        </div>
       </div>
     </div>
   );
+}
+
+function renderFieldInput(field: CustomField) {
+  switch (field.field_type) {
+    case 'dropdown':
+      return (
+        <select className="input-field" disabled>
+          <option>Select {field.name}...</option>
+          {field.options?.map((opt) => <option key={opt}>{opt}</option>)}
+        </select>
+      );
+    case 'number':
+      return <input type="number" className="input-field" placeholder="0" disabled />;
+    case 'date':
+      return <input type="date" className="input-field" disabled />;
+    default:
+      return <input type="text" className="input-field" placeholder={`Enter ${field.name.toLowerCase()}`} disabled />;
+  }
 }

--- a/src/components/layout/preview/FormPreview.tsx
+++ b/src/components/layout/preview/FormPreview.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { TypeLayout } from '@/lib/layout/types';
+import type { CustomField } from '@/lib/types';
+
+interface Props {
+  layout: TypeLayout;
+  customFields: CustomField[];
+  itemTypeName: string;
+}
+
+export default function FormPreview({ itemTypeName }: Props) {
+  return (
+    <div className="bg-gray-100 rounded-xl p-3">
+      <div className="bg-white rounded-xl shadow-lg p-4 text-center text-sage text-sm">
+        Form preview for {itemTypeName} — coming in Task 13
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -22,6 +22,7 @@ import { getPropertyGeoLayersPublic, getGeoLayerPublic } from "@/app/admin/geo-l
 import { clipLayerToBoundary, filterItemsByBoundary } from "@/lib/geo/spatial";
 import type { GeoLayerSummary, GeoLayerProperty } from "@/lib/geo/types";
 import type { FeatureCollection } from "geojson";
+import type { SheetState } from "@/components/ui/MultiSnapBottomSheet";
 
 const MapView = dynamic(() => import("@/components/map/MapView"), {
   ssr: false,
@@ -61,6 +62,8 @@ function HomeMapViewContent() {
   const config = useConfig();
   const propertyId = config.propertyId;
   const offlineStore = useOfflineStore();
+
+  const [sheetState, setSheetState] = useState<SheetState | null>(null);
 
   const [geoLayers, setGeoLayers] = useState<GeoLayerSummary[]>([]);
   const [visibleGeoLayerIds, setVisibleGeoLayerIds] = useState<Set<string>>(new Set());
@@ -286,6 +289,7 @@ function HomeMapViewContent() {
         boundaryGeoJSON={boundaryGeoJSON}
         visibleGeoLayerIds={visibleGeoLayerIds}
         onToggleGeoLayer={handleToggleGeoLayer}
+        sheetState={selectedItem ? sheetState : null}
       />
 
       {/* List view link */}
@@ -303,6 +307,7 @@ function HomeMapViewContent() {
         isAuthenticated={isAuthenticated}
         canEditItem={permissions.items.edit_any || permissions.items.edit_assigned}
         canAddUpdate={permissions.updates.create}
+        onSheetStateChange={setSheetState}
       />
     </div>
   );

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -29,6 +29,7 @@ interface MapViewProps {
   boundaryGeoJSON?: FeatureCollection | null;
   onToggleGeoLayer?: (layerId: string) => void;
   visibleGeoLayerIds?: Set<string>;
+  sheetState?: 'peek' | 'half' | 'full' | null;
 }
 
 /** Flies map to user position when trigger increments */
@@ -61,6 +62,7 @@ export default function MapView({
   boundaryGeoJSON,
   onToggleGeoLayer,
   visibleGeoLayerIds,
+  sheetState,
 }: MapViewProps) {
   const config = useConfig();
   const theme = useTheme();
@@ -206,14 +208,18 @@ export default function MapView({
       <LocateButton onLocate={() => setFlyToUserTrigger((n) => n + 1)} />
       <MapLegend itemTypes={itemTypes} />
 
-      {/* Quick-add FAB */}
-      <button
-        onClick={() => setQuickAddOpen(true)}
-        className="fixed bottom-24 right-4 z-30 bg-green-600 hover:bg-green-700 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-3xl font-light"
-        aria-label="Quick add item"
-      >
-        +
-      </button>
+      {/* Quick-add FAB — hidden when sheet is half/full, raised above peek sheet */}
+      {sheetState !== 'half' && sheetState !== 'full' && (
+        <button
+          onClick={() => setQuickAddOpen(true)}
+          className={`fixed right-4 z-30 bg-green-600 hover:bg-green-700 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-3xl font-light transition-all duration-300 ${
+            sheetState === 'peek' ? 'bottom-[calc(25vh+1rem)]' : 'bottom-24'
+          }`}
+          aria-label="Quick add item"
+        >
+          +
+        </button>
+      )}
 
       <QuickAddSheet
         open={quickAddOpen}

--- a/src/components/ui/MultiSnapBottomSheet.tsx
+++ b/src/components/ui/MultiSnapBottomSheet.tsx
@@ -189,9 +189,21 @@ export default function MultiSnapBottomSheet({
               />
             </div>
 
+            {/* Swipe-up affordance — only visible in peek state */}
+            {animatedState === 'peek' && (
+              <div className="flex justify-center -mt-1 mb-1">
+                <svg className="w-4 h-4 text-gray-400 animate-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+                </svg>
+              </div>
+            )}
+
             {/* Content */}
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
-              {children}
+            <div className="relative min-h-0 flex-1">
+              <div className="overflow-y-auto px-4 pb-4 h-full">
+                {children}
+              </div>
+              <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent" />
             </div>
           </motion.div>
         </>

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -48,6 +48,7 @@ describe('ItemType structure', () => {
       sort_order: 0,
       created_at: '2025-01-01T00:00:00Z',
       org_id: 'org-1',
+      layout: null,
     };
     expect(type.icon).toBe('🏠');
   });
@@ -123,7 +124,7 @@ describe('ItemWithDetails composite type', () => {
   it('assembles a full item with type, updates, photos, and custom fields', () => {
     const itemType: ItemType = {
       id: 'type-1', name: 'Bird Box', icon: '🏠', color: '#5D7F3A',
-      sort_order: 0, created_at: '2025-01-01T00:00:00Z', org_id: 'org-1',
+      sort_order: 0, created_at: '2025-01-01T00:00:00Z', org_id: 'org-1', layout: null,
     };
 
     const updateType: UpdateType = {
@@ -322,7 +323,7 @@ describe('ItemWithDetails with entities', () => {
 
     const itemType: ItemType = {
       id: 'type-1', name: 'Bird Box', icon: '🏠', color: '#5D7F3A',
-      sort_order: 0, created_at: '2025-01-01T00:00:00Z', org_id: 'org-1',
+      sort_order: 0, created_at: '2025-01-01T00:00:00Z', org_id: 'org-1', layout: null,
     };
 
     const updateType: UpdateType = {

--- a/src/lib/layout/__tests__/defaults.test.ts
+++ b/src/lib/layout/__tests__/defaults.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { generateDefaultLayout } from '../defaults';
+import type { CustomField } from '@/lib/types';
+
+describe('generateDefaultLayout', () => {
+  it('generates starter layout with no custom fields', () => {
+    const layout = generateDefaultLayout([]);
+    expect(layout.version).toBe(1);
+    expect(layout.spacing).toBe('comfortable');
+    expect(layout.peekBlockCount).toBe(2);
+    expect(layout.blocks).toHaveLength(3);
+    expect(layout.blocks[0].type).toBe('status_badge');
+    expect(layout.blocks[1].type).toBe('photo_gallery');
+    expect(layout.blocks[2].type).toBe('action_buttons');
+  });
+
+  it('inserts field_display blocks for each custom field', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin'], required: true, sort_order: 0, org_id: 'o1' },
+      { id: 'f2', item_type_id: 't1', name: 'Install Date', field_type: 'date', options: null, required: false, sort_order: 1, org_id: 'o1' },
+    ];
+    const layout = generateDefaultLayout(fields);
+    expect(layout.blocks).toHaveLength(5);
+    expect(layout.blocks[2].type).toBe('field_display');
+    expect(layout.blocks[3].type).toBe('field_display');
+    const config0 = layout.blocks[2].config as { fieldId: string };
+    const config1 = layout.blocks[3].config as { fieldId: string };
+    expect(config0.fieldId).toBe('f1');
+    expect(config1.fieldId).toBe('f2');
+  });
+
+  it('sorts fields by sort_order', () => {
+    const fields: CustomField[] = [
+      { id: 'f2', item_type_id: 't1', name: 'B', field_type: 'text', options: null, required: false, sort_order: 2, org_id: 'o1' },
+      { id: 'f1', item_type_id: 't1', name: 'A', field_type: 'text', options: null, required: false, sort_order: 1, org_id: 'o1' },
+    ];
+    const layout = generateDefaultLayout(fields);
+    const config0 = layout.blocks[2].config as { fieldId: string };
+    const config1 = layout.blocks[3].config as { fieldId: string };
+    expect(config0.fieldId).toBe('f1');
+    expect(config1.fieldId).toBe('f2');
+  });
+
+  it('generates unique IDs for all blocks', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'A', field_type: 'text', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const layout = generateDefaultLayout(fields);
+    const ids = layout.blocks.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/lib/layout/__tests__/defaults.test.ts
+++ b/src/lib/layout/__tests__/defaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateDefaultLayout } from '../defaults';
 import type { CustomField } from '@/lib/types';
+import type { LayoutBlock } from '../types';
 
 describe('generateDefaultLayout', () => {
   it('generates starter layout with no custom fields', () => {
@@ -23,8 +24,8 @@ describe('generateDefaultLayout', () => {
     expect(layout.blocks).toHaveLength(5);
     expect(layout.blocks[2].type).toBe('field_display');
     expect(layout.blocks[3].type).toBe('field_display');
-    const config0 = layout.blocks[2].config as { fieldId: string };
-    const config1 = layout.blocks[3].config as { fieldId: string };
+    const config0 = (layout.blocks[2] as LayoutBlock).config as { fieldId: string };
+    const config1 = (layout.blocks[3] as LayoutBlock).config as { fieldId: string };
     expect(config0.fieldId).toBe('f1');
     expect(config1.fieldId).toBe('f2');
   });
@@ -35,8 +36,8 @@ describe('generateDefaultLayout', () => {
       { id: 'f1', item_type_id: 't1', name: 'A', field_type: 'text', options: null, required: false, sort_order: 1, org_id: 'o1' },
     ];
     const layout = generateDefaultLayout(fields);
-    const config0 = layout.blocks[2].config as { fieldId: string };
-    const config1 = layout.blocks[3].config as { fieldId: string };
+    const config0 = (layout.blocks[2] as LayoutBlock).config as { fieldId: string };
+    const config1 = (layout.blocks[3] as LayoutBlock).config as { fieldId: string };
     expect(config0.fieldId).toBe('f1');
     expect(config1.fieldId).toBe('f2');
   });

--- a/src/lib/layout/__tests__/field-sync.test.ts
+++ b/src/lib/layout/__tests__/field-sync.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { removeFieldFromLayout, findFieldsNotInLayout } from '../field-sync';
+import type { TypeLayout } from '../types';
+
+describe('removeFieldFromLayout', () => {
+  it('removes a field_display block referencing the deleted field', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+        { id: 'b3', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = removeFieldFromLayout(layout, 'f1');
+    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks.find((b) => b.type === 'field_display' && (b as any).config.fieldId === 'f1')).toBeUndefined();
+  });
+
+  it('removes a field_display from inside a row', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = removeFieldFromLayout(layout, 'f1');
+    // Row should unwrap since only 1 child remains
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0].type).toBe('field_display');
+  });
+
+  it('returns layout unchanged if field not referenced', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'status_badge', config: {} }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = removeFieldFromLayout(layout, 'f999');
+    expect(result.blocks).toHaveLength(1);
+  });
+});
+
+describe('findFieldsNotInLayout', () => {
+  it('finds fields not referenced by any field_display block', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const fieldIds = ['f1', 'f2', 'f3'];
+    const missing = findFieldsNotInLayout(layout, fieldIds);
+    expect(missing).toEqual(['f2', 'f3']);
+  });
+
+  it('checks inside rows too', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'normal', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const missing = findFieldsNotInLayout(layout, ['f1', 'f2', 'f3']);
+    expect(missing).toEqual(['f3']);
+  });
+
+  it('returns empty array when all fields are in layout', () => {
+    const layout: TypeLayout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'normal', showLabel: true } },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const missing = findFieldsNotInLayout(layout, ['f1']);
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/lib/layout/__tests__/integration.test.ts
+++ b/src/lib/layout/__tests__/integration.test.ts
@@ -5,6 +5,7 @@ import { generateMockItem } from '../mock-data';
 import { deriveFormFields } from '../form-derivation';
 import { removeFieldFromLayout, findFieldsNotInLayout } from '../field-sync';
 import type { CustomField, ItemType } from '@/lib/types';
+import type { LayoutBlock, TypeLayout } from '../types';
 
 const itemType: ItemType = {
   id: 't1',
@@ -75,10 +76,10 @@ describe('Layout system integration', () => {
 
   it('layout with rows validates and derives form correctly', () => {
     const layout = generateDefaultLayout(fields);
-    const fieldBlocks = layout.blocks.filter((b) => b.type === 'field_display');
+    const fieldBlocks = layout.blocks.filter((b) => b.type === 'field_display') as LayoutBlock[];
     const otherBlocks = layout.blocks.filter((b) => b.type !== 'field_display');
 
-    const rowLayout = {
+    const rowLayout: TypeLayout = {
       ...layout,
       blocks: [
         ...otherBlocks.slice(0, -1),

--- a/src/lib/layout/__tests__/integration.test.ts
+++ b/src/lib/layout/__tests__/integration.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { typeLayoutSchema } from '../schemas';
+import { generateDefaultLayout } from '../defaults';
+import { generateMockItem } from '../mock-data';
+import { deriveFormFields } from '../form-derivation';
+import { removeFieldFromLayout, findFieldsNotInLayout } from '../field-sync';
+import type { CustomField, ItemType } from '@/lib/types';
+
+const itemType: ItemType = {
+  id: 't1',
+  name: 'Bird Box',
+  icon: '🏠',
+  color: '#5D7F3A',
+  sort_order: 0,
+  created_at: '2026-01-01',
+  org_id: 'o1',
+  layout: null,
+};
+
+const fields: CustomField[] = [
+  { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin', 'Wren'], required: true, sort_order: 0, org_id: 'o1' },
+  { id: 'f2', item_type_id: 't1', name: 'Install Date', field_type: 'date', options: null, required: false, sort_order: 1, org_id: 'o1' },
+  { id: 'f3', item_type_id: 't1', name: 'Height', field_type: 'number', options: null, required: false, sort_order: 2, org_id: 'o1' },
+];
+
+describe('Layout system integration', () => {
+  it('full lifecycle: generate → validate → mock → derive form → delete field', () => {
+    // 1. Generate default layout
+    const layout = generateDefaultLayout(fields);
+    expect(layout.blocks.length).toBeGreaterThan(3);
+
+    // 2. Validate generated layout
+    const validated = typeLayoutSchema.safeParse(layout);
+    expect(validated.success).toBe(true);
+
+    // 3. Generate mock item for preview
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe('Robin');
+    expect(mock.custom_field_values['f2']).toBeDefined();
+    expect(mock.custom_field_values['f3']).toBe(42);
+
+    // 4. Derive form fields
+    const form = deriveFormFields(layout, fields);
+    expect(form.fields).toHaveLength(3);
+    expect(form.fields[0].name).toBe('Species');
+    expect(form.fields[1].name).toBe('Install Date');
+    expect(form.fields[2].name).toBe('Height');
+
+    // 5. Delete a field — layout updates
+    const updated = removeFieldFromLayout(layout, 'f2');
+    expect(updated.blocks.length).toBe(layout.blocks.length - 1);
+
+    // 6. Validate updated layout still valid
+    const revalidated = typeLayoutSchema.safeParse(updated);
+    expect(revalidated.success).toBe(true);
+
+    // 7. Derive form after deletion — should have 2 fields
+    const formAfterDelete = deriveFormFields(updated, fields.filter((f) => f.id !== 'f2'));
+    expect(formAfterDelete.fields).toHaveLength(2);
+  });
+
+  it('backward compatibility: null layout handled gracefully', () => {
+    const emptyFields = findFieldsNotInLayout(
+      { version: 1, blocks: [], spacing: 'comfortable', peekBlockCount: 0 } as any,
+      ['f1', 'f2'],
+    );
+    expect(emptyFields).toEqual(['f1', 'f2']);
+  });
+
+  it('field sync detects fields not in layout', () => {
+    const layout = generateDefaultLayout([fields[0]]);
+    const missing = findFieldsNotInLayout(layout, ['f1', 'f2', 'f3']);
+    expect(missing).toEqual(['f2', 'f3']);
+  });
+
+  it('layout with rows validates and derives form correctly', () => {
+    const layout = generateDefaultLayout(fields);
+    const fieldBlocks = layout.blocks.filter((b) => b.type === 'field_display');
+    const otherBlocks = layout.blocks.filter((b) => b.type !== 'field_display');
+
+    const rowLayout = {
+      ...layout,
+      blocks: [
+        ...otherBlocks.slice(0, -1),
+        {
+          id: 'row1',
+          type: 'row' as const,
+          children: [fieldBlocks[0], fieldBlocks[1]],
+          gap: 'normal' as const,
+          distribution: 'equal' as const,
+        },
+        fieldBlocks[2],
+        otherBlocks[otherBlocks.length - 1],
+      ],
+    };
+
+    const validated = typeLayoutSchema.safeParse(rowLayout);
+    expect(validated.success).toBe(true);
+
+    const form = deriveFormFields(rowLayout, fields);
+    expect(form.rows).toHaveLength(1);
+    expect(form.rows[0].fieldIds).toHaveLength(2);
+  });
+});

--- a/src/lib/layout/__tests__/mock-data.test.ts
+++ b/src/lib/layout/__tests__/mock-data.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { generateMockItem } from '../mock-data';
+import type { CustomField, ItemType } from '@/lib/types';
+
+describe('generateMockItem', () => {
+  const itemType: ItemType = {
+    id: 't1',
+    name: 'Bird Box',
+    icon: '🏠',
+    color: '#5D7F3A',
+    sort_order: 0,
+    created_at: '2026-01-01',
+    org_id: 'o1',
+    layout: null,
+  };
+
+  it('generates a mock item with correct type info', () => {
+    const mock = generateMockItem(itemType, []);
+    expect(mock.name).toBe('Sample Bird Box');
+    expect(mock.item_type_id).toBe('t1');
+    expect(mock.status).toBe('active');
+    expect(mock.latitude).toBeTypeOf('number');
+    expect(mock.longitude).toBeTypeOf('number');
+  });
+
+  it('generates mock values for text fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Notes', field_type: 'text', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe('Sample text');
+  });
+
+  it('generates mock values for number fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Count', field_type: 'number', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe(42);
+  });
+
+  it('generates first option for dropdown fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Species', field_type: 'dropdown', options: ['Robin', 'Wren'], required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe('Robin');
+  });
+
+  it('generates today for date fields', () => {
+    const fields: CustomField[] = [
+      { id: 'f1', item_type_id: 't1', name: 'Installed', field_type: 'date', options: null, required: false, sort_order: 0, org_id: 'o1' },
+    ];
+    const mock = generateMockItem(itemType, fields);
+    expect(mock.custom_field_values['f1']).toBe(new Date().toISOString().split('T')[0]);
+  });
+
+  it('includes mock photos', () => {
+    const mock = generateMockItem(itemType, []);
+    expect(mock.photos.length).toBeGreaterThan(0);
+  });
+
+  it('includes mock updates', () => {
+    const mock = generateMockItem(itemType, []);
+    expect(mock.updates.length).toBe(3);
+  });
+});

--- a/src/lib/layout/__tests__/schemas.test.ts
+++ b/src/lib/layout/__tests__/schemas.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { typeLayoutSchema } from '../schemas';
+
+describe('typeLayoutSchema', () => {
+  it('accepts a valid layout with blocks', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        { id: 'b1', type: 'status_badge', config: {} },
+        { id: 'b2', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 4 } },
+        {
+          id: 'b3',
+          type: 'field_display',
+          config: { fieldId: 'f1', size: 'normal', showLabel: true },
+          hideWhenEmpty: true,
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 2,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a layout with a row', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'field_display', config: { fieldId: 'f1', size: 'compact', showLabel: true } },
+            { id: 'b2', type: 'field_display', config: { fieldId: 'f2', size: 'compact', showLabel: true } },
+          ],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'compact',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts row with number[] distribution', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [
+            { id: 'b1', type: 'status_badge', config: {} },
+            { id: 'b2', type: 'text_label', config: { text: 'Hello', style: 'heading' } },
+          ],
+          gap: 'tight',
+          distribution: [2, 1],
+        },
+      ],
+      spacing: 'spacious',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty blocks array', () => {
+    const layout = {
+      version: 1,
+      blocks: [],
+      spacing: 'comfortable',
+      peekBlockCount: 0,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid block type', () => {
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'unknown_block', config: {} }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects row with fewer than 2 children', () => {
+    const layout = {
+      version: 1,
+      blocks: [
+        {
+          id: 'r1',
+          type: 'row',
+          children: [{ id: 'b1', type: 'status_badge', config: {} }],
+          gap: 'normal',
+          distribution: 'equal',
+        },
+      ],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects row with more than 4 children', () => {
+    const children = Array.from({ length: 5 }, (_, i) => ({
+      id: `b${i}`,
+      type: 'status_badge' as const,
+      config: {},
+    }));
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'r1', type: 'row', children, gap: 'normal', distribution: 'equal' }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects maxPhotos outside 1-20', () => {
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'photo_gallery', config: { style: 'hero', maxPhotos: 25 } }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid spacing preset', () => {
+    const layout = {
+      version: 1,
+      blocks: [{ id: 'b1', type: 'divider', config: {} }],
+      spacing: 'extra-wide',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults to version 1', () => {
+    const layout = {
+      blocks: [{ id: 'b1', type: 'divider', config: {} }],
+      spacing: 'comfortable',
+      peekBlockCount: 1,
+    };
+    const result = typeLayoutSchema.safeParse(layout);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe(1);
+    }
+  });
+});

--- a/src/lib/layout/__tests__/types.test.ts
+++ b/src/lib/layout/__tests__/types.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isLayoutRow, isLayoutBlock } from '../types';
+import type { LayoutBlock, LayoutRow } from '../types';
+
+describe('layout type guards', () => {
+  const block: LayoutBlock = {
+    id: 'b1',
+    type: 'status_badge',
+    config: {},
+  };
+
+  const row: LayoutRow = {
+    id: 'r1',
+    type: 'row',
+    children: [block],
+    gap: 'normal',
+    distribution: 'equal',
+  };
+
+  it('isLayoutRow returns true for rows', () => {
+    expect(isLayoutRow(row)).toBe(true);
+  });
+
+  it('isLayoutRow returns false for blocks', () => {
+    expect(isLayoutRow(block)).toBe(false);
+  });
+
+  it('isLayoutBlock returns true for blocks', () => {
+    expect(isLayoutBlock(block)).toBe(true);
+  });
+
+  it('isLayoutBlock returns false for rows', () => {
+    expect(isLayoutBlock(row)).toBe(false);
+  });
+});

--- a/src/lib/layout/defaults.ts
+++ b/src/lib/layout/defaults.ts
@@ -1,0 +1,25 @@
+import { nanoid } from 'nanoid';
+import type { TypeLayout, LayoutBlock } from './types';
+import type { CustomField } from '@/lib/types';
+
+export function generateDefaultLayout(customFields: CustomField[]): TypeLayout {
+  const sorted = [...customFields].sort((a, b) => a.sort_order - b.sort_order);
+
+  const fieldBlocks: LayoutBlock[] = sorted.map((field) => ({
+    id: nanoid(10),
+    type: 'field_display',
+    config: { fieldId: field.id, size: 'normal' as const, showLabel: true },
+  }));
+
+  return {
+    version: 1,
+    spacing: 'comfortable',
+    peekBlockCount: 2,
+    blocks: [
+      { id: nanoid(10), type: 'status_badge', config: {} },
+      { id: nanoid(10), type: 'photo_gallery', config: { style: 'hero' as const, maxPhotos: 4 } },
+      ...fieldBlocks,
+      { id: nanoid(10), type: 'action_buttons', config: {} },
+    ],
+  };
+}

--- a/src/lib/layout/field-sync.ts
+++ b/src/lib/layout/field-sync.ts
@@ -1,0 +1,54 @@
+import type { TypeLayout, LayoutNode, LayoutBlock, FieldDisplayConfig } from './types';
+import { isLayoutRow } from './types';
+
+/**
+ * Remove all field_display blocks referencing a given fieldId.
+ * If a row is left with <2 children, unwrap it to a single block.
+ */
+export function removeFieldFromLayout(layout: TypeLayout, fieldId: string): TypeLayout {
+  const blocks: LayoutNode[] = [];
+
+  for (const node of layout.blocks) {
+    if (isLayoutRow(node)) {
+      const filtered = node.children.filter(
+        (c) => !(c.type === 'field_display' && (c.config as FieldDisplayConfig).fieldId === fieldId),
+      );
+      if (filtered.length === 0) continue;
+      if (filtered.length === 1) {
+        blocks.push(filtered[0]);
+      } else {
+        blocks.push({ ...node, children: filtered });
+      }
+    } else {
+      if (node.type === 'field_display' && (node.config as FieldDisplayConfig).fieldId === fieldId) {
+        continue;
+      }
+      blocks.push(node);
+    }
+  }
+
+  return { ...layout, blocks };
+}
+
+/**
+ * Find field IDs that are not referenced by any field_display block in the layout.
+ */
+export function findFieldsNotInLayout(layout: TypeLayout, fieldIds: string[]): string[] {
+  const inLayout = new Set<string>();
+
+  function scanBlock(block: LayoutBlock) {
+    if (block.type === 'field_display') {
+      inLayout.add((block.config as FieldDisplayConfig).fieldId);
+    }
+  }
+
+  for (const node of layout.blocks) {
+    if (isLayoutRow(node)) {
+      node.children.forEach(scanBlock);
+    } else {
+      scanBlock(node);
+    }
+  }
+
+  return fieldIds.filter((id) => !inLayout.has(id));
+}

--- a/src/lib/layout/form-derivation.ts
+++ b/src/lib/layout/form-derivation.ts
@@ -1,5 +1,5 @@
 import type { CustomField } from '@/lib/types';
-import type { LayoutBlock } from './types';
+import type { LayoutBlock, LayoutNode, FieldDisplayConfig, TextLabelConfig } from './types';
 import { isLayoutRow } from './types';
 import type { TypeLayout } from './types';
 
@@ -31,13 +31,13 @@ export function deriveFormFields(layout: TypeLayout, customFields: CustomField[]
   // formElementIndex tracks position among form elements (fields + photo)
   let formElementIndex = 0;
 
-  function processBlock(block: LayoutBlock): void {
-    if (isLayoutRow(block)) {
+  function processNode(node: LayoutNode): void {
+    if (isLayoutRow(node)) {
       const rowFieldIds: string[] = [];
 
-      for (const child of block.children) {
+      for (const child of node.children) {
         if (child.type === 'field_display') {
-          const field = fieldMap.get(child.config.fieldId);
+          const field = fieldMap.get((child.config as FieldDisplayConfig).fieldId);
           if (field) {
             fields.push(field);
             rowFieldIds.push(field.id);
@@ -53,9 +53,9 @@ export function deriveFormFields(layout: TypeLayout, customFields: CustomField[]
       return;
     }
 
-    switch (block.type) {
+    switch (node.type) {
       case 'field_display': {
-        const field = fieldMap.get(block.config.fieldId);
+        const field = fieldMap.get((node.config as FieldDisplayConfig).fieldId);
         if (field) {
           fields.push(field);
           formElementIndex++;
@@ -70,9 +70,10 @@ export function deriveFormFields(layout: TypeLayout, customFields: CustomField[]
       }
 
       case 'text_label': {
+        const config = node.config as TextLabelConfig;
         sections.push({
-          text: block.config.text,
-          style: block.config.style,
+          text: config.text,
+          style: config.style,
           beforeFieldIndex: formElementIndex,
         });
         break;
@@ -89,8 +90,8 @@ export function deriveFormFields(layout: TypeLayout, customFields: CustomField[]
     }
   }
 
-  for (const block of layout.blocks) {
-    processBlock(block);
+  for (const node of layout.blocks) {
+    processNode(node);
   }
 
   return { fields, rows, sections, photoPosition };

--- a/src/lib/layout/mock-data.ts
+++ b/src/lib/layout/mock-data.ts
@@ -1,0 +1,137 @@
+import type { CustomField, Entity, EntityType, ItemType, ItemUpdate, ItemWithDetails, Photo, UpdateType } from '@/lib/types';
+
+const MOCK_ORG_ID = 'mock-org';
+const MOCK_PROPERTY_ID = 'mock-property';
+const MOCK_ITEM_ID = 'mock-item';
+
+function dateOffset(daysAgo: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return d.toISOString();
+}
+
+function today(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function getMockFieldValue(field: CustomField): unknown {
+  switch (field.field_type) {
+    case 'text':
+      return 'Sample text';
+    case 'number':
+      return 42;
+    case 'dropdown':
+      return Array.isArray(field.options) && field.options.length > 0 ? field.options[0] : '';
+    case 'date':
+      return today();
+    default:
+      return null;
+  }
+}
+
+const MOCK_UPDATE_TYPE: UpdateType = {
+  id: 'mock-update-type',
+  name: 'Inspection',
+  icon: '🔍',
+  is_global: true,
+  item_type_id: null,
+  sort_order: 0,
+  org_id: MOCK_ORG_ID,
+  min_role_create: null,
+  min_role_edit: null,
+  min_role_delete: null,
+};
+
+const MOCK_ENTITY_TYPE: EntityType = {
+  id: 'mock-entity-type',
+  org_id: MOCK_ORG_ID,
+  name: 'Volunteer',
+  icon: '👤',
+  color: '#4A90D9',
+  link_to: ['items'],
+  sort_order: 0,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const MOCK_ENTITY: Entity & { entity_type: EntityType } = {
+  id: 'mock-entity',
+  entity_type_id: 'mock-entity-type',
+  org_id: MOCK_ORG_ID,
+  name: 'Jane Smith',
+  description: null,
+  photo_path: null,
+  external_link: null,
+  custom_field_values: {},
+  sort_order: 0,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  entity_type: MOCK_ENTITY_TYPE,
+};
+
+function makeMockUpdate(id: string, daysAgo: number): ItemUpdate & { update_type: UpdateType; photos: Photo[]; entities: (Entity & { entity_type: EntityType })[] } {
+  const ts = dateOffset(daysAgo);
+  return {
+    id,
+    item_id: MOCK_ITEM_ID,
+    update_type_id: 'mock-update-type',
+    content: 'Routine check completed. Everything looks good.',
+    update_date: ts.split('T')[0],
+    created_at: ts,
+    created_by: null,
+    org_id: MOCK_ORG_ID,
+    property_id: MOCK_PROPERTY_ID,
+    custom_field_values: {},
+    update_type: MOCK_UPDATE_TYPE,
+    photos: [],
+    entities: [],
+  };
+}
+
+export function generateMockItem(itemType: ItemType, fields: CustomField[]): ItemWithDetails {
+  const customFieldValues: Record<string, unknown> = {};
+  for (const field of fields) {
+    customFieldValues[field.id] = getMockFieldValue(field);
+  }
+
+  const photos: Photo[] = [
+    {
+      id: 'mock-photo-1',
+      item_id: MOCK_ITEM_ID,
+      update_id: null,
+      storage_path: 'mock/placeholder.jpg',
+      caption: 'Sample photo',
+      is_primary: true,
+      created_at: '2026-01-01T00:00:00Z',
+      org_id: MOCK_ORG_ID,
+      property_id: MOCK_PROPERTY_ID,
+    },
+  ];
+
+  const updates = [
+    makeMockUpdate('mock-update-1', 0),
+    makeMockUpdate('mock-update-2', 7),
+    makeMockUpdate('mock-update-3', 30),
+  ];
+
+  return {
+    id: MOCK_ITEM_ID,
+    name: `Sample ${itemType.name}`,
+    description: 'This is a sample item for layout preview.',
+    latitude: 51.505,
+    longitude: -0.09,
+    item_type_id: itemType.id,
+    custom_field_values: customFieldValues,
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    created_by: null,
+    org_id: MOCK_ORG_ID,
+    property_id: MOCK_PROPERTY_ID,
+    item_type: itemType,
+    updates,
+    photos,
+    custom_fields: fields,
+    entities: [MOCK_ENTITY],
+  };
+}

--- a/src/lib/layout/schemas.ts
+++ b/src/lib/layout/schemas.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+
+// Block config schemas
+const fieldDisplayConfigSchema = z.object({
+  fieldId: z.string().min(1),
+  size: z.enum(['compact', 'normal', 'large']),
+  showLabel: z.boolean(),
+});
+
+const photoGalleryConfigSchema = z.object({
+  style: z.enum(['hero', 'grid', 'carousel']),
+  maxPhotos: z.number().int().min(1).max(20),
+});
+
+const statusBadgeConfigSchema = z.object({});
+
+const entityListConfigSchema = z.object({
+  entityTypeIds: z.array(z.string()),
+});
+
+const timelineConfigSchema = z.object({
+  showUpdates: z.boolean(),
+  showScheduled: z.boolean(),
+  maxItems: z.number().int().min(1).max(50),
+});
+
+const textLabelConfigSchema = z.object({
+  text: z.string(),
+  style: z.enum(['heading', 'subheading', 'body', 'caption']),
+});
+
+const emptyConfigSchema = z.object({});
+
+// Discriminated block schemas
+const fieldDisplayBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('field_display'),
+  config: fieldDisplayConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const photoGalleryBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('photo_gallery'),
+  config: photoGalleryConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const statusBadgeBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('status_badge'),
+  config: statusBadgeConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const entityListBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('entity_list'),
+  config: entityListConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const textLabelBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('text_label'),
+  config: textLabelConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const timelineBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('timeline'),
+  config: timelineConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const dividerBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('divider'),
+  config: emptyConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const actionButtonsBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('action_buttons'),
+  config: emptyConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+const mapSnippetBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('map_snippet'),
+  config: emptyConfigSchema,
+  hideWhenEmpty: z.boolean().optional(),
+});
+
+export const layoutBlockSchema = z.discriminatedUnion('type', [
+  fieldDisplayBlockSchema,
+  photoGalleryBlockSchema,
+  statusBadgeBlockSchema,
+  entityListBlockSchema,
+  textLabelBlockSchema,
+  timelineBlockSchema,
+  dividerBlockSchema,
+  actionButtonsBlockSchema,
+  mapSnippetBlockSchema,
+]);
+
+const layoutRowSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('row'),
+  children: z.array(layoutBlockSchema).min(2).max(4),
+  gap: z.enum(['tight', 'normal', 'loose']),
+  distribution: z.union([
+    z.enum(['equal', 'auto']),
+    z.array(z.number().positive()),
+  ]),
+});
+
+export const layoutNodeSchema = z.union([layoutBlockSchema, layoutRowSchema]);
+
+export const typeLayoutSchema = z.object({
+  version: z.literal(1).default(1),
+  blocks: z.array(layoutNodeSchema).min(1),
+  spacing: z.enum(['compact', 'comfortable', 'spacious']),
+  peekBlockCount: z.number().int().min(0).max(10),
+});

--- a/src/lib/layout/spacing.ts
+++ b/src/lib/layout/spacing.ts
@@ -1,0 +1,10 @@
+import type { SpacingPreset } from './types';
+
+export const SPACING = {
+  compact: { blockGap: 8, rowGap: 8, sectionPadding: 12 },
+  comfortable: { blockGap: 12, rowGap: 12, sectionPadding: 16 },
+  spacious: { blockGap: 16, rowGap: 16, sectionPadding: 20 },
+} as const satisfies Record<SpacingPreset, { blockGap: number; rowGap: number; sectionPadding: number }>;
+
+/** Width below which rows collapse to vertical stacking */
+export const ROW_COLLAPSE_BREAKPOINT = 480;

--- a/src/lib/layout/types.ts
+++ b/src/lib/layout/types.ts
@@ -1,21 +1,68 @@
-// ======================
-// Layout block configs
-// ======================
+// src/lib/layout/types.ts
+
+export type SpacingPreset = 'compact' | 'comfortable' | 'spacious';
+
+export interface TypeLayout {
+  version: 1;
+  blocks: LayoutNode[];
+  spacing: SpacingPreset;
+  peekBlockCount: number;
+}
+
+export type LayoutNode = LayoutBlock | LayoutRow;
+
+export interface LayoutBlock {
+  id: string;
+  type: BlockType;
+  config: BlockConfig;
+  hideWhenEmpty?: boolean;
+}
+
+export interface LayoutRow {
+  id: string;
+  type: 'row';
+  children: LayoutBlock[];
+  gap: 'tight' | 'normal' | 'loose';
+  distribution: 'equal' | 'auto' | number[];
+}
+
+export type BlockType =
+  | 'field_display'
+  | 'photo_gallery'
+  | 'status_badge'
+  | 'entity_list'
+  | 'text_label'
+  | 'divider'
+  | 'action_buttons'
+  | 'map_snippet'
+  | 'timeline';
+
+export type BlockConfig =
+  | FieldDisplayConfig
+  | PhotoGalleryConfig
+  | StatusBadgeConfig
+  | EntityListConfig
+  | TimelineConfig
+  | TextLabelConfig
+  | DividerConfig
+  | MapSnippetConfig
+  | ActionButtonsConfig;
 
 export interface FieldDisplayConfig {
   fieldId: string;
-  size: 'normal' | 'large';
+  size: 'compact' | 'normal' | 'large';
   showLabel: boolean;
 }
 
 export interface PhotoGalleryConfig {
-  style: 'hero' | 'grid' | 'strip';
+  style: 'hero' | 'grid' | 'carousel';
   maxPhotos: number;
 }
 
-export interface TextLabelConfig {
-  text: string;
-  style: string;
+export interface StatusBadgeConfig {}
+
+export interface EntityListConfig {
+  entityTypeIds: string[];
 }
 
 export interface TimelineConfig {
@@ -24,108 +71,22 @@ export interface TimelineConfig {
   maxItems: number;
 }
 
-// ======================
-// Layout block types
-// ======================
-
-export type LayoutBlockType =
-  | 'field_display'
-  | 'photo_gallery'
-  | 'text_label'
-  | 'status_badge'
-  | 'entity_list'
-  | 'timeline'
-  | 'map_snippet'
-  | 'action_buttons'
-  | 'divider'
-  | 'row';
-
-interface BaseLayoutBlock {
-  id: string;
-  type: LayoutBlockType;
+export interface TextLabelConfig {
+  text: string;
+  style: 'heading' | 'subheading' | 'body' | 'caption';
 }
 
-export interface FieldDisplayBlock extends BaseLayoutBlock {
-  type: 'field_display';
-  config: FieldDisplayConfig;
+export interface DividerConfig {}
+
+export interface MapSnippetConfig {}
+
+export interface ActionButtonsConfig {}
+
+// Type guard helpers
+export function isLayoutRow(node: LayoutNode): node is LayoutRow {
+  return node.type === 'row';
 }
 
-export interface PhotoGalleryBlock extends BaseLayoutBlock {
-  type: 'photo_gallery';
-  config: PhotoGalleryConfig;
-}
-
-export interface TextLabelBlock extends BaseLayoutBlock {
-  type: 'text_label';
-  config: TextLabelConfig;
-}
-
-export interface StatusBadgeBlock extends BaseLayoutBlock {
-  type: 'status_badge';
-  config: Record<string, unknown>;
-}
-
-export interface EntityListBlock extends BaseLayoutBlock {
-  type: 'entity_list';
-  config: Record<string, unknown>;
-}
-
-export interface TimelineBlock extends BaseLayoutBlock {
-  type: 'timeline';
-  config: TimelineConfig;
-}
-
-export interface MapSnippetBlock extends BaseLayoutBlock {
-  type: 'map_snippet';
-  config: Record<string, unknown>;
-}
-
-export interface ActionButtonsBlock extends BaseLayoutBlock {
-  type: 'action_buttons';
-  config: Record<string, unknown>;
-}
-
-export interface DividerBlock extends BaseLayoutBlock {
-  type: 'divider';
-  config?: Record<string, unknown>;
-}
-
-export interface LayoutRow extends BaseLayoutBlock {
-  type: 'row';
-  children: LayoutBlock[];
-  gap: 'normal' | 'tight' | 'wide';
-  distribution: 'equal' | 'auto';
-}
-
-export type LayoutBlock =
-  | FieldDisplayBlock
-  | PhotoGalleryBlock
-  | TextLabelBlock
-  | StatusBadgeBlock
-  | EntityListBlock
-  | TimelineBlock
-  | MapSnippetBlock
-  | ActionButtonsBlock
-  | DividerBlock
-  | LayoutRow;
-
-export type LayoutNode = LayoutBlock;
-
-// ======================
-// Top-level layout type
-// ======================
-
-export interface TypeLayout {
-  version: number;
-  blocks: LayoutBlock[];
-  spacing: 'comfortable' | 'compact' | 'spacious';
-  peekBlockCount: number;
-}
-
-// ======================
-// Type guards
-// ======================
-
-export function isLayoutRow(block: LayoutBlock): block is LayoutRow {
-  return block.type === 'row';
+export function isLayoutBlock(node: LayoutNode): node is LayoutBlock {
+  return node.type !== 'row';
 }

--- a/src/lib/offline/__tests__/store.test.ts
+++ b/src/lib/offline/__tests__/store.test.ts
@@ -34,8 +34,8 @@ describe('Offline Store', () => {
 
     it('getItemTypes returns types for an org', async () => {
       await db.item_types.bulkPut([
-        { id: 't1', name: 'Birdhouse', icon: '🏠', color: '#000', sort_order: 1, created_at: '', org_id: 'o1', _synced_at: '' },
-        { id: 't2', name: 'Nest', icon: '🪺', color: '#fff', sort_order: 2, created_at: '', org_id: 'o2', _synced_at: '' },
+        { id: 't1', name: 'Birdhouse', icon: '🏠', color: '#000', sort_order: 1, layout: null, created_at: '', org_id: 'o1', _synced_at: '' },
+        { id: 't2', name: 'Nest', icon: '🪺', color: '#fff', sort_order: 2, layout: null, created_at: '', org_id: 'o2', _synced_at: '' },
       ]);
 
       const types = await getItemTypes(db, 'o1');

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { TypeLayout } from '@/lib/layout/types';
+
 // ======================
 // Enums / Union types
 // ======================
@@ -48,6 +50,7 @@ export interface ItemType {
   icon: string;
   color: string;
   sort_order: number;
+  layout: TypeLayout | null;
   created_at: string;
   org_id: string;
 }

--- a/supabase/migrations/030_item_type_layout.sql
+++ b/supabase/migrations/030_item_type_layout.sql
@@ -1,0 +1,8 @@
+-- supabase/migrations/030_item_type_layout.sql
+-- Add layout JSONB column to item_types for custom detail panel layouts
+
+ALTER TABLE item_types
+ADD COLUMN layout jsonb DEFAULT NULL;
+
+COMMENT ON COLUMN item_types.layout IS
+  'JSON layout definition for the item detail panel. NULL = use default rendering.';


### PR DESCRIPTION
## Summary

- **Drag-and-drop layout builder** for item types — admins can design custom detail panel views with live preview
- **Multi-snap bottom sheet** (peek/half/full) replaces fixed bottom sheet for item details
- **9 block types**: Field Display, Photo Gallery, Status Badge, Entity List, Timeline, Text Label, Divider, Map Snippet, Action Buttons
- **Auto-generated form preview** derives input forms from the detail layout
- **Field lifecycle sync** — deletion cascade removes blocks referencing deleted fields
- **Responsive**: mobile full-screen tabbed builder, desktop side-by-side with live preview

## What's included

### Database
- Migration `030_item_type_layout.sql` — adds JSONB `layout` column to `item_types`

### Layout system (`src/lib/layout/`)
- TypeScript types, Zod validation schemas, spacing constants
- Default layout generation, mock data for preview
- Form derivation logic, field sync (deletion cascade + missing field detection)

### Components
- `LayoutRenderer` + 9 block components + `RowBlock` + error boundary
- `MultiSnapBottomSheet` with safe area insets, swipe affordance, scroll fade
- **Builder UI** (9 components): `BlockPalette`, `BlockList`, `BlockListItem`, `BlockConfigPanel`, `InlineFieldCreator`, `SpacingPicker`, `PeekBoundary`, `RowEditor`, `LayoutBuilder`
- `FormPreview` + `DetailPreview` for live builder previews

### Integration
- `DetailPanel` — backward-compatible layout/legacy rendering toggle
- Admin types page — Layout/Fields/Settings tabs per item type
- FAB repositioning based on bottom sheet state
- Server actions for layout save/delete

## Test plan

- [x] 774 tests passing (96 test files)
- [x] `tsc --noEmit` — 0 type errors
- [x] `npm run build` — production build succeeds
- [x] Integration tests cover full lifecycle: generate → validate → mock → derive form → delete field → revalidate
- [ ] Manual test: create an item type, open Layout tab, add/reorder/configure blocks, save
- [ ] Manual test: verify bottom sheet renders layout on map view
- [ ] Manual test: test mobile responsive builder (< 768px)
- [ ] Manual test: delete a field from Fields tab, verify layout auto-updates

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)