### PR TITLE
feat: add cross-tool developer memory system

### DIFF
--- a/.cursor/rules/00-project-overview.mdc
+++ b/.cursor/rules/00-project-overview.mdc
@@ -1,0 +1,30 @@
+---
+description: Project overview and architecture for FieldMapper
+globs:
+alwaysApply: true
+---
+
+# FieldMapper — Project Overview
+
+FieldMapper is a multi-tenant field mapping platform for conservation teams.
+
+## Stack
+- Next.js 14 (App Router)
+- Supabase (Auth, PostgreSQL, RLS)
+- Tailwind CSS (custom classes: .card, .btn-primary, .btn-secondary, .input-field, .label)
+- Leaflet (mapping)
+
+## Architecture
+- Multi-tenant: tenant resolution via middleware
+- Server actions: `'use server'` files, return `{ success: true }` or `{ error: string }`
+- Auth: Supabase Auth (email/password + Google OAuth)
+- No external UI component library — all custom
+
+## Key Commands
+- `npm run dev` — dev server
+- `npm run build` — production build
+- `npm run test` — Vitest
+- `npm run type-check` — TypeScript check
+
+## Full Details
+See AGENTS.md for the complete operating manual.

--- a/.cursor/rules/10-coding-standards.mdc
+++ b/.cursor/rules/10-coding-standards.mdc
@@ -1,0 +1,30 @@
+---
+description: Coding standards and safe modification policy
+globs:
+alwaysApply: true
+---
+
+# Coding Standards
+
+## TypeScript
+- Strict TypeScript throughout
+- No `any` types without justification
+
+## Styling
+- Tailwind CSS only — no inline styles, no CSS modules
+- Use custom utility classes (.card, .btn-primary, etc.)
+
+## Server Actions
+- Return `{ success: true }` or `{ error: string }`
+- Use `createClient()` from `@/lib/supabase/server`
+
+## Testing
+- Unit tests: Vitest + @testing-library/react
+- E2E tests: Playwright
+- Run `npm run test` before committing
+
+## Safe Modification Policy
+- Read existing code before modifying
+- Make small, focused changes
+- Do not refactor code unrelated to the current task
+- Do not add features beyond what was requested

