### PR TITLE
fix(ia): hide redundant sidebar title on desktop

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -12,9 +12,10 @@ interface AdminSidebarProps {
   items: SidebarItem[];
   backLink?: { label: string; href: string };
   onNavClick?: () => void;
+  hideTitle?: boolean;
 }
 
-export function AdminSidebar({ title, items, backLink, onNavClick }: AdminSidebarProps) {
+export function AdminSidebar({ title, items, backLink, onNavClick, hideTitle }: AdminSidebarProps) {
   const pathname = usePathname();
 
   return (
@@ -28,9 +29,11 @@ export function AdminSidebar({ title, items, backLink, onNavClick }: AdminSideba
           ← {backLink.label}
         </Link>
       )}
-      <div className="px-4 py-3 font-bold text-forest-dark text-sm">
-        {title}
-      </div>
+      {!hideTitle && (
+        <div className="px-4 py-3 font-bold text-forest-dark text-sm">
+          {title}
+        </div>
+      )}
       {items.map((item, i) => {
         if ('type' in item && item.type === 'section') {
           return (

--- a/src/components/layout/OrgShell.tsx
+++ b/src/components/layout/OrgShell.tsx
@@ -89,7 +89,7 @@ export function OrgShell({ orgId, orgSlug, userEmail, children }: OrgShellProps)
 
       <div className="flex flex-1 min-h-0">
         <div className="hidden md:block">
-          <AdminSidebar title={orgName} items={ORG_NAV_ITEMS} />
+          <AdminSidebar title={orgName} items={ORG_NAV_ITEMS} hideTitle />
         </div>
         <main className="flex-1 overflow-auto flex flex-col">{children}</main>
       </div>

--- a/src/components/layout/PropertyAdminShell.tsx
+++ b/src/components/layout/PropertyAdminShell.tsx
@@ -127,7 +127,7 @@ export function PropertyAdminShell({
 
       <div className="flex flex-1 min-h-0">
         <div className="hidden md:block">
-          <AdminSidebar title={propertyName} items={items} backLink={backLink} />
+          <AdminSidebar title={propertyName} items={items} backLink={backLink} hideTitle />
         </div>
         <div className="flex-1 overflow-auto p-6">{children}</div>
       </div>


### PR DESCRIPTION
## Summary

- Hides the org/property name title in the sidebar on desktop — it's redundant with the ContextBar breadcrumb directly above
- Mobile drawer still shows the title since the ContextBar is hidden behind the overlay

## Test plan

- [ ] Desktop: sidebar starts directly with nav items, no redundant title
- [ ] Mobile: open drawer — title still shows at top for context
- [ ] Verify on both org (`/org`) and property admin (`/p/[slug]/admin`) views

Follow-up to #201

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)