### PR TITLE
fix: show property name on property domain pages

### DIFF
--- a/src/app/admin/settings/actions.ts
+++ b/src/app/admin/settings/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { getTenantContext } from '@/lib/tenant/server';
+import { invalidateConfig } from '@/lib/config/server';
 import type { SubscriptionTier, SubscriptionStatus } from '@/lib/types';
 
 export interface OrgSettings {
@@ -100,5 +101,6 @@ export async function updateOrgSettings(
     return { error: error.message };
   }
 
+  invalidateConfig();
   return { success: true };
 }

--- a/src/lib/config/__tests__/config.test.ts
+++ b/src/lib/config/__tests__/config.test.ts
@@ -13,6 +13,7 @@ describe('buildSiteConfig', () => {
       setup_complete: true,
     };
     const property = {
+      name: 'Eagle River Property',
       description: 'Bainbridge Island',
       map_default_lat: 47.6,
       map_default_lng: -122.5,
@@ -35,7 +36,7 @@ describe('buildSiteConfig', () => {
 
     const config = buildSiteConfig(org, property);
 
-    expect(config.siteName).toBe('My Bird Project');
+    expect(config.siteName).toBe('Eagle River Property');
     expect(config.tagline).toBe('Tracking nests');
     expect(config.locationName).toBe('Bainbridge Island');
     expect(config.mapCenter).toEqual({ lat: 47.6, lng: -122.5, zoom: 16 });

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -81,7 +81,7 @@ export function buildSiteConfig(
   }
 ): SiteConfig {
   return {
-    siteName: org.name,
+    siteName: property.name ?? org.name,
     propertyName: property.name ?? null,
     pwaName: property.pwa_name ?? org.pwa_name ?? null,
     tagline: org.tagline ?? '',


### PR DESCRIPTION
## Summary

- `siteName` now uses `property.name` with `org.name` as fallback — the public site is property-scoped, so Navigation should show the property name, not the org name
- Adds missing `invalidateConfig()` call to org settings save action — config cache was serving stale org name for up to 60 seconds after changes

## Root cause

`buildSiteConfig()` in `src/lib/config/types.ts` hardcoded `siteName: org.name`. On property domains (e.g. fairbankseagle.org), the Navigation header displayed the org name instead of the property name. Additionally, changing the org name in settings didn't invalidate the config cache.

## Test plan

- [ ] Visit property domain unauthenticated — Navigation header shows property name
- [ ] Visit `/p/[slug]` authenticated — FieldModeShell shows property name (unchanged)
- [ ] Change org name in settings → refresh public page → shows updated name immediately (no stale cache)
- [ ] Config unit tests pass (updated assertion for property name)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)