### PR TITLE
feat: add admin & profile actions to site-builder header/nav

### DIFF
--- a/src/lib/puck/chrome-config.ts
+++ b/src/lib/puck/chrome-config.ts
@@ -34,6 +34,7 @@ export const chromeConfig: Config<ChromeComponents> = {
         layout: 'left-aligned',
         showTagline: false,
         backgroundColor: 'default',
+        showAuthActions: false,
       },
       fields: {
         layout: {
@@ -136,6 +137,14 @@ export const chromeConfig: Config<ChromeComponents> = {
           },
         },
         linkColor: colorPickerField('Link Color'),
+        showAuthActions: {
+          type: 'radio',
+          label: 'Show Admin & Profile',
+          options: [
+            { label: 'Yes', value: true },
+            { label: 'No', value: false },
+          ],
+        },
       },
       resolveFields: (data: any, { fields }: any) => {
         if (!data.props.showTagline) {
@@ -153,6 +162,7 @@ export const chromeConfig: Config<ChromeComponents> = {
         style: 'horizontal',
         position: 'below-header',
         showMobileBottomBar: false,
+        showAuthActions: false,
       },
       fields: {
         style: {
@@ -175,6 +185,14 @@ export const chromeConfig: Config<ChromeComponents> = {
         showMobileBottomBar: {
           type: 'radio',
           label: 'Show Mobile Bottom Bar',
+          options: [
+            { label: 'Yes', value: true },
+            { label: 'No', value: false },
+          ],
+        },
+        showAuthActions: {
+          type: 'radio',
+          label: 'Show Admin & Profile',
           options: [
             { label: 'Yes', value: true },
             { label: 'No', value: false },

--- a/src/lib/puck/components/chrome/AuthActions.tsx
+++ b/src/lib/puck/components/chrome/AuthActions.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/client';
+import { AvatarMenu } from '@/components/layout/AvatarMenu';
+
+interface AuthActionsProps {
+  linkColor?: string;
+}
+
+export function AuthActions({ linkColor }: AuthActionsProps) {
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    // Check current session
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUserEmail(user?.email ?? null);
+    });
+
+    // Stay in sync with auth changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUserEmail(session?.user?.email ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  if (!userEmail) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Link
+        href="/org"
+        className="p-1.5 rounded-lg hover:bg-black/10 transition-colors"
+        aria-label="Admin settings"
+        style={linkColor ? { color: linkColor } : undefined}
+      >
+        <GearIcon className="w-5 h-5" />
+      </Link>
+      <AvatarMenu userEmail={userEmail} />
+    </div>
+  );
+}
+
+function GearIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  );
+}

--- a/src/lib/puck/components/chrome/HeaderBar.tsx
+++ b/src/lib/puck/components/chrome/HeaderBar.tsx
@@ -5,6 +5,7 @@ import { getLogoUrl } from '@/lib/config/logo';
 import type { HeaderBarProps } from '../../types';
 import { resolveLink } from '../../fields/link-utils';
 import { IconRenderer } from '../../icons/IconRenderer';
+import { AuthActions } from './AuthActions';
 
 const bgClasses = {
   primary: 'bg-[var(--color-primary)] text-white',
@@ -43,6 +44,7 @@ export function HeaderBar({
   taglineColor,
   links,
   linkColor,
+  showAuthActions,
 }: HeaderBarProps) {
   const config = useConfig();
   const alignClass = layout === 'centered' ? 'text-center' : 'text-left';
@@ -97,25 +99,28 @@ export function HeaderBar({
             )}
           </Link>
 
-          {links && links.length > 0 && (
-            <nav className="flex items-center gap-4">
-              {links.map((link, i) => {
-                const resolved = resolveLink(link.href);
-                return (
-                  <Link
-                    key={i}
-                    href={resolved.href}
-                    target={resolved.target}
-                    rel={resolved.target === '_blank' ? 'noopener noreferrer' : undefined}
-                    className="text-sm hover:underline"
-                    style={linkColor ? { color: linkColor } : undefined}
-                  >
-                    {link.label}
-                  </Link>
-                );
-              })}
-            </nav>
-          )}
+          <div className="flex items-center gap-4">
+            {links && links.length > 0 && (
+              <nav className="flex items-center gap-4">
+                {links.map((link, i) => {
+                  const resolved = resolveLink(link.href);
+                  return (
+                    <Link
+                      key={i}
+                      href={resolved.href}
+                      target={resolved.target}
+                      rel={resolved.target === '_blank' ? 'noopener noreferrer' : undefined}
+                      className="text-sm hover:underline"
+                      style={linkColor ? { color: linkColor } : undefined}
+                    >
+                      {link.label}
+                    </Link>
+                  );
+                })}
+              </nav>
+            )}
+            {showAuthActions && <AuthActions linkColor={linkColor} />}
+          </div>
         </div>
 
         {showTagline && !isGrouped && config.tagline && (

--- a/src/lib/puck/components/chrome/NavBar.tsx
+++ b/src/lib/puck/components/chrome/NavBar.tsx
@@ -4,8 +4,9 @@ import { usePathname } from 'next/navigation';
 import { useConfig } from '@/lib/config/client';
 import { useState } from 'react';
 import type { NavBarProps } from '../../types';
+import { AuthActions } from './AuthActions';
 
-export function NavBar({ style, position, showMobileBottomBar }: NavBarProps) {
+export function NavBar({ style, position, showMobileBottomBar, showAuthActions }: NavBarProps) {
   const config = useConfig();
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -29,6 +30,7 @@ export function NavBar({ style, position, showMobileBottomBar }: NavBarProps) {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={menuOpen ? 'M6 18L18 6M6 6l12 12' : 'M4 6h16M4 12h16M4 18h16'} />
             </svg>
           </button>
+          {showAuthActions && <AuthActions />}
         </div>
         {menuOpen && (
           <div className="border-t border-gray-100 py-2">
@@ -44,16 +46,19 @@ export function NavBar({ style, position, showMobileBottomBar }: NavBarProps) {
   return (
     <>
       <nav className={`bg-white border-b border-gray-200 px-4 py-2 ${positionClass}`}>
-        <div className="mx-auto flex max-w-6xl items-center gap-6">
-          {navItems.map((item) => {
-            const isActive = pathname === item.href;
-            return (
-              <Link key={item.href} href={item.href}
-                className={`text-sm font-medium transition ${isActive ? 'text-[var(--color-primary)]' : 'text-gray-600 hover:text-gray-900'}`}>
-                {item.label}
-              </Link>
-            );
-          })}
+        <div className="mx-auto flex max-w-6xl items-center justify-between">
+          <div className="flex items-center gap-6">
+            {navItems.map((item) => {
+              const isActive = pathname === item.href;
+              return (
+                <Link key={item.href} href={item.href}
+                  className={`text-sm font-medium transition ${isActive ? 'text-[var(--color-primary)]' : 'text-gray-600 hover:text-gray-900'}`}>
+                  {item.label}
+                </Link>
+              );
+            })}
+          </div>
+          {showAuthActions && <AuthActions />}
         </div>
       </nav>
       {showMobileBottomBar && (

--- a/src/lib/puck/components/chrome/__tests__/AuthActions.test.tsx
+++ b/src/lib/puck/components/chrome/__tests__/AuthActions.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { AuthActions } from '../AuthActions';
+
+let authChangeCallback: ((event: string, session: { user?: { email: string } } | null) => void) | null = null;
+const mockGetUser = vi.fn();
+const mockUnsubscribe = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: mockGetUser,
+      onAuthStateChange: (_event: string, cb: typeof authChangeCallback) => {
+        authChangeCallback = cb;
+        return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
+      },
+    },
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('AuthActions', () => {
+  beforeEach(() => {
+    authChangeCallback = null;
+    mockGetUser.mockReset();
+    mockUnsubscribe.mockReset();
+  });
+
+  it('renders nothing when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { container } = render(<AuthActions />);
+    await act(() => Promise.resolve());
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders admin link and avatar when authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: 'admin@test.com' } } });
+    render(<AuthActions />);
+    await act(() => Promise.resolve());
+    expect(screen.getByLabelText('Admin settings')).toBeDefined();
+    expect(screen.getByLabelText('User menu')).toBeDefined();
+  });
+
+  it('admin link points to /org', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: 'admin@test.com' } } });
+    render(<AuthActions />);
+    await act(() => Promise.resolve());
+    const link = screen.getByLabelText('Admin settings');
+    expect(link.getAttribute('href')).toBe('/org');
+  });
+
+  it('applies linkColor to admin icon', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: 'admin@test.com' } } });
+    render(<AuthActions linkColor="#ff0000" />);
+    await act(() => Promise.resolve());
+    const link = screen.getByLabelText('Admin settings');
+    expect(link.style.color).toBe('rgb(255, 0, 0)');
+  });
+
+  it('unsubscribes on unmount', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { unmount } = render(<AuthActions />);
+    await act(() => Promise.resolve());
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/lib/puck/types.ts
+++ b/src/lib/puck/types.ts
@@ -147,12 +147,14 @@ export interface HeaderBarProps {
   taglineColor?: string;
   links?: Array<{ label: string; href: string | LinkValue }>;
   linkColor?: string;
+  showAuthActions?: boolean;
 }
 
 export interface NavBarProps {
   style: 'horizontal' | 'hamburger' | 'tabs';
   position: 'below-header' | 'sticky';
   showMobileBottomBar: boolean;
+  showAuthActions?: boolean;
 }
 
 export interface AnnouncementBarProps {


### PR DESCRIPTION
## Summary
- Adds a configurable **"Show Admin & Profile"** toggle to both HeaderBar and NavBar Puck chrome components
- When enabled, authenticated users see a gear icon (→ `/org`) and AvatarMenu; anonymous visitors see nothing
- Auth state detected client-side via Supabase `onAuthStateChange` — no server prop changes needed
- Reuses existing `AvatarMenu` component; defaults to off (non-breaking)

## Test plan
- [x] TypeScript type-check passes
- [x] 874/874 unit tests pass (5 new AuthActions tests)
- [x] Manual: toggle "Show Admin & Profile" in site-builder chrome editor for HeaderBar
- [x] Manual: toggle in NavBar (horizontal + hamburger layouts)
- [x] Manual: verify buttons hidden when logged out, visible when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)