### PR TITLE
fix: login from Vercel preview redirects to production (#193)

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -51,8 +51,14 @@ export async function GET(request: Request) {
           const org = (membership?.orgs as any);
           if (org?.slug) {
             const requestHost = new URL(request.url).hostname;
-            // On localhost, stay on the same origin — subdomain URLs don't work
-            if (requestHost === 'localhost') {
+            // On localhost or Vercel preview, stay on the same origin —
+            // subdomain/custom domain URLs won't point to the preview deployment
+            const isPreviewOrLocal =
+              requestHost === 'localhost' ||
+              process.env.VERCEL_ENV === 'preview' ||
+              process.env.VERCEL_ENV === 'development' ||
+              (requestHost.endsWith('.vercel.app') && requestHost !== process.env.PLATFORM_DOMAIN);
+            if (isPreviewOrLocal) {
               return NextResponse.redirect(new URL('/manage', origin));
             }
             // Prefer primary custom domain, fall back to platform subdomain


### PR DESCRIPTION
## Summary

Fixes #193 — Logging in from a Vercel preview URL redirects back to the production domain instead of staying on the preview.

## Root Cause

Two issues:

1. **Auth callback code** — The platform context branch in `/api/auth/callback` redirects to the org's custom domain or platform subdomain after login. On Vercel preview deploys, this sends users to production.

2. **Supabase redirect whitelist** — Supabase validates the `redirectTo` URL against configured Redirect URLs. If Vercel preview URLs aren't whitelisted, Supabase falls back to the Site URL (production).

## Code Fix

Detect Vercel preview/dev environments in the auth callback and stay on the current origin — same pattern already used for localhost:

```typescript
const isPreviewOrLocal =
  requestHost === 'localhost' ||
  process.env.VERCEL_ENV === 'preview' ||
  process.env.VERCEL_ENV === 'development' ||
  (requestHost.endsWith('.vercel.app') && requestHost !== process.env.PLATFORM_DOMAIN);
```

## Required Supabase Config

Also add Vercel preview URLs to the Supabase redirect whitelist:

**Supabase Dashboard > Authentication > URL Configuration > Redirect URLs:**
```
https://*-patrick-jacksons-projects-c406a118.vercel.app/**
```

This allows Supabase to accept the preview URL as a valid redirect target.

## Test plan

- [x] TypeScript type-check clean
- [ ] Deploy this PR, open the Vercel preview URL
- [ ] Login with Google → should redirect back to the preview URL, not production
- [ ] Verify production login still redirects to custom domain/subdomain

🤖 Generated with [Claude Code](https://claude.com/claude-code)