### PR TITLE
fix: Google Photos picker redirect_uri_mismatch (#143)

### DIFF
--- a/src/__tests__/google/picker.test.ts
+++ b/src/__tests__/google/picker.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isGooglePhotosConfigured } from '@/lib/google/picker';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isGooglePhotosConfigured, getGooglePhotosPickerUrl } from '@/lib/google/picker';
 
 describe('isGooglePhotosConfigured', () => {
   const originalEnv = process.env;
@@ -31,5 +31,60 @@ describe('isGooglePhotosConfigured', () => {
     delete process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
     delete process.env.NEXT_PUBLIC_GOOGLE_API_KEY;
     expect(isGooglePhotosConfigured()).toBe(false);
+  });
+});
+
+describe('getGooglePhotosPickerUrl', () => {
+  const originalWindow = globalThis.window;
+
+  function mockHostname(hostname: string) {
+    Object.defineProperty(globalThis, 'window', {
+      value: { location: { hostname } },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('returns relative path on localhost', () => {
+    mockHostname('localhost');
+    expect(getGooglePhotosPickerUrl(5, 'fieldmapper.org')).toBe('/google-photos-picker?maxFiles=5');
+  });
+
+  it('returns relative path on 127.0.0.1', () => {
+    mockHostname('127.0.0.1');
+    expect(getGooglePhotosPickerUrl(3, 'fieldmapper.org')).toBe('/google-photos-picker?maxFiles=3');
+  });
+
+  it('returns relative path when on the platform domain', () => {
+    mockHostname('fieldmapper.org');
+    expect(getGooglePhotosPickerUrl(5, 'fieldmapper.org')).toBe('/google-photos-picker?maxFiles=5');
+  });
+
+  it('returns relative path on Vercel preview URLs', () => {
+    mockHostname('birdhouse-mapper-abc123.vercel.app');
+    expect(getGooglePhotosPickerUrl(5, 'birdhouse-mapper.vercel.app')).toBe('/google-photos-picker?maxFiles=5');
+  });
+
+  it('returns platform domain URL for custom domains', () => {
+    mockHostname('fairbankseagle.org');
+    expect(getGooglePhotosPickerUrl(5, 'fieldmapper.org')).toBe('https://fieldmapper.org/google-photos-picker?maxFiles=5');
+  });
+
+  it('returns relative path when platformDomain is null', () => {
+    mockHostname('example.com');
+    expect(getGooglePhotosPickerUrl(5, null)).toBe('/google-photos-picker?maxFiles=5');
+  });
+
+  it('uses http protocol for localhost platform domain', () => {
+    mockHostname('fairbankseagle.org');
+    expect(getGooglePhotosPickerUrl(5, 'localhost:3000')).toBe('http://localhost:3000/google-photos-picker?maxFiles=5');
   });
 });

--- a/src/__tests__/photos/GooglePhotosSource.test.tsx
+++ b/src/__tests__/photos/GooglePhotosSource.test.tsx
@@ -7,9 +7,10 @@ vi.mock('@/lib/utils', () => ({
   resizeImage: vi.fn((file: File) => Promise.resolve(new Blob(['resized'], { type: 'image/jpeg' }))),
 }));
 
-// Mock picker module (only used by the popup page, not this component directly)
+// Mock picker module
 vi.mock('@/lib/google/picker', () => ({
   isGooglePhotosConfigured: () => true,
+  getGooglePhotosPickerUrl: (maxFiles: number) => `/google-photos-picker?maxFiles=${maxFiles}`,
 }));
 
 describe('GooglePhotosSource', () => {

--- a/src/app/google-photos-picker/page.tsx
+++ b/src/app/google-photos-picker/page.tsx
@@ -44,8 +44,9 @@ export default function GooglePhotosPickerPage() {
       window.close();
     } catch (err) {
       setStatus('error');
+      const baseMsg = err instanceof Error ? err.message : "Couldn't connect to Google Photos";
       setErrorMessage(
-        err instanceof Error ? err.message : "Couldn't connect to Google Photos"
+        `${baseMsg}\n\nIf you see "redirect_uri_mismatch", register ${window.location.origin} as an authorized JavaScript origin in Google Cloud Console.`
       );
     }
   }, []);

--- a/src/components/photos/GooglePhotosSource.tsx
+++ b/src/components/photos/GooglePhotosSource.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import type { PickerResult } from '@/lib/google/picker';
+import { type PickerResult, getGooglePhotosPickerUrl } from '@/lib/google/picker';
 import { resizeImage } from '@/lib/utils';
 import { useConfig } from '@/lib/config/client';
 
@@ -12,17 +12,6 @@ interface GooglePhotosSourceProps {
 }
 
 type Status = 'idle' | 'authenticating' | 'downloading' | 'error';
-
-/** Build the picker popup URL on the platform domain */
-function getPickerUrl(maxFiles: number, platformDomain: string | null): string {
-  if (platformDomain && platformDomain !== 'localhost') {
-    // Use platform domain so OAuth origin always matches Google's authorized JS origins
-    const protocol = platformDomain.includes('localhost') ? 'http' : 'https';
-    return `${protocol}://${platformDomain}/google-photos-picker?maxFiles=${maxFiles}`;
-  }
-  // Local dev or same-origin — use relative path
-  return `/google-photos-picker?maxFiles=${maxFiles}`;
-}
 
 const POLL_INTERVAL = 500; // ms — check if popup was closed
 
@@ -115,7 +104,7 @@ export default function GooglePhotosSource({
     setStatus('authenticating');
     setErrorMessage('');
 
-    const url = getPickerUrl(maxFiles, config.platformDomain);
+    const url = getGooglePhotosPickerUrl(maxFiles, config.platformDomain);
     const popup = window.open(url, 'google-photos-picker', 'width=900,height=600,scrollbars=yes');
 
     if (!popup) {

--- a/src/lib/google/picker.ts
+++ b/src/lib/google/picker.ts
@@ -6,6 +6,31 @@ export function isGooglePhotosConfigured(): boolean {
   );
 }
 
+/**
+ * Build the Google Photos picker popup URL.
+ *
+ * On custom domains, the popup opens on the platform domain so only one
+ * JavaScript origin needs to be registered in Google Cloud Console.
+ * On localhost, Vercel previews, or when already on the platform domain,
+ * use a relative path to avoid cross-origin issues.
+ */
+export function getGooglePhotosPickerUrl(maxFiles: number, platformDomain: string | null): string {
+  if (typeof window === 'undefined') return `/google-photos-picker?maxFiles=${maxFiles}`;
+
+  const currentHost = window.location.hostname;
+  const isLocalhost = currentHost === 'localhost' || currentHost === '127.0.0.1';
+  const isVercelPreview = currentHost.endsWith('.vercel.app') && currentHost !== platformDomain;
+  const isOnPlatformDomain = platformDomain && currentHost === platformDomain;
+
+  if (isLocalhost || isVercelPreview || isOnPlatformDomain || !platformDomain) {
+    return `/google-photos-picker?maxFiles=${maxFiles}`;
+  }
+
+  // Custom domain — open popup on the platform domain
+  const protocol = platformDomain.includes('localhost') ? 'http' : 'https';
+  return `${protocol}://${platformDomain}/google-photos-picker?maxFiles=${maxFiles}`;
+}
+
 const PICKER_API_URL = 'https://apis.google.com/js/api.js';
 const GIS_URL = 'https://accounts.google.com/gsi/client';
 const PHOTOS_SCOPE = 'https://www.googleapis.com/auth/photoslibrary.readonly';

--- a/src/lib/puck/fields/ImagePickerField.tsx
+++ b/src/lib/puck/fields/ImagePickerField.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback } from 'react';
 import { resizeImage } from '@/lib/utils';
 import { uploadLandingAsset } from '@/app/admin/landing/actions';
 import { useConfig } from '@/lib/config/client';
-import { isGooglePhotosConfigured } from '@/lib/google/picker';
+import { isGooglePhotosConfigured, getGooglePhotosPickerUrl } from '@/lib/google/picker';
 
 type Tab = 'library' | 'upload' | 'google-photos' | 'url';
 
@@ -132,16 +132,7 @@ function ImagePickerModal({
   function handleGooglePhotos() {
     setGoogleStatus('loading');
 
-    const getPickerUrl = (maxFiles: number) => {
-      const platformDomain = config.platformDomain;
-      if (platformDomain && platformDomain !== 'localhost') {
-        const protocol = platformDomain.includes('localhost') ? 'http' : 'https';
-        return `${protocol}://${platformDomain}/google-photos-picker?maxFiles=${maxFiles}`;
-      }
-      return `/google-photos-picker?maxFiles=${maxFiles}`;
-    };
-
-    const popup = window.open(getPickerUrl(1), 'google-photos-picker', 'width=900,height=600,scrollbars=yes');
+    const popup = window.open(getGooglePhotosPickerUrl(1, config.platformDomain), 'google-photos-picker', 'width=900,height=600,scrollbars=yes');
     if (!popup) {
       setGoogleStatus('error');
       return;


### PR DESCRIPTION
## Summary

Fixes #143 — Google Photos picker failing with `redirect_uri_mismatch` error.

## Root Cause

`getPickerUrl()` always opened the picker popup on `PLATFORM_DOMAIN`, which breaks on:
- **Vercel preview deploys** — origin is `birdhouse-mapper-abc123.vercel.app` but popup tries to open on `birdhouse-mapper.vercel.app`, causing cross-origin issues
- **Production** — works only if the domain is registered as a JavaScript origin in Google Cloud Console (config step that was likely missed)

## Fix

- Extract shared `getGooglePhotosPickerUrl()` to `src/lib/google/picker.ts` (was duplicated in 2 files)
- Smart origin detection:
  - **Localhost** → relative path
  - **Vercel preview** → relative path (avoids cross-origin with production domain)
  - **Already on platform domain** → relative path
  - **Custom domain** (e.g. `fairbankseagle.org`) → redirect to platform domain popup
- Improved error message shows which origin to register in Google Cloud Console
- 7 new tests covering all domain scenarios

**Note:** You still need to register `https://birdhouse-mapper.vercel.app` (and `http://localhost:3000` for local dev) as authorized JavaScript origins in Google Cloud Console → OAuth 2.0 Client IDs.

## Test plan

- [x] 16/16 picker and GooglePhotosSource tests pass
- [x] TypeScript type-check clean
- [ ] Manual: Open site builder → Gallery → Google Photos on production domain
- [ ] Manual: Verify picker works on Vercel preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)