--- a/.cursor/rules/20-memory-policy.mdc
+++ b/.cursor/rules/20-memory-policy.mdc
@@ -1,0 +1,32 @@
+---
+description: Memory policy for durable project knowledge
+globs:
+alwaysApply: true
+---
+
+# Memory Policy
+
+Durable knowledge must be stored in repo files, not in tool-specific memory.
+
+## Where to Store Memory
+
+| Kind | Location |
+|------|----------|
+| Technical decisions | `docs/adr/NNN-title.md` |
+| Project decisions | `memory/decisions/project-decisions.md` |
+| Org decisions | `memory/decisions/org-decisions.md` |
+| Coding patterns | `memory/patterns/coding-patterns.md` |
+| Architecture patterns | `memory/patterns/architecture-patterns.md` |
+| Release process | `memory/procedures/release-process.md` |
+| Product context | `memory/context/product-context.md` |
+| Quick notes | `memory/inbox/` |
+
+## Rules
+1. When you learn something worth remembering, write it to the appropriate file.
+2. Always state which file you updated.
+3. Significant technical decisions require an ADR in `docs/adr/`.
+4. Use `scripts/remember.sh` for quick entries.
+5. Periodically promote inbox items to proper locations.
+
+## Full Policy
+See AGENTS.md for complete memory policy details.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- Brief description of changes -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] Infrastructure / CI
+
+## Testing
+
+- [ ] Unit tests pass (`npm run test`)
+- [ ] Type check passes (`npm run type-check`)
+- [ ] E2E tests pass (if applicable)
+
+## Memory & Decision Tracking
+
+- [ ] Does this change introduce a lasting technical decision? If yes, create or update an ADR in `docs/adr/`.
+- [ ] Should project or org memory be updated? Check `memory/decisions/`, `memory/patterns/`, or `memory/context/`.
+- [ ] Files updated in `docs/adr/` or `memory/`: <!-- list them here -->
+
+## Screenshots
+
+<!-- If applicable, add before/after screenshots -->

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -1,0 +1,63 @@
+name: Memory Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  memory-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes that may need memory updates
+        run: |
+          # Get changed files
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
+
+          NEEDS_REVIEW=false
+          REASONS=""
+
+          # Check for infrastructure/config changes
+          if echo "$CHANGED" | grep -qE '(next\.config|vercel\.json|\.env\.example|tsconfig)'; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- Configuration files changed"
+          fi
+
+          # Check for database/migration changes
+          if echo "$CHANGED" | grep -qE '(supabase/migrations|schema)'; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- Database migrations or schema changed"
+          fi
+
+          # Check for new dependencies
+          if echo "$CHANGED" | grep -q 'package\.json'; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- Dependencies may have changed (package.json modified)"
+          fi
+
+          # Check for middleware/auth changes
+          if echo "$CHANGED" | grep -qE '(middleware\.(ts|js)|auth|supabase/.*config)'; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- Auth or middleware changed"
+          fi
+
+          # Check for workflow changes
+          if echo "$CHANGED" | grep -qE '\.github/workflows/'; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- CI/CD workflows changed"
+          fi
+
+          if [ "$NEEDS_REVIEW" = true ]; then
+            echo "::notice::📝 Memory check: This PR includes changes that may warrant an ADR or memory update."
+            echo -e "Reasons:${REASONS}"
+            echo ""
+            echo "Consider:"
+            echo "  - Creating an ADR: ./scripts/new-adr.sh \"Your decision title\""
+            echo "  - Updating memory: ./scripts/remember.sh project \"What changed and why\""
+            echo "  - Checking docs/adr/ and memory/ are up to date"
+          else
+            echo "No memory-sensitive changes detected."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# AGENTS.md — Operating Manual for AI Agents
+
+This is the canonical operating manual for all AI agents working in the FieldMapper repository. Every agent — Claude Code, OpenClaw, Copilot, Cursor, or any other — must read and follow this file.
+
+## Mission
+
+FieldMapper is a multi-tenant field mapping platform for conservation teams. It enables organizations to collect, visualize, and manage geospatial field data through a browser-based mapping interface. The tech stack is Next.js 14, Supabase, Tailwind CSS, and Leaflet.
+
+## Agent Conduct
+
+1. **Read before writing.** Understand the file, module, or system you are changing before making edits.
+2. **Small, verifiable changes.** Prefer focused commits. Do not bundle unrelated changes.
+3. **No speculative refactors.** Only change code that is necessary to complete the task at hand.
+4. **Ask when uncertain.** If a requirement is ambiguous, ask rather than guess.
+5. **Leave the repo better than you found it** — but only in ways directly related to the current task.
+6. **Never commit secrets, credentials, or .env files.**
+
+## Architectural Invariants
+
+These are non-negotiable. Do not deviate without an ADR (see below).
+
+| Invariant | Detail |
+|---|---|
+| Framework | Next.js 14 (App Router) |
+| Database | Supabase PostgreSQL |
+| Auth | Supabase Auth (email/password + Google OAuth) |
+| Row-Level Security | All tables must have RLS policies. Never bypass RLS. |
+| Multi-tenancy | Tenant resolution via middleware (custom domains, platform subdomains, default org) |
+| Maps | Leaflet (no Mapbox GL, no Google Maps) |
+| Styling | Tailwind CSS with custom utility classes (`.card`, `.btn-primary`, `.btn-secondary`, `.input-field`, `.label`) |
+| UI Components | Custom-built only. No external component libraries (no shadcn, no MUI, no Chakra). |
+| Server mutations | Server actions (`'use server'`) returning `{ success: true }` or `{ error: string }` |
+| Server Supabase | `createClient()` from `@/lib/supabase/server` (synchronous) |
+| Client Supabase | `createClient()` from `@/lib/supabase/client` (synchronous) |
+
+## Coding and Change Discipline
+
+- **TypeScript** everywhere. No `any` types without explicit justification.
+- **Vitest** for unit/integration tests. `@testing-library/react` with jsdom environment.
+- **Playwright** for E2E tests.
+- **Tailwind CSS** — use the project's custom classes before inventing new ones.
+- **Server actions pattern** — mutations go in `'use server'` files, not in API routes.
+- Run `npm run type-check` before considering work done.
+- Run `npm run test` to verify tests pass.
+- See `CLAUDE.md` for the full list of commands and playbooks.
+
+## Memory Policy
+
+Durable memory lives in **repo files**, not in chat context, not in external databases, not in agent-specific config. If it matters beyond the current conversation, it must be written to the repo.
+
+### Memory Locations
+
+| Kind of memory | Where it goes | Format |
+|---|---|---|
+| **Technical decisions (ADRs)** | `docs/adr/NNNN-title.md` | ADR (see below) |
+| **Project decisions** | `memory/decisions/project-decisions.md` | Table: Date, Decision, Context, Status |
+| **Org decisions** | `memory/decisions/org-decisions.md` | Table: Date, Decision, Context, Status |
+| **Coding patterns** | `memory/patterns/coding-patterns.md` | Categorized notes |
+| **Architecture patterns** | `memory/patterns/architecture-patterns.md` | Categorized notes |
+| **Procedures** | `memory/procedures/*.md` | Step-by-step guide |
+| **Product context** | `memory/context/product-context.md` | Prose or structured notes |
+| **Team context** | `memory/context/team-context.md` | Prose or structured notes |
+| **Quick notes (unsorted)** | `memory/inbox/` | Timestamped files |
+| **Playbooks** | `docs/playbooks/*.md` | Step-by-step guide |
+
+### Handling Memory Commands
+
+When a user says:
+
+- **"Remember this locally"** or **"remember this for the project"** — Write to the appropriate file under `memory/`. Use `scripts/remember.sh <category> "message"` or edit the file directly. State exactly which file was updated.
+- **"Record this as a decision"** — Create an ADR in `docs/adr/` using `scripts/new-adr.sh "Title"`. State the file path.
+- **"Promote this to org memory"** — Add to `memory/decisions/org-decisions.md` or to `AGENTS.md` (if it is an invariant or cross-agent policy). Use `scripts/promote-memory.sh` to move inbox items. State which file was updated.
+- **"Add this to the playbook"** — Write or update a file in `docs/playbooks/`. State the file path.
+
+### Rules
+
+1. **Always write memory to a repo file.** Never rely on conversation history alone.
+2. **Always state which file was updated** when memory changes. Example: "Recorded in `docs/adr/0003-switch-to-server-actions.md`."
+3. **Create directories as needed.** If `memory/context/` does not exist, create it.
+4. **Keep files focused.** One topic per memory file, one decision per ADR.
+
+## Architecture Decision Records (ADRs)
+
+Create an ADR when:
+- Choosing between two or more viable technical approaches
+- Introducing a new dependency or removing an existing one
+- Changing an architectural invariant listed above
+- Making a decision that future agents or developers will need to understand
+
+### ADR Format
+
+```markdown
+# NNNN — Title
+
+## Status
+Proposed | Accepted | Deprecated | Superseded by NNNN
+
+## Context
+What is the situation? What problem are we solving?
+
+## Decision
+What did we decide?
+
+## Consequences
+What are the trade-offs? What changes as a result?
+```
+
+ADRs are stored in `docs/adr/` and numbered sequentially (0001, 0002, ...).
+
+## Reference
+
+- `CLAUDE.md` — Claude Code-specific instructions, commands, conventions, and playbooks.
+- `SOUL.md` — OpenClaw-specific behavior directives.
+- `.cursor/rules/` — Cursor IDE rules (project overview, coding standards, memory policy).
+- `docs/adr/` — Architectural decision records.
+- `docs/playbooks/` — Step-by-step operational procedures.
+- `memory/` — Durable project memory (decisions, patterns, procedures, context, inbox).
+- `scripts/new-adr.sh` — Create a new ADR from template.
+- `scripts/remember.sh` — Quick-add a timestamped entry to a memory file.
+- `scripts/promote-memory.sh` — Promote an inbox item to a permanent memory location.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # FieldMapper — Claude Code Instructions
 
