### PR TITLE
fix: add Knowledge to sidebar nav and platform feature registry

### DIFF
--- a/src/app/admin/AdminShell.tsx
+++ b/src/app/admin/AdminShell.tsx
@@ -19,6 +19,7 @@ const ORG_NAV_ITEMS: SidebarItem[] = [
   { label: 'Members', href: '/admin/members' },
   { label: 'Roles', href: '/admin/roles' },
   { type: 'section', label: 'Data' },
+  { label: 'Knowledge', href: '/admin/knowledge' },
   { label: 'Data Vault', href: '/admin/vault' },
   { label: 'AI Context', href: '/admin/ai-context' },
   { label: 'Geo Layers', href: '/admin/geo-layers' },

--- a/src/components/layout/OrgShell.tsx
+++ b/src/components/layout/OrgShell.tsx
@@ -20,6 +20,7 @@ const ORG_NAV_ITEMS: SidebarItem[] = [
   { label: 'Members', href: '/org/members' },
   { label: 'Roles', href: '/org/roles' },
   { type: 'section', label: 'Data' },
+  { label: 'Knowledge', href: '/admin/knowledge' },
   { label: 'Item Types', href: '/org/types' },
   { label: 'Entity Types', href: '/org/entity-types' },
   { label: 'Data Vault', href: '/org/vault' },

--- a/src/lib/platform/features.ts
+++ b/src/lib/platform/features.ts
@@ -12,6 +12,7 @@ export const PLATFORM_FEATURES = {
   ai_context:     { type: 'boolean' as const, label: 'AI Context' },
   custom_domains: { type: 'boolean' as const, label: 'Custom Domains' },
   site_builder:   { type: 'boolean' as const, label: 'Site Builder' },
+  knowledge:      { type: 'boolean' as const, label: 'Knowledge Base' },
   // Numeric limits (null = unlimited)
   max_properties:         { type: 'numeric' as const, label: 'Max Properties' },
   max_members:            { type: 'numeric' as const, label: 'Max Members' },
@@ -32,22 +33,22 @@ export type FeatureMap = {
 export const TIER_DEFAULTS: Record<SubscriptionTier, FeatureMap> = {
   free: {
     tasks: false, volunteers: false, public_forms: true, qr_codes: false,
-    reports: false, ai_context: false, custom_domains: false, site_builder: false,
+    reports: false, ai_context: false, custom_domains: false, site_builder: false, knowledge: false,
     max_properties: 1, max_members: 5, storage_limit_mb: 100, max_ai_context_entries: 0,
   },
   community: {
     tasks: true, volunteers: true, public_forms: true, qr_codes: true,
-    reports: false, ai_context: false, custom_domains: false, site_builder: false,
+    reports: false, ai_context: false, custom_domains: false, site_builder: false, knowledge: false,
     max_properties: 3, max_members: 25, storage_limit_mb: 500, max_ai_context_entries: 10,
   },
   pro: {
     tasks: true, volunteers: true, public_forms: true, qr_codes: true,
-    reports: true, ai_context: true, custom_domains: true, site_builder: true,
+    reports: true, ai_context: true, custom_domains: true, site_builder: true, knowledge: true,
     max_properties: null, max_members: null, storage_limit_mb: 5000, max_ai_context_entries: 100,
   },
   municipal: {
     tasks: true, volunteers: true, public_forms: true, qr_codes: true,
-    reports: true, ai_context: true, custom_domains: true, site_builder: true,
+    reports: true, ai_context: true, custom_domains: true, site_builder: true, knowledge: true,
     max_properties: null, max_members: null, storage_limit_mb: null, max_ai_context_entries: null,
   },
 };


### PR DESCRIPTION
## Summary

- Add missing "Knowledge" nav item to AdminShell and OrgShell sidebars — pages exist at `/admin/knowledge` but were never linked after the IA redesign (#201)
- Add `knowledge` boolean to the platform feature registry (pro/municipal: on, free/community: off)

## Test plan

- [ ] Verify "Knowledge" appears in the sidebar under Data section
- [ ] Verify clicking it navigates to `/admin/knowledge`
- [ ] Verify Knowledge Base toggle appears in platform admin org detail page
- [ ] Run `npm run test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)