### PR TITLE
fix: auto-size bottom sheet to content

### DIFF
--- a/src/components/item/DetailPanel.tsx
+++ b/src/components/item/DetailPanel.tsx
@@ -23,7 +23,6 @@ interface DetailPanelProps {
 
 export default function DetailPanel({ item, onClose, isAuthenticated, canEditItem, canAddUpdate, onSheetStateChange }: DetailPanelProps) {
   const [isMobile, setIsMobile] = useState(false);
-  const [sheetState, setSheetState] = useState<SheetState>('peek');
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
@@ -33,10 +32,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   }, []);
 
   useEffect(() => {
-    if (item) {
-      setSheetState('peek');
-      onSheetStateChange?.('peek');
-    } else {
+    if (!item) {
       onSheetStateChange?.(null);
     }
   }, [item?.id]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -81,7 +77,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
         item={item}
         mode="live"
         context={isMobile ? 'bottom-sheet' : 'side-panel'}
-        sheetState={isMobile ? sheetState : undefined}
+        sheetState={isMobile ? 'full' : undefined}
         customFields={item.custom_fields ?? []}
       />
     </div>
@@ -214,7 +210,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   // Mobile: bottom sheet
   if (isMobile) {
     return (
-      <MultiSnapBottomSheet isOpen={!!item} onClose={onClose} onStateChange={(s) => { setSheetState(s); onSheetStateChange?.(s); }} initialState="peek">
+      <MultiSnapBottomSheet isOpen={!!item} onClose={onClose} onStateChange={(s) => { onSheetStateChange?.(s); }}>
         {content}
       </MultiSnapBottomSheet>
     );

--- a/src/components/ui/MultiSnapBottomSheet.tsx
+++ b/src/components/ui/MultiSnapBottomSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, ReactNode } from 'react';
+import { useEffect, useRef, useState, ReactNode, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export type SheetState = 'peek' | 'half' | 'full';
@@ -8,63 +8,54 @@ export type SheetState = 'peek' | 'half' | 'full';
 interface MultiSnapBottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
-  onStateChange: (state: SheetState) => void;
-  initialState?: SheetState;
+  onStateChange?: (state: SheetState) => void;
   children: ReactNode;
 }
 
-const SNAP_PERCENTAGES: Record<SheetState, number> = {
-  peek: 25,
-  half: 50,
-  full: 92,
-};
-
-const SNAP_ORDER: SheetState[] = ['peek', 'half', 'full'];
-
-function getHeightForState(state: SheetState): string {
-  return `${SNAP_PERCENTAGES[state]}vh`;
-}
-
-function getOverlayOpacity(state: SheetState): number {
-  if (state === 'peek') return 0.15;
-  if (state === 'half') return 0.4;
-  return 0.6;
-}
-
-function findNearestSnap(heightVh: number): SheetState {
-  let nearest: SheetState = 'peek';
-  let minDist = Infinity;
-  for (const state of SNAP_ORDER) {
-    const dist = Math.abs(SNAP_PERCENTAGES[state] - heightVh);
-    if (dist < minDist) {
-      minDist = dist;
-      nearest = state;
-    }
-  }
-  return nearest;
-}
+const HANDLE_HEIGHT = 48; // handle bar + padding
+const MAX_HEIGHT_RATIO = 0.92;
 
 export default function MultiSnapBottomSheet({
   isOpen,
   onClose,
   onStateChange,
-  initialState = 'peek',
   children,
 }: MultiSnapBottomSheetProps) {
-  // Use a ref to hold mutable state values needed in touch handlers without
-  // causing re-renders mid-gesture.
-  const stateRef = useRef<SheetState>(initialState);
-  // We track the "committed" state in a separate ref so we can read it in
-  // touch handlers without needing it in deps arrays.
-  const currentStateRef = useRef<SheetState>(initialState);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState(0);
+  const [maxHeight, setMaxHeight] = useState(
+    typeof window !== 'undefined' ? window.innerHeight * MAX_HEIGHT_RATIO : 600
+  );
 
-  // Keep currentStateRef up-to-date when the sheet opens/resets.
+  // Measure content natural height
+  useEffect(() => {
+    if (!isOpen || !measureRef.current) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContentHeight(entry.contentRect.height);
+      }
+    });
+
+    observer.observe(measureRef.current);
+    return () => observer.disconnect();
+  }, [isOpen]);
+
+  // Track viewport height changes (rotation, resize)
+  useEffect(() => {
+    const handleResize = () => {
+      setMaxHeight(window.innerHeight * MAX_HEIGHT_RATIO);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Emit 'full' when sheet opens
   useEffect(() => {
     if (isOpen) {
-      currentStateRef.current = initialState;
-      stateRef.current = initialState;
+      onStateChange?.('full');
     }
-  }, [isOpen, initialState]);
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Body overflow lock
   useEffect(() => {
@@ -78,80 +69,33 @@ export default function MultiSnapBottomSheet({
     };
   }, [isOpen]);
 
-  // Touch tracking refs — not state so we don't re-render during a drag.
+  const sheetHeight = Math.min(contentHeight + HANDLE_HEIGHT, maxHeight);
+  const enableScroll = contentHeight + HANDLE_HEIGHT > maxHeight;
+
+  // Swipe-to-dismiss
   const touchStartY = useRef(0);
   const touchStartTime = useRef(0);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  const handleTouchStart = (e: React.TouchEvent) => {
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
     touchStartY.current = e.touches[0].clientY;
     touchStartTime.current = Date.now();
-  };
+  }, []);
 
-  const handleTouchEnd = (e: React.TouchEvent) => {
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
     const endY = e.changedTouches[0].clientY;
-    const deltaY = touchStartY.current - endY; // positive = swipe up
-    const elapsed = (Date.now() - touchStartTime.current) / 1000; // seconds
-    const velocity = Math.abs(deltaY) / elapsed; // px/s
+    const deltaY = endY - touchStartY.current; // positive = swipe down
+    const elapsed = (Date.now() - touchStartTime.current) / 1000;
+    const velocity = Math.abs(deltaY) / elapsed;
 
-    const currentIndex = SNAP_ORDER.indexOf(currentStateRef.current);
-
+    // Only dismiss on downward swipe when content is scrolled to top
     if (deltaY > 0) {
-      // Swiping up — go to next snap(s)
-      if (velocity > 500 && currentIndex < SNAP_ORDER.length - 2) {
-        // Fast swipe: skip one snap point
-        const newState = SNAP_ORDER[currentIndex + 2];
-        currentStateRef.current = newState;
-        onStateChange(newState);
-      } else if (currentIndex < SNAP_ORDER.length - 1) {
-        const newState = SNAP_ORDER[currentIndex + 1];
-        currentStateRef.current = newState;
-        onStateChange(newState);
-      }
-    } else {
-      // Swiping down
-      const viewportHeight = window.innerHeight;
-      const deltaVh = (Math.abs(deltaY) / viewportHeight) * 100;
-      const currentHeightVh = SNAP_PERCENTAGES[currentStateRef.current];
-      const projectedVh = currentHeightVh - deltaVh;
-
-      if (projectedVh < 15) {
-        // Below dismiss threshold
+      const scrollTop = scrollRef.current?.scrollTop ?? 0;
+      if (scrollTop <= 0 && (deltaY > 80 || velocity > 500)) {
         onClose();
-        return;
-      }
-
-      if (velocity > 500 && currentIndex > 1) {
-        // Fast swipe down: skip one snap point
-        const newState = SNAP_ORDER[currentIndex - 2];
-        currentStateRef.current = newState;
-        onStateChange(newState);
-      } else if (currentIndex > 0) {
-        const newState = SNAP_ORDER[currentIndex - 1];
-        currentStateRef.current = newState;
-        onStateChange(newState);
-      } else {
-        // Already at peek, check if should dismiss
-        if (Math.abs(deltaY) > 80) {
-          onClose();
-        }
       }
     }
-  };
-
-  const handleHandleClick = () => {
-    const current = currentStateRef.current;
-    const newState: SheetState = current === 'peek' ? 'half' : 'peek';
-    currentStateRef.current = newState;
-    onStateChange(newState);
-  };
-
-  // We read the committed state to drive the animation height. Because touch
-  // handlers update currentStateRef and call onStateChange, the parent will
-  // re-render us with new props if it manages state externally — but we also
-  // keep our own internal ref for self-contained snap logic.
-  // For animation we derive the height from whatever initialState the parent
-  // last passed (they should mirror onStateChange back as initialState).
-  const animatedState = isOpen ? initialState : 'peek';
+  }, [onClose]);
 
   return (
     <AnimatePresence>
@@ -163,7 +107,7 @@ export default function MultiSnapBottomSheet({
             className="fixed inset-0 z-40"
             style={{ backgroundColor: 'black' }}
             initial={{ opacity: 0 }}
-            animate={{ opacity: getOverlayOpacity(animatedState) }}
+            animate={{ opacity: 0.4 }}
             exit={{ opacity: 0 }}
             transition={{ type: 'spring', damping: 30, stiffness: 300 }}
             onClick={onClose}
@@ -173,37 +117,32 @@ export default function MultiSnapBottomSheet({
           <motion.div
             className="fixed bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-2xl bg-white shadow-2xl"
             style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-            initial={{ height: '0vh' }}
-            animate={{ height: getHeightForState(animatedState) }}
-            exit={{ height: '0vh' }}
+            initial={{ height: 0 }}
+            animate={{ height: sheetHeight }}
+            exit={{ height: 0 }}
             transition={{ type: 'spring', damping: 30, stiffness: 300 }}
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
           >
             {/* Handle */}
             <div className="flex shrink-0 items-center justify-center pt-3 pb-2">
-              <button
-                aria-label="Expand or collapse sheet"
-                className="h-1.5 w-12 rounded-full bg-gray-300"
-                onClick={handleHandleClick}
-              />
+              <div className="h-1.5 w-12 rounded-full bg-gray-300" />
             </div>
-
-            {/* Swipe-up affordance — only visible in peek state */}
-            {animatedState === 'peek' && (
-              <div className="flex justify-center -mt-1 mb-1">
-                <svg className="w-4 h-4 text-gray-400 animate-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
-                </svg>
-              </div>
-            )}
 
             {/* Content */}
             <div className="relative min-h-0 flex-1">
-              <div className="overflow-y-auto px-4 pb-4 h-full">
-                {children}
+              <div
+                ref={scrollRef}
+                className="px-4 pb-4 h-full"
+                style={{ overflowY: enableScroll ? 'auto' : 'hidden' }}
+              >
+                <div ref={measureRef}>
+                  {children}
+                </div>
               </div>
-              <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent" />
+              {enableScroll && (
+                <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent" />
+              )}
             </div>
           </motion.div>
         </>

--- a/src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx
+++ b/src/components/ui/__tests__/MultiSnapBottomSheet.test.tsx
@@ -1,13 +1,46 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import MultiSnapBottomSheet from '../MultiSnapBottomSheet';
+
+// Capture ResizeObserver callbacks so we can trigger them in tests
+let resizeCallback: ResizeObserverCallback | null = null;
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    resizeCallback = cb;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    resizeCallback = null;
+  }
+}
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    div: ({ children, style, animate, initial, exit, transition, ...props }: any) => (
+      <div
+        {...props}
+        style={{
+          ...style,
+          ...(animate && typeof animate === 'object' ? animate : {}),
+        }}
+      >
+        {children}
+      </div>
+    ),
   },
   AnimatePresence: ({ children }: any) => children,
 }));