+> **Read `AGENTS.md` at the start of every session.** It is the canonical operating manual — architectural invariants, coding discipline, memory policy, ADR process, and cross-agent conventions. This file contains Claude Code-specific instructions that extend it.
+
 ## Project Overview
 
 FieldMapper is a multi-tenant field mapping platform for conservation teams. Built with Next.js 14, Supabase, Tailwind CSS, and Leaflet.
@@ -35,3 +37,24 @@ FieldMapper is a multi-tenant field mapping platform for conservation teams. Bui
 
 When completing issues that affect UI, follow the visual diff screenshot playbook:
 - [Visual Diff Screenshots](docs/playbooks/visual-diff-screenshots.md) — Capture before/after screenshots and include in PR descriptions
+
+## Memory Policy
+
+See `AGENTS.md` for the full memory policy. Key rules for Claude Code:
+
+### Repo files are the canonical memory layer
+
+Claude Code has its own built-in memory (`~/.claude/projects/` with `MEMORY.md`). **Use repo files instead** for anything that should be shared across tools, developers, or sessions. Claude Code's built-in memory is fine for personal preferences and ephemeral session notes, but durable project knowledge must go into repo files so every tool and contributor can see it.
+
+1. **Durable memory lives in repo files.** If it matters beyond this conversation, write it to a file.
+2. **Always state which file was updated** when recording memory.
+3. **Technical decisions** → `docs/adr/NNNN-title.md` (use `scripts/new-adr.sh`).
+4. **Project/org decisions** → `memory/decisions/`.
+5. **Patterns** → `memory/patterns/`.
+6. **Procedures** → `memory/procedures/` or `docs/playbooks/`.
+7. **Context** → `memory/context/`.
+8. **Quick notes** → `memory/inbox/` (use `scripts/remember.sh`).
+
+### When the user says "remember this"
+
+Do **not** save to Claude Code's built-in memory. Instead, write to the appropriate repo file under `memory/` or `docs/adr/` and confirm the file path. See the Handling Memory Commands section in `AGENTS.md` for the full routing table.

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,42 @@
+# SOUL.md — OpenClaw Behavior Directives
+
+This file provides identity and behavioral guidelines for OpenClaw agents working in the FieldMapper repository. It is intentionally minimal — the canonical operating manual is `AGENTS.md`. Read that first.
+
+## Identity
+
+You are an AI development agent contributing to FieldMapper, a multi-tenant field mapping platform for conservation teams. You work alongside human developers and other AI agents. Your contributions are held to the same standard as any team member's.
+
+## Behavioral Guidelines
+
+### Be direct and precise
+- State what you changed and why. No filler, no hedging.
+- When you create or update a file, say the exact path.
+- When you are unsure, say so plainly.
+
+### Be disciplined
+- Follow the architectural invariants in `AGENTS.md`. Do not deviate.
+- Follow the coding conventions in `CLAUDE.md`. Do not invent alternatives.
+- Run tests and type-checks before declaring work complete.
+- Make small, focused changes. Do not bundle unrelated work.
+
+### Be a good steward of memory
+- Durable knowledge belongs in repo files, not in conversation. See the Memory Policy in `AGENTS.md`.
+- When asked to remember something, write it to the correct location and confirm the file path.
+- When making a significant technical decision, create an ADR in `docs/adr/`.
+
+### Be conservation-minded
+- This platform serves conservation teams doing fieldwork. Respect the domain.
+- Prioritize reliability over cleverness. Field teams may have limited connectivity.
+- Keep the interface simple and functional. Avoid unnecessary complexity.
+
+### Be collaborative
+- Respect existing code, patterns, and decisions. Read ADRs before proposing changes that contradict them.
+- When your work overlaps with another agent's or developer's, coordinate rather than overwrite.
+- Leave clear commit messages and PR descriptions so others understand your reasoning.
+
+## Canonical References
+
+- `AGENTS.md` — Full operating manual (architecture, conventions, memory policy, ADR process)
+- `CLAUDE.md` — Commands, stack details, playbooks
+- `docs/adr/` — Prior decisions and their rationale
+- `memory/` — Durable project memory

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,47 @@
+# ADR-NNN: Title
+
+**Status:** Proposed | Accepted | Deprecated | Superseded
+
+**Date:** YYYY-MM-DD
+
+**Owners:** @name
+
+## Context
+
+Why is this decision needed? What problem or situation prompted it?
+
+## Decision
+
+What was decided.
+
+## Alternatives Considered
+
+- **Alternative A** — Description and why it was not chosen.
+- **Alternative B** — Description and why it was not chosen.
+
+## Decision Drivers
+
+- What factors influenced the choice (e.g., performance, team familiarity, cost, timeline).
+
+## Consequences
+
+**Positive:**
+- Expected benefits.
+
+**Negative:**
+- Known trade-offs or risks.
+
+**Neutral:**
+- Side effects that are neither clearly good nor bad.
+
+## Related Files
+
+- `path/to/relevant/file`
+
+## Related Issues / PRs
+
+- #NNN
+
+## Tags
+
+`tag1`, `tag2`

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,58 @@
+# Cross-Tool Developer Memory
+
+Canonical durable memory that works across Claude Code, OpenClaw, Cursor, and Codex/AGENTS.md.
+
+## Purpose
+
+This directory is the single source of truth for project knowledge that AI coding tools need to work effectively. It stores decisions, patterns, procedures, and context as plain markdown files, reviewable in git with no external dependencies.
+
+## Directory Structure
+
+```
+memory/
+  decisions/        # Technical decisions at project and org level
+  patterns/         # Recurring coding and architecture patterns
+  procedures/       # Runbooks for releases, incidents, etc.
+  context/          # Product and team context
+  inbox/            # Uncategorized notes awaiting promotion
+```
+
+## How Each Tool Discovers Memory
+
+- **Claude Code** — Reads `CLAUDE.md` which references `memory/` files. Memory files are loaded as context.
+- **Cursor** — `.cursorrules` or project-level rules reference memory files.
+- **Codex / AGENTS.md** — `AGENTS.md` references memory files for agent context.
+- **OpenClaw** — Configured to read memory directory as project knowledge.
+
+All tools converge on the same markdown files, ensuring consistency.
+
+## Adding Entries
+
+**Manually:** Edit the relevant file in `memory/` directly and commit.
+
+**Via script:**
+```bash
+scripts/remember.sh "category" "Your note here"
+# Example:
+scripts/remember.sh decision "Chose Zod over Yup for schema validation"
+```
+
+Notes added via `remember.sh` land in `memory/inbox/` by default unless a category is specified.
+
+## Promoting Entries
+
+Items in `inbox/` should be periodically reviewed and moved to the appropriate memory file:
+
+```bash
+scripts/promote-memory.sh
+```
+
+This walks through inbox items and prompts you to file them into the correct location.
+
+## Design Principles
+
+1. **Repo files as source of truth** — No databases, no SaaS, no external state.
+2. **Reviewable in git** — All memory changes go through normal PR review.
+3. **No external dependencies** — Plain markdown, plain bash scripts.
+4. **Tool-agnostic** — Any tool that can read files can use this memory.
+5. **Append-friendly** — Easy to add, hard to accidentally lose.

