### PR TITLE
fix: resolve logo URL in sitebuilder HeaderBar

### DIFF
--- a/src/lib/puck/components/chrome/HeaderBar.tsx
+++ b/src/lib/puck/components/chrome/HeaderBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { useConfig } from '@/lib/config/client';
+import { getLogoUrl } from '@/lib/config/logo';
 import type { HeaderBarProps } from '../../types';
 import { resolveLink } from '../../fields/link-utils';
 import { IconRenderer } from '../../icons/IconRenderer';
@@ -45,7 +46,7 @@ export function HeaderBar({
 }: HeaderBarProps) {
   const config = useConfig();
   const alignClass = layout === 'centered' ? 'text-center' : 'text-left';
-  const displayLogo = logoUrl || config.logoUrl;
+  const displayLogo = logoUrl || (config.logoUrl ? getLogoUrl(config.logoUrl, 'original.png') : null);
   const isGrouped = taglinePosition === 'grouped' && showTagline && config.tagline;
 
   const nameNode = (


### PR DESCRIPTION
## Summary
- `config.logoUrl` is a Supabase storage path (e.g. `orgs/abc/logos`), not a renderable URL
- HeaderBar was using it directly in `<img src>`, causing a broken image
- Now uses `getLogoUrl()` to convert it to a full public URL, matching how admin settings already handles it

## Test plan
- [ ] Visit fairbankseagle.org (Springbrook Creek Preserve) sitebuilder
- [ ] Verify the header logo renders correctly instead of showing a broken image
- [ ] Verify that logos set via the Puck editor ImagePickerField still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)