+
+function triggerResize(height: number) {
+  if (resizeCallback) {
+    resizeCallback(
+      [{ contentRect: { height } } as ResizeObserverEntry],
+      {} as ResizeObserver
+    );
+  }
+}
 
 const defaultProps = {
   isOpen: true,
@@ -16,6 +49,18 @@ const defaultProps = {
 };
 
 describe('MultiSnapBottomSheet', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    vi.stubGlobal('innerHeight', 800);
+    defaultProps.onClose = vi.fn();
+    defaultProps.onStateChange = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resizeCallback = null;
+  });
+
   it('renders children when open', () => {
     render(
       <MultiSnapBottomSheet {...defaultProps}>
@@ -34,16 +79,6 @@ describe('MultiSnapBottomSheet', () => {
     expect(screen.queryByText('Sheet content')).not.toBeInTheDocument();
   });
 
-  it('renders a handle button with aria-label matching /expand/i', () => {
-    render(
-      <MultiSnapBottomSheet {...defaultProps}>
-        <p>Content</p>
-      </MultiSnapBottomSheet>
-    );
-    const handle = screen.getByRole('button', { name: /expand/i });
-    expect(handle).toBeInTheDocument();
-  });
-
   it('calls onClose when overlay is clicked', () => {
     const onClose = vi.fn();
     render(
@@ -54,5 +89,118 @@ describe('MultiSnapBottomSheet', () => {
     const overlay = screen.getByTestId('sheet-overlay');
     fireEvent.click(overlay);
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('emits full state when opened', () => {
+    const onStateChange = vi.fn();
+    render(
+      <MultiSnapBottomSheet {...defaultProps} onStateChange={onStateChange}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>
+    );
+    expect(onStateChange).toHaveBeenCalledWith('full');
+  });
+
+  it('sizes sheet to content height when content fits viewport', () => {
+    const { container } = render(
+      <MultiSnapBottomSheet {...defaultProps}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>
+    );
+
+    act(() => triggerResize(200));
+
+    // Sheet height = contentHeight (200) + HANDLE_HEIGHT (48) = 248
+    const sheet = container.querySelector('.fixed.bottom-0') as HTMLElement;
+    expect(sheet.style.height).toBe('248px');
+  });
+
+  it('caps sheet height at 92% of viewport and enables scrolling', () => {
+    const { container } = render(
+      <MultiSnapBottomSheet {...defaultProps}>
+        <p>Lots of content</p>
+      </MultiSnapBottomSheet>
+    );
+
+    // Content taller than viewport * 0.92 - handle overhead
+    act(() => triggerResize(900));
+
+    const sheet = container.querySelector('.fixed.bottom-0') as HTMLElement;
+    // maxHeight = 800 * 0.92 = 736
+    expect(sheet.style.height).toBe('736px');
+
+    // Scroll container should have overflow-y: auto
+    const scrollContainer = sheet.querySelector('[style*="overflow-y"]') as HTMLElement;
+    expect(scrollContainer.style.overflowY).toBe('auto');
+  });
+
+  it('disables scrolling when content fits', () => {
+    const { container } = render(
+      <MultiSnapBottomSheet {...defaultProps}>
+        <p>Short content</p>
+      </MultiSnapBottomSheet>
+    );
+
+    act(() => triggerResize(100));
+
+    const sheet = container.querySelector('.fixed.bottom-0') as HTMLElement;
+    const scrollContainer = sheet.querySelector('[style*="overflow-y"]') as HTMLElement;
+    expect(scrollContainer.style.overflowY).toBe('hidden');
+  });
+
+  it('dismisses on swipe down when scrolled to top', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <MultiSnapBottomSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>
+    );
+
+    const sheet = container.querySelector('.fixed.bottom-0') as HTMLElement;
+
+    fireEvent.touchStart(sheet, {
+      touches: [{ clientY: 100 }],
+    });
+    fireEvent.touchEnd(sheet, {
+      changedTouches: [{ clientY: 250 }],
+    });
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not dismiss on upward swipe', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <MultiSnapBottomSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>
+    );
+
+    const sheet = container.querySelector('.fixed.bottom-0') as HTMLElement;
+
+    fireEvent.touchStart(sheet, {
+      touches: [{ clientY: 300 }],
+    });
+    fireEvent.touchEnd(sheet, {
+      changedTouches: [{ clientY: 100 }],
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows gradient fade only when scrolling is enabled', () => {
+    const { container } = render(
+      <MultiSnapBottomSheet {...defaultProps}>
+        <p>Content</p>
+      </MultiSnapBottomSheet>
+    );
+
+    // Short content — no gradient
+    act(() => triggerResize(100));
+    expect(container.querySelector('.bg-gradient-to-t')).not.toBeInTheDocument();
+
+    // Tall content — gradient appears
+    act(() => triggerResize(900));
+    expect(container.querySelector('.bg-gradient-to-t')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Replace fixed snap points (25vh/50vh/92vh) with ResizeObserver-based content measurement so the bottom sheet auto-sizes to fit its content
- Cap at 92% viewport height with internal scrolling when content overflows
- Simplify swipe handling to dismiss-only (no snap cycling needed)
- Update tests to cover auto-sizing, scroll toggle, swipe dismiss, and gradient fade behavior (10 tests, all passing)

## Test plan
- [ ] Tap an item with short content — sheet should be small, just wrapping the content
- [ ] Tap an item with long content (many fields, photos, updates) — sheet should grow to fit, up to ~92vh
- [ ] When content exceeds viewport, verify sheet scrolls internally
- [ ] Swipe down on sheet to dismiss
- [ ] Verify FAB hides when sheet is open, reappears on close
- [ ] Test on different viewport sizes / device rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)