--- a/memory/context/product-context.md
+++ b/memory/context/product-context.md
@@ -1,0 +1,22 @@
+# Product Context
+
+FieldMapper is a multi-tenant field mapping platform for conservation teams. It enables organizations to collect, manage, and visualize geospatial field data -- starting with birdhouse mapping.
+
+## Target Users
+
+- Conservation field teams collecting location data in the field.
+- Program managers reviewing and analyzing collected data.
+- Organization admins managing teams and data access.
+
+## Key Features
+
+- GPS-based field data collection (birdhouse locations, conditions, observations).
+- Map visualization of collected data points.
+- Multi-tenant support for multiple conservation organizations.
+- Offline-capable data entry for areas with limited connectivity.
+
+## Product Goals
+
+- Make field data collection simple enough for volunteer teams.
+- Provide reliable data management for conservation decision-making.
+- Scale across organizations without per-tenant infrastructure overhead.

--- a/memory/context/team-context.md
+++ b/memory/context/team-context.md
@@ -1,0 +1,17 @@
+# Team Context
+
+Document team structure, roles, and responsibilities here.
+
+## Team Members
+
+| Name | Role | Area |
+|------|------|------|
+| _Add team members as the team grows_ | | |
+
+## Communication
+
+- _Document preferred channels, meeting cadence, etc._
+
+## Working Agreements
+
+- _Document team norms and agreements here_

--- a/memory/decisions/org-decisions.md
+++ b/memory/decisions/org-decisions.md
@@ -1,0 +1,7 @@
+# Organization-Wide Decisions
+
+Tracks decisions that apply across projects and teams. For project-specific decisions, see `project-decisions.md`.
+
+| Date | Decision | Context | Status |
+|------|----------|---------|--------|
+| 2024-10-01 | Multi-tenant architecture with shared database | Need to support multiple conservation organizations on one platform. Chose shared DB with RLS over separate databases for operational simplicity. | Accepted |

--- a/memory/decisions/project-decisions.md
+++ b/memory/decisions/project-decisions.md
@@ -1,0 +1,7 @@
+# Project-Level Technical Decisions
+
+Tracks technical decisions specific to this project. For organization-wide decisions, see `org-decisions.md`.
+
+| Date | Decision | Context | Status |
+|------|----------|---------|--------|
+| 2024-11-15 | Next.js 14 App Router + Supabase | Needed full-stack framework with auth, DB, and edge support. Next.js 14 gives us RSC and server actions; Supabase provides auth, Postgres, and RLS out of the box. | Accepted |

--- a/memory/inbox/README.md
+++ b/memory/inbox/README.md
@@ -1,0 +1,11 @@
+# Inbox
+
+Landing zone for quick notes and observations that haven't been categorized yet.
+
+Items here should be periodically reviewed and promoted to the appropriate memory file using `scripts/promote-memory.sh`. Don't let this pile up -- review weekly.
+
+## Format
+
+Add entries as bullet points with a date:
+
+- `2024-01-15` — Your observation or note here.

--- a/memory/patterns/architecture-patterns.md
+++ b/memory/patterns/architecture-patterns.md
@@ -1,0 +1,22 @@
+# Architecture Patterns
+
+High-level architecture patterns used in the system.
+
+## Multi-Tenancy
+
+- Tenant resolution happens in Next.js middleware via subdomain or header.
+- Every database query is scoped to the current tenant.
+- Tenant ID is stored in Supabase JWT claims and enforced by RLS.
+
+## Auth
+
+- Supabase Auth handles sign-up, sign-in, and session management.
+- Auth state is accessed via `createServerClient` in server components and actions.
+- Protected routes are enforced in middleware before rendering.
+
+## Database
+
+- Supabase Postgres with Row-Level Security (RLS) on all tenant-scoped tables.
+- Migrations managed via `supabase/migrations/`.
+- Database types are generated from the schema and kept in sync.
+- Use Supabase client libraries, not raw SQL, in application code.

--- a/memory/patterns/coding-patterns.md
+++ b/memory/patterns/coding-patterns.md
@@ -1,0 +1,25 @@
+# Coding Patterns
+
+Recurring patterns used across the codebase. Keep this updated as conventions evolve.
+
+## Server Actions
+
+- All server actions return `{ success: true, data }` or `{ error: string }`.
+- Use `"use server"` directive at the top of action files.
+- Validate inputs with Zod schemas before processing.
+- Always check tenant context before mutating data.
+
+## Client Components
+
+- Mark with `"use client"` only when needed (event handlers, hooks, browser APIs).
+- Prefer server components by default.
+- Use Tailwind utility classes; project-specific custom classes live in `tailwind.config.ts`.
+- Co-locate component-specific types in the same file.
+
+## Testing
+
+- **Framework:** Vitest + React Testing Library.
+- Test files live next to source: `Component.test.tsx`.
+- Use `describe` / `it` blocks with clear behavior descriptions.
+- Mock Supabase client in tests using `vi.mock`.
+- E2E tests in `e2e/` directory.

--- a/memory/procedures/incident-response.md
+++ b/memory/procedures/incident-response.md
@@ -1,0 +1,20 @@
+# Incident Response
+
+Document your incident response process here.
+
+## Severity Levels
+
+| Level | Description | Response Time |
+|-------|-------------|---------------|
+| P0 | Service down, data loss risk | Immediate |
+| P1 | Major feature broken, workaround exists | < 1 hour |
+| P2 | Minor feature broken | < 1 business day |
+| P3 | Cosmetic / low impact | Next sprint |
+
+## Response Steps
+
+1. _Document triage and response steps here_
+
+## Post-Incident Review
+
+- _Document review process and template here_

--- a/memory/procedures/release-process.md
+++ b/memory/procedures/release-process.md
@@ -1,0 +1,18 @@
+# Release Process
+
+Document your release process here as it evolves.
+
+## Pre-release Checklist
+
+- [ ] All tests pass (`npm test`)
+- [ ] E2E tests pass (`npm run test:e2e`)
+- [ ] No pending migrations that haven't been applied
+- [ ] Changelog updated
+
+## Deploy Steps
+
+- [ ] _Document deployment steps here_
+
+## Post-deploy Verification
+
+- [ ] _Document verification steps here_

--- a/scripts/new-adr.sh
+++ b/scripts/new-adr.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ADR_DIR="$REPO_ROOT/docs/adr"
+TEMPLATE="$ADR_DIR/template.md"
+
+usage() {
+  echo "Usage: $0 \"Title of the ADR\""
+  echo ""
+  echo "Creates a new Architecture Decision Record from the template."
+  echo ""
+  echo "Example:"
+  echo "  $0 \"Use Redis for caching\""
+  exit 1
+}
+
+if [[ $# -lt 1 ]] || [[ -z "$1" ]]; then
+  usage
+fi
+
+TITLE="$1"
+
+# Find the next ADR number by scanning existing files
+NEXT_NUM=1
+if ls "$ADR_DIR"/[0-9]*.md &>/dev/null; then
+  LAST_NUM=$(ls "$ADR_DIR"/[0-9]*.md | sed 's|.*/||' | grep -oE '^[0-9]+' | sort -n | tail -1)
+  NEXT_NUM=$((LAST_NUM + 1))
+fi
+
+# Pad to 4 digits
+NUM=$(printf "%04d" "$NEXT_NUM")
+
+# Slugify the title: lowercase, spaces to hyphens, strip special chars
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+
+FILENAME="$NUM-$SLUG.md"
+FILEPATH="$ADR_DIR/$FILENAME"
+
+# Get today's date
+TODAY=$(date +%Y-%m-%d)
+
+# Copy template and replace placeholders
+cp "$TEMPLATE" "$FILEPATH"
+sed -i '' "s/ADR-NNN/ADR-$NUM/" "$FILEPATH"
+sed -i '' "s/# ADR-$NUM: Title/# ADR-$NUM: $TITLE/" "$FILEPATH"
+sed -i '' "s/YYYY-MM-DD/$TODAY/" "$FILEPATH"
+
+echo "$FILEPATH"

--- a/scripts/promote-memory.sh
+++ b/scripts/promote-memory.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  echo "Usage: $0 [--yes] <source-file> <target-category>"
+  echo ""
+  echo "Promotes a memory file (e.g., from inbox) to a target category."
+  echo ""
+  echo "Options:"
+  echo "  --yes    Skip confirmation prompt"
+  echo ""
+  echo "Categories:"
+  echo "  project       → memory/decisions/project-decisions.md"
+  echo "  org           → memory/decisions/org-decisions.md"
+  echo "  pattern       → memory/patterns/coding-patterns.md"
+  echo "  architecture  → memory/patterns/architecture-patterns.md"
+  echo "  release       → memory/procedures/release-process.md"
+  echo "  incident      → memory/procedures/incident-response.md"
+  echo "  product       → memory/context/product-context.md"
+  echo "  team          → memory/context/team-context.md"
+  echo ""
+  echo "Example:"
+  echo "  $0 memory/inbox/note-2024-01-15-103045.md project"
+  echo "  $0 --yes memory/inbox/note-2024-01-15-103045.md pattern"
+  exit 1
+}
+
+AUTO_YES=false
+if [[ "${1:-}" == "--yes" ]]; then
+  AUTO_YES=true
+  shift
+fi
+
+if [[ $# -lt 2 ]] || [[ -z "$1" ]] || [[ -z "$2" ]]; then
+  usage
+fi
+
+SOURCE="$1"
+CATEGORY="$2"
+
+# Resolve source path relative to repo root if not absolute
+if [[ "$SOURCE" != /* ]]; then
+  SOURCE="$REPO_ROOT/$SOURCE"
+fi
+
+if [[ ! -f "$SOURCE" ]]; then
+  echo "Error: Source file not found: $SOURCE"
+  exit 1
+fi
+
+# Map category to file
+case "$CATEGORY" in
+  project)      TARGET="$REPO_ROOT/memory/decisions/project-decisions.md" ;;
+  org)          TARGET="$REPO_ROOT/memory/decisions/org-decisions.md" ;;
+  pattern)      TARGET="$REPO_ROOT/memory/patterns/coding-patterns.md" ;;
+  architecture) TARGET="$REPO_ROOT/memory/patterns/architecture-patterns.md" ;;
+  release)      TARGET="$REPO_ROOT/memory/procedures/release-process.md" ;;
+  incident)     TARGET="$REPO_ROOT/memory/procedures/incident-response.md" ;;
+  product)      TARGET="$REPO_ROOT/memory/context/product-context.md" ;;
+  team)         TARGET="$REPO_ROOT/memory/context/team-context.md" ;;
+  *)
+    echo "Error: Unknown category '$CATEGORY'"
+    echo ""
+    usage
+    ;;
+esac
+
+# Show contents
+echo "=== Source: $SOURCE ==="
+echo ""
+cat "$SOURCE"
+echo ""
+echo "=== Target: $TARGET ==="
+echo ""
+
+# Confirm
+if [[ "$AUTO_YES" == false ]]; then
+  read -rp "Append contents to target and remove source? [y/N] " CONFIRM
+  if [[ "$CONFIRM" != [yY] ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+# Ensure target directory exists
+mkdir -p "$(dirname "$TARGET")"
+
+# Create the file with a heading if it doesn't exist
+if [[ ! -f "$TARGET" ]]; then
+  echo "# ${CATEGORY^} Notes" > "$TARGET"
+  echo "" >> "$TARGET"
+fi
+
+# Append contents
+echo "" >> "$TARGET"
+cat "$SOURCE" >> "$TARGET"
+
+echo "Appended to: $TARGET"
+
+# Remove source
+rm "$SOURCE"
+echo "Removed: $SOURCE"

--- a/scripts/remember.sh
+++ b/scripts/remember.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  echo "Usage: $0 <category> \"message\""
+  echo ""
+  echo "Appends a timestamped entry to the appropriate memory file."
+  echo ""
+  echo "Categories:"
+  echo "  project       → memory/decisions/project-decisions.md"
+  echo "  org           → memory/decisions/org-decisions.md"
+  echo "  pattern       → memory/patterns/coding-patterns.md"
+  echo "  architecture  → memory/patterns/architecture-patterns.md"
+  echo "  release       → memory/procedures/release-process.md"
+  echo "  incident      → memory/procedures/incident-response.md"
+  echo "  product       → memory/context/product-context.md"
+  echo "  team          → memory/context/team-context.md"
+  echo "  inbox         → memory/inbox/note-<timestamp>.md (new file)"
+  echo ""
+  echo "Example:"
+  echo "  $0 project \"Decided to use Redis for session caching\""
+  exit 1
+}
+
+if [[ $# -lt 2 ]] || [[ -z "$1" ]] || [[ -z "$2" ]]; then
+  usage
+fi
+
+CATEGORY="$1"
+MESSAGE="$2"
+TODAY=$(date +%Y-%m-%d)
+TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
+
+# Map category to file
+case "$CATEGORY" in
+  project)      TARGET="$REPO_ROOT/memory/decisions/project-decisions.md" ;;
+  org)          TARGET="$REPO_ROOT/memory/decisions/org-decisions.md" ;;
+  pattern)      TARGET="$REPO_ROOT/memory/patterns/coding-patterns.md" ;;
+  architecture) TARGET="$REPO_ROOT/memory/patterns/architecture-patterns.md" ;;
+  release)      TARGET="$REPO_ROOT/memory/procedures/release-process.md" ;;
+  incident)     TARGET="$REPO_ROOT/memory/procedures/incident-response.md" ;;
+  product)      TARGET="$REPO_ROOT/memory/context/product-context.md" ;;
+  team)         TARGET="$REPO_ROOT/memory/context/team-context.md" ;;
+  inbox)
+    TARGET="$REPO_ROOT/memory/inbox/note-$TIMESTAMP.md"
+    mkdir -p "$(dirname "$TARGET")"
+    echo "- [$TODAY] $MESSAGE" > "$TARGET"
+    echo "Created: $TARGET"
+    exit 0
+    ;;
+  *)
+    echo "Error: Unknown category '$CATEGORY'"
+    echo ""
+    usage
+    ;;
+esac
+
+# Ensure the target directory exists
+mkdir -p "$(dirname "$TARGET")"
+
+# Create the file with a heading if it doesn't exist
+if [[ ! -f "$TARGET" ]]; then
+  echo "# ${CATEGORY^} Notes" > "$TARGET"
+  echo "" >> "$TARGET"
+fi
+
+# Append the entry
+echo "- [$TODAY] $MESSAGE" >> "$TARGET"
+echo "Recorded in: $TARGET"


### PR DESCRIPTION
## Summary

- Installs a durable, repo-file-based developer memory system compatible with Claude Code, OpenClaw, Cursor, and Codex/AGENTS.md tools
- Adds ADR templates, structured memory directories, automation scripts, and CI integration
- Establishes AGENTS.md as the canonical operating manual for all AI agents

## What's included

**Agent config files:**
- `AGENTS.md` — canonical operating manual (invariants, memory policy, ADR process)
- `CLAUDE.md` — extended with memory policy section, repo-file-first directive
- `SOUL.md` — OpenClaw behavior directives

**Cursor rules:** `.cursor/rules/` — project overview, coding standards, memory policy

**ADR system:** `docs/adr/template.md` — structured template for architecture decision records

**Memory directories:** `memory/` — decisions, patterns, procedures, context, inbox (all seeded with starter content)

**Automation scripts:**
- `scripts/new-adr.sh` — create numbered ADRs from template
- `scripts/remember.sh` — quick-add timestamped entries to memory files
- `scripts/promote-memory.sh` — move inbox items to permanent locations

**GitHub integration:**
- `.github/pull_request_template.md` — PR template with memory/ADR nudges
- `.github/workflows/memory-check.yml` — CI notice for memory-sensitive changes (non-blocking)

## Design principles

1. Canonical memory lives in repo files, not tool-specific storage
2. Tool configs (CLAUDE.md, SOUL.md, .cursor/rules) are adapters pointing to AGENTS.md
3. Everything is reviewable in git — no databases, servers, or cloud services
4. Scripts use POSIX shell with zero dependencies

## Test plan

- [x] All 3 scripts pass `bash -n` syntax check
- [x] `scripts/new-adr.sh` smoke tested — creates numbered ADR from template
- [x] `scripts/remember.sh` smoke tested — appends timestamped entry to correct file
- [ ] Review memory file content for accuracy
- [ ] Verify memory-check.yml triggers on relevant PR changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)