### PR TITLE
feat: configurable map display controls per property/org

### DIFF
--- a/docs/superpowers/plans/2026-04-05-map-display-config.md
+++ b/docs/superpowers/plans/2026-04-05-map-display-config.md
@@ -1,0 +1,1199 @@
+# Map Display Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make map controls (legend, layer selector, locate me, view as list, quick add) and legend content configurable per property/org with cascade inheritance.
+
+**Architecture:** New `map_display_config` JSONB column on `orgs` and `properties` tables. `buildSiteConfig` merges org → property config with per-key control toggle fallback and full-replacement legend lists. Components read resolved config via `useConfig().mapDisplayConfig`. Admin UI uses card-per-control layout with toggle switches in both org and property settings.
+
+**Tech Stack:** Next.js 14, Supabase PostgreSQL, TypeScript, React, Tailwind CSS, Vitest
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `supabase/migrations/034_map_display_config.sql` | Create | Add JSONB column to orgs + properties |
+| `src/lib/config/map-display.ts` | Create | `MapDisplayConfig` type + `resolveMapDisplayConfig` merge function |
+| `src/lib/config/__tests__/map-display.test.ts` | Create | Tests for resolve/merge logic |
+| `src/lib/config/types.ts` | Modify | Add `mapDisplayConfig` to `SiteConfig`, update `buildSiteConfig` signature + body |
+| `src/lib/config/__tests__/config.test.ts` | Modify | Update existing tests for new field |
+| `src/lib/config/defaults.ts` | Modify | Add `mapDisplayConfig` to `DEFAULT_CONFIG` |
+| `src/lib/config/server.ts` | Modify | Add `map_display_config` to org + property select queries |
+| `src/lib/types.ts` | Modify | Add `map_display_config` to `Property` and `Org` interfaces |
+| `src/components/map/MapView.tsx` | Modify | Conditionally render legend, locate, layers, quick add |
+| `src/components/map/HomeMapView.tsx` | Modify | Conditionally render "View as List" link |
+| `src/components/map/MapLegend.tsx` | Modify | Filter statuses and item types based on legend config |
+| `src/components/admin/MapDisplayConfigEditor.tsx` | Create | Shared card-per-control toggle UI component |
+| `src/app/admin/settings/page.tsx` | Modify | Add Map Display section to org settings |
+| `src/app/admin/settings/actions.ts` | Modify | Add `map_display_config` to OrgSettings + update action |
+| `src/app/admin/properties/[slug]/settings/page.tsx` | Modify | Add Map Display section to Appearance tab |
+| `src/app/admin/properties/[slug]/settings/actions.ts` | Modify | Add `map_display_config` to PROPERTY_KEY_TO_COLUMN |
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migrations/034_map_display_config.sql`
+
+- [ ] **Step 1: Create migration file**
+
+```sql
+-- Add map display configuration to orgs and properties
+-- Stores control visibility toggles and legend content filters as JSONB
+-- null = use all defaults (everything visible)
+
+ALTER TABLE orgs
+  ADD COLUMN IF NOT EXISTS map_display_config JSONB DEFAULT NULL;
+
+ALTER TABLE properties
+  ADD COLUMN IF NOT EXISTS map_display_config JSONB DEFAULT NULL;
+```
+
+- [ ] **Step 2: Verify migration applies cleanly**
+
+Run: `cd /Users/patrick/birdhousemapper && npx supabase db reset 2>&1 | tail -5`
+Expected: Migration applies without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/034_map_display_config.sql
+git commit -m "feat: add map_display_config column to orgs and properties"
+```
+
+---
+
+### Task 2: MapDisplayConfig Type and Resolve Function
+
+**Files:**
+- Create: `src/lib/config/map-display.ts`
+- Create: `src/lib/config/__tests__/map-display.test.ts`
+
+- [ ] **Step 1: Write tests for resolveMapDisplayConfig**
+
+File: `src/lib/config/__tests__/map-display.test.ts`
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { resolveMapDisplayConfig } from '../map-display';
+import type { MapDisplayConfig, ResolvedMapDisplayConfig } from '../map-display';
+
+describe('resolveMapDisplayConfig', () => {
+  it('returns all-true defaults when both org and property are null', () => {
+    const result = resolveMapDisplayConfig(null, null);
+    expect(result.controls.legend).toBe(true);
+    expect(result.controls.layerSelector).toBe(true);
+    expect(result.controls.locateMe).toBe(true);
+    expect(result.controls.viewAsList).toBe(true);
+    expect(result.controls.quickAdd).toBe(true);
+    expect(result.legend.statuses).toBeUndefined();
+    expect(result.legend.itemTypeIds).toBeUndefined();
+  });
+
+  it('uses org config when property is null', () => {
+    const org: MapDisplayConfig = {
+      controls: { legend: false, quickAdd: false },
+      legend: { statuses: ['active', 'planned'] },
+    };
+    const result = resolveMapDisplayConfig(org, null);
+    expect(result.controls.legend).toBe(false);
+    expect(result.controls.layerSelector).toBe(true);
+    expect(result.controls.quickAdd).toBe(false);
+    expect(result.legend.statuses).toEqual(['active', 'planned']);
+  });
+
+  it('property controls override org controls per-key', () => {
+    const org: MapDisplayConfig = {
+      controls: { legend: false, locateMe: false },
+    };
+    const property: MapDisplayConfig = {
+      controls: { legend: true },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.controls.legend).toBe(true);    // property overrides
+    expect(result.controls.locateMe).toBe(false);  // falls through to org
+    expect(result.controls.layerSelector).toBe(true); // default
+  });
+
+  it('property legend statuses fully replace org legend statuses', () => {
+    const org: MapDisplayConfig = {
+      legend: { statuses: ['active', 'planned'] },
+    };
+    const property: MapDisplayConfig = {
+      legend: { statuses: ['active', 'damaged'] },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.legend.statuses).toEqual(['active', 'damaged']);
+  });
+
+  it('property legend itemTypeIds fully replace org itemTypeIds', () => {
+    const org: MapDisplayConfig = {
+      legend: { itemTypeIds: ['id-1', 'id-2'] },
+    };
+    const property: MapDisplayConfig = {
+      legend: { itemTypeIds: ['id-3'] },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.legend.itemTypeIds).toEqual(['id-3']);
+  });
+
+  it('falls through to org legend when property legend is undefined', () => {
+    const org: MapDisplayConfig = {
+      legend: { statuses: ['active'], itemTypeIds: ['id-1'] },
+    };
+    const property: MapDisplayConfig = {
+      controls: { quickAdd: false },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.legend.statuses).toEqual(['active']);
+    expect(result.legend.itemTypeIds).toEqual(['id-1']);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/config/__tests__/map-display.test.ts 2>&1 | tail -10`
+Expected: FAIL — module `../map-display` not found.
+
+- [ ] **Step 3: Write the type and resolve function**
+
+File: `src/lib/config/map-display.ts`
+
+```typescript
+export interface MapDisplayConfig {
+  controls?: {
+    legend?: boolean;
+    layerSelector?: boolean;
+    locateMe?: boolean;
+    viewAsList?: boolean;
+    quickAdd?: boolean;
+  };
+  legend?: {
+    statuses?: string[];
+    itemTypeIds?: string[];
+  };
+}
+
+export interface ResolvedMapDisplayConfig {
+  controls: {
+    legend: boolean;
+    layerSelector: boolean;
+    locateMe: boolean;
+    viewAsList: boolean;
+    quickAdd: boolean;
+  };
+  legend: {
+    statuses?: string[];
+    itemTypeIds?: string[];
+  };
+}
+
+/**
+ * Merge org and property map display configs with cascade logic.
+ * Controls: property per-key overrides org per-key, unset defaults to true.
+ * Legend lists: property fully replaces org if set, otherwise falls through.
+ */
+export function resolveMapDisplayConfig(
+  orgConfig: MapDisplayConfig | null | undefined,
+  propertyConfig: MapDisplayConfig | null | undefined,
+): ResolvedMapDisplayConfig {
+  const orgControls = orgConfig?.controls;
+  const propControls = propertyConfig?.controls;
+
+  return {
+    controls: {
+      legend: propControls?.legend ?? orgControls?.legend ?? true,
+      layerSelector: propControls?.layerSelector ?? orgControls?.layerSelector ?? true,
+      locateMe: propControls?.locateMe ?? orgControls?.locateMe ?? true,
+      viewAsList: propControls?.viewAsList ?? orgControls?.viewAsList ?? true,
+      quickAdd: propControls?.quickAdd ?? orgControls?.quickAdd ?? true,
+    },
+    legend: {
+      statuses: propertyConfig?.legend?.statuses ?? orgConfig?.legend?.statuses,
+      itemTypeIds: propertyConfig?.legend?.itemTypeIds ?? orgConfig?.legend?.itemTypeIds,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/config/__tests__/map-display.test.ts 2>&1 | tail -10`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/config/map-display.ts src/lib/config/__tests__/map-display.test.ts
+git commit -m "feat: add MapDisplayConfig type and resolve function with tests"
+```
+
+---
+
+### Task 3: Integrate into SiteConfig and buildSiteConfig
+
+**Files:**
+- Modify: `src/lib/config/types.ts`
+- Modify: `src/lib/config/defaults.ts`
+- Modify: `src/lib/config/__tests__/config.test.ts`
+- Modify: `src/lib/types.ts`
+
+- [ ] **Step 1: Write the failing test for mapDisplayConfig in buildSiteConfig**
+
+Add to the end of the `buildSiteConfig` describe block in `src/lib/config/__tests__/config.test.ts`, before the closing `});` of the describe:
+
+```typescript
+  it('resolves mapDisplayConfig from org and property', () => {
+    const org = {
+      name: 'Test',
+      tagline: null,
+      logo_url: null,
+      favicon_url: null,
+      theme: null,
+      setup_complete: false,
+      map_display_config: { controls: { legend: false, quickAdd: false } },
+    };
+    const property = {
+      description: null,
+      map_default_lat: null,
+      map_default_lng: null,
+      map_default_zoom: null,
+      map_style: null,
+      custom_map: null,
+      about_content: null,
+      about_page_enabled: null,
+      footer_text: null,
+      footer_links: null,
+      custom_nav_items: null,
+      landing_page: null,
+      logo_url: null,
+      puck_pages: null,
+      puck_root: null,
+      puck_template: null,
+      puck_pages_draft: null,
+      puck_root_draft: null,
+      puck_page_meta: null,
+      map_display_config: { controls: { legend: true } },
+    };
+
+    const config = buildSiteConfig(org, property);
+
+    expect(config.mapDisplayConfig.controls.legend).toBe(true);     // property overrides
+    expect(config.mapDisplayConfig.controls.quickAdd).toBe(false);  // org value
+    expect(config.mapDisplayConfig.controls.locateMe).toBe(true);   // default
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/config/__tests__/config.test.ts 2>&1 | tail -15`
+Expected: FAIL — `map_display_config` not recognized in org/property type, or `mapDisplayConfig` not on SiteConfig.
+
+- [ ] **Step 3: Add map_display_config to Org and Property interfaces**
+
+In `src/lib/types.ts`, add to the `Org` interface (after `updated_at: string;`):
+
+```typescript
+  map_display_config: unknown | null;
+```
+
+Add to the `Property` interface (after `deleted_at: string | null;`):
+
+```typescript
+  map_display_config: unknown | null;
+```
+
+- [ ] **Step 4: Add mapDisplayConfig to SiteConfig and buildSiteConfig**
+
+In `src/lib/config/types.ts`:
+
+1. Add import at top:
+
+```typescript
+import { resolveMapDisplayConfig, type ResolvedMapDisplayConfig } from './map-display';
+```
+
+2. Add to the `SiteConfig` interface (after `puckPageMeta`):
+
+```typescript
+  mapDisplayConfig: ResolvedMapDisplayConfig;
+```
+
+3. Add `map_display_config` to the `org` parameter type in `buildSiteConfig`:
+
+```typescript
+    map_display_config?: unknown | null;
+```
+
+4. Add `map_display_config` to the `property` parameter type in `buildSiteConfig`:
+
+```typescript
+    map_display_config?: unknown | null;
+```
+
+5. Add to the return object in `buildSiteConfig` (at the end, before the closing `};`):
+
+```typescript
+    mapDisplayConfig: resolveMapDisplayConfig(
+      org.map_display_config as import('./map-display').MapDisplayConfig | null,
+      property.map_display_config as import('./map-display').MapDisplayConfig | null,
+    ),
+```
+
+- [ ] **Step 5: Add mapDisplayConfig to DEFAULT_CONFIG**
+
+In `src/lib/config/defaults.ts`, add the import:
+
+```typescript
+import { resolveMapDisplayConfig } from './map-display';
+```
+
+Add to the DEFAULT_CONFIG object:
+
+```typescript
+  mapDisplayConfig: resolveMapDisplayConfig(null, null),
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run src/lib/config/__tests__/config.test.ts 2>&1 | tail -15`
+Expected: All tests PASS (existing + new).
+
+- [ ] **Step 7: Update the config server query to include map_display_config**
+
+In `src/lib/config/server.ts`, update the org select query (line 32) to add `map_display_config`:
+
+Change:
+```typescript
+      .select('name, pwa_name, tagline, logo_url, favicon_url, theme, setup_complete, default_property_id')
+```
+To:
+```typescript
+      .select('name, pwa_name, tagline, logo_url, favicon_url, theme, setup_complete, default_property_id, map_display_config')
+```
+
+Update the property select query (line 49) to add `map_display_config`:
+
+Change:
+```typescript
+      .select('id, name, pwa_name, description, map_default_lat, map_default_lng, map_default_zoom, map_style, custom_map, about_content, about_page_enabled, footer_text, footer_links, custom_nav_items, landing_page, logo_url, puck_pages, puck_root, puck_template, puck_pages_draft, puck_root_draft, puck_page_meta')
+```
+To:
+```typescript
+      .select('id, name, pwa_name, description, map_default_lat, map_default_lng, map_default_zoom, map_style, custom_map, about_content, about_page_enabled, footer_text, footer_links, custom_nav_items, landing_page, logo_url, puck_pages, puck_root, puck_template, puck_pages_draft, puck_root_draft, puck_page_meta, map_display_config')
+```
+
+- [ ] **Step 8: Run full test suite to verify nothing is broken**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run 2>&1 | tail -15`
+Expected: All tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/config/types.ts src/lib/config/defaults.ts src/lib/config/server.ts src/lib/config/__tests__/config.test.ts
+git commit -m "feat: integrate mapDisplayConfig into SiteConfig and buildSiteConfig"
+```
+
+---
+
+### Task 4: Conditional Rendering in Map Components
+
+**Files:**
+- Modify: `src/components/map/MapView.tsx`
+- Modify: `src/components/map/HomeMapView.tsx`
+- Modify: `src/components/map/MapLegend.tsx`
+
+- [ ] **Step 1: Conditionally render controls in MapView.tsx**
+
+In `src/components/map/MapView.tsx`:
+
+1. Read `mapDisplayConfig` from config (after line 68 where `config` is already destructured):
+
+```typescript
+  const { controls: mapControls } = config.mapDisplayConfig;
+```
+
+2. Wrap `<LocateButton>` (line 208) in a controls check:
+
+Change:
+```tsx
+      <LocateButton onLocate={() => setFlyToUserTrigger((n) => n + 1)} />
+```
+To:
+```tsx
+      {mapControls.locateMe && (
+        <LocateButton onLocate={() => setFlyToUserTrigger((n) => n + 1)} />
+      )}
+```
+
+3. Wrap `<MapLegend>` (line 209) in a controls check:
+
+Change:
+```tsx
+      <MapLegend itemTypes={itemTypes} />
+```
+To:
+```tsx
+      {mapControls.legend && (
+        <MapLegend itemTypes={itemTypes} legendConfig={config.mapDisplayConfig.legend} />
+      )}
+```
+
+4. Wrap the `LayerControlPanel` block (lines 154-159) in a controls check:
+
+Change:
+```tsx
+      {geoLayers && geoLayers.length > 0 && (
+        <LayerControlPanel
+```
+To:
+```tsx
+      {mapControls.layerSelector && geoLayers && geoLayers.length > 0 && (
+        <LayerControlPanel
+```
+
+5. Wrap the Quick Add FAB block (lines 212-221) in a controls check:
+
+Change:
+```tsx
+      {sheetState !== 'half' && sheetState !== 'full' && (
+```
+To:
+```tsx
+      {mapControls.quickAdd && sheetState !== 'half' && sheetState !== 'full' && (
+```
+
+- [ ] **Step 2: Conditionally render "View as List" in HomeMapView.tsx**
+
+In `src/components/map/HomeMapView.tsx`:
+
+1. The `config` is already available (line 62). Add after it:
+
+```typescript
+  const { controls: mapControls } = config.mapDisplayConfig;
+```
+
+2. Wrap the "List view link" block (lines 295-301) in a controls check:
+
+Change:
+```tsx
+      {/* List view link */}
+      <Link
+        href="/list"
+        className="absolute top-4 right-4 z-10 bg-white backdrop-blur-sm rounded-lg shadow-lg border border-sage-light px-3 py-2 text-xs font-medium text-forest-dark hover:bg-sage-light transition-colors"
+      >
+        View as List
+      </Link>
+```
+To:
+```tsx
+      {/* List view link */}
+      {mapControls.viewAsList && (
+        <Link
+          href="/list"
+          className="absolute top-4 right-4 z-10 bg-white backdrop-blur-sm rounded-lg shadow-lg border border-sage-light px-3 py-2 text-xs font-medium text-forest-dark hover:bg-sage-light transition-colors"
+        >
+          View as List
+        </Link>
+      )}
+```
+
+- [ ] **Step 3: Filter legend content in MapLegend.tsx**
+
+In `src/components/map/MapLegend.tsx`:
+
+1. Update the interface to accept legend config:
+
+Change:
+```typescript
+interface MapLegendProps {
+  itemTypes: ItemType[];
+}
+```
+To:
+```typescript
+interface MapLegendProps {
+  itemTypes: ItemType[];
+  legendConfig?: {
+    statuses?: string[];
+    itemTypeIds?: string[];
+  };
+}
+```
+
+2. Update the function signature:
+
+Change:
+```typescript
+export default function MapLegend({ itemTypes }: MapLegendProps) {
+```
+To:
+```typescript
+export default function MapLegend({ itemTypes, legendConfig }: MapLegendProps) {
+```
+
+3. Add import for `ItemStatus` type and `statusLabels` at top:
+
+```typescript
+import type { ItemType, ItemStatus } from '@/lib/types';
+import { statusColors, statusLabels } from '@/lib/utils';
+```
+
+(Remove the existing `import { statusColors } from '@/lib/utils';` line.)
+
+4. Replace the hardcoded `statusItems` array (lines 14-18):
+
+Change:
+```typescript
+  const statusItems = [
+    { color: statusColors.active, label: 'Active' },
+    { color: statusColors.planned, label: 'Planned' },
+    { color: statusColors.damaged, label: 'Needs Repair' },
+  ];
+```
+To:
+```typescript
+  const allStatuses: ItemStatus[] = ['active', 'planned', 'damaged', 'removed'];
+  const visibleStatuses = legendConfig?.statuses
+    ? allStatuses.filter((s) => legendConfig.statuses!.includes(s))
+    : allStatuses.filter((s) => s !== 'removed'); // preserve existing default: hide 'removed'
+
+  const statusItems = visibleStatuses.map((s) => ({
+    color: statusColors[s],
+    label: statusLabels[s],
+  }));
+```
+
+5. Filter item types by config. Change the itemTypes rendering block (lines 59-72):
+
+Change:
+```tsx
+          {itemTypes.length > 1 && (
+            <>
+              <h4 className="text-[10px] font-medium text-sage uppercase tracking-wider mt-2 mb-1.5">
+                Types
+              </h4>
+              <div className="space-y-1">
+                {itemTypes.map((type) => (
+```
+To:
+```tsx
+          {(() => {
+            const visibleTypes = legendConfig?.itemTypeIds
+              ? itemTypes.filter((t) => legendConfig.itemTypeIds!.includes(t.id))
+              : itemTypes;
+            return visibleTypes.length > 1 ? (
+              <>
+                <h4 className="text-[10px] font-medium text-sage uppercase tracking-wider mt-2 mb-1.5">
+                  Types
+                </h4>
+                <div className="space-y-1">
+                  {visibleTypes.map((type) => (
+```
+
+And close the IIFE after the existing closing tags:
+
+Change:
+```tsx
+              </div>
+            </>
+          )}
+```
+To:
+```tsx
+                  </div>
+                </>
+              ) : null;
+          })()}
+```
+
+- [ ] **Step 4: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper && npx tsc --noEmit 2>&1 | tail -20`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/map/MapView.tsx src/components/map/HomeMapView.tsx src/components/map/MapLegend.tsx
+git commit -m "feat: conditionally render map controls based on mapDisplayConfig"
+```
+
+---
+
+### Task 5: MapDisplayConfigEditor Component
+
+**Files:**
+- Create: `src/components/admin/MapDisplayConfigEditor.tsx`
+
+- [ ] **Step 1: Create the shared editor component**
+
+File: `src/components/admin/MapDisplayConfigEditor.tsx`
+
+```tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { MapDisplayConfig } from '@/lib/config/map-display';
+import type { ItemType, ItemStatus } from '@/lib/types';
+import { statusColors, statusLabels } from '@/lib/utils';
+
+interface ControlDef {
+  key: keyof NonNullable<MapDisplayConfig['controls']>;
+  label: string;
+  description: string;
+  icon: string;
+}
+
+const CONTROLS: ControlDef[] = [
+  { key: 'legend', label: 'Legend', description: 'Status colors & item types', icon: '🗺️' },
+  { key: 'locateMe', label: 'Current Position', description: 'Center map on user location', icon: '📍' },
+  { key: 'viewAsList', label: 'View as List', description: 'Link to list view', icon: '📋' },
+  { key: 'layerSelector', label: 'Layer Selector', description: 'Toggle geo layer visibility', icon: '🗂️' },
+  { key: 'quickAdd', label: 'Quick Add', description: 'Floating add button', icon: '➕' },
+];
+
+const ALL_STATUSES: ItemStatus[] = ['active', 'planned', 'damaged', 'removed'];
+
+interface Props {
+  value: MapDisplayConfig | null;
+  onChange: (config: MapDisplayConfig | null) => void;
+  itemTypes: ItemType[];
+  /** Org-level config for showing defaults on property page. Omit for org-level editing. */
+  orgDefaults?: MapDisplayConfig | null;
+}
+
+export default function MapDisplayConfigEditor({ value, onChange, itemTypes, orgDefaults }: Props) {
+  const config = value ?? {};
+  const isPropertyLevel = orgDefaults !== undefined;
+
+  function getControlValue(key: keyof NonNullable<MapDisplayConfig['controls']>): boolean {
+    return config.controls?.[key] ?? (isPropertyLevel ? (orgDefaults?.controls?.[key] ?? true) : true);
+  }
+
+  function isControlOverridden(key: keyof NonNullable<MapDisplayConfig['controls']>): boolean {
+    if (!isPropertyLevel) return false;
+    return config.controls?.[key] !== undefined;
+  }
+
+  function getOrgDefault(key: keyof NonNullable<MapDisplayConfig['controls']>): boolean {
+    return orgDefaults?.controls?.[key] ?? true;
+  }
+
+  function setControl(key: keyof NonNullable<MapDisplayConfig['controls']>, val: boolean) {
+    const newControls = { ...config.controls, [key]: val };
+    onChange({ ...config, controls: newControls });
+  }
+
+  function resetControl(key: keyof NonNullable<MapDisplayConfig['controls']>) {
+    if (!config.controls) return;
+    const newControls = { ...config.controls };
+    delete newControls[key];
+    const hasKeys = Object.keys(newControls).length > 0;
+    onChange({ ...config, controls: hasKeys ? newControls : undefined });
+  }
+
+  function getLegendStatuses(): string[] | undefined {
+    return config.legend?.statuses ?? (isPropertyLevel ? orgDefaults?.legend?.statuses : undefined);
+  }
+
+  function getLegendItemTypeIds(): string[] | undefined {
+    return config.legend?.itemTypeIds ?? (isPropertyLevel ? orgDefaults?.legend?.itemTypeIds : undefined);
+  }
+
+  function setLegendStatuses(statuses: string[] | undefined) {
+    const newLegend = { ...config.legend, statuses };
+    if (!statuses) delete newLegend.statuses;
+    const hasKeys = Object.keys(newLegend).length > 0;
+    onChange({ ...config, legend: hasKeys ? newLegend : undefined });
+  }
+
+  function setLegendItemTypeIds(ids: string[] | undefined) {
+    const newLegend = { ...config.legend, itemTypeIds: ids };
+    if (!ids) delete newLegend.itemTypeIds;
+    const hasKeys = Object.keys(newLegend).length > 0;
+    onChange({ ...config, legend: hasKeys ? newLegend : undefined });
+  }
+
+  function toggleStatus(status: string) {
+    const current = getLegendStatuses();
+    if (!current) {
+      // Currently showing all — toggling one off means explicitly list the rest
+      setLegendStatuses(ALL_STATUSES.filter((s) => s !== status));
+    } else if (current.includes(status)) {
+      const next = current.filter((s) => s !== status);
+      setLegendStatuses(next.length > 0 ? next : undefined);
+    } else {
+      setLegendStatuses([...current, status]);
+    }
+  }
+
+  function toggleItemType(typeId: string) {
+    const current = getLegendItemTypeIds();
+    if (!current) {
+      // Currently showing all — toggling one off means explicitly list the rest
+      setLegendItemTypeIds(itemTypes.filter((t) => t.id !== typeId).map((t) => t.id));
+    } else if (current.includes(typeId)) {
+      const next = current.filter((id) => id !== typeId);
+      setLegendItemTypeIds(next.length > 0 ? next : undefined);
+    } else {
+      setLegendItemTypeIds([...current, typeId]);
+    }
+  }
+
+  function isStatusChecked(status: string): boolean {
+    const statuses = getLegendStatuses();
+    return !statuses || statuses.includes(status);
+  }
+
+  function isItemTypeChecked(typeId: string): boolean {
+    const ids = getLegendItemTypeIds();
+    return !ids || ids.includes(typeId);
+  }
+
+  const legendEnabled = getControlValue('legend');
+
+  return (
+    <div className="space-y-2">
+      {CONTROLS.map((ctrl) => {
+        const enabled = getControlValue(ctrl.key);
+        const overridden = isControlOverridden(ctrl.key);
+        const orgDefault = isPropertyLevel ? getOrgDefault(ctrl.key) : null;
+
+        return (
+          <div key={ctrl.key}>
+            <div
+              className={`flex items-center justify-between p-3 rounded-lg border transition-colors ${
+                overridden
+                  ? 'bg-amber-50 border-amber-300'
+                  : 'bg-sage-light/30 border-sage-light'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-base">{ctrl.icon}</span>
+                <div>
+                  <div className="text-sm font-medium text-forest-dark">{ctrl.label}</div>
+                  {isPropertyLevel && (
+                    <div className={`text-[10px] ${overridden ? 'text-amber-700' : 'text-sage'}`}>
+                      Org default: {orgDefault ? 'On' : 'Off'}
+                      {overridden && (
+                        <>
+                          {' · '}
+                          <button
+                            type="button"
+                            onClick={() => resetControl(ctrl.key)}
+                            className="underline hover:no-underline"
+                          >
+                            Reset
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  {!isPropertyLevel && (
+                    <div className="text-[10px] text-sage">{ctrl.description}</div>
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => setControl(ctrl.key, !enabled)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                  enabled ? 'bg-forest' : 'bg-gray-300'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform ${
+                    enabled ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Legend detail section — only shown when legend control card is expanded */}
+            {ctrl.key === 'legend' && legendEnabled && (
+              <div className="ml-3 mt-2 p-3 rounded-lg border border-sage-light bg-white space-y-3">
+                <div>
+                  <div className="text-xs font-medium text-sage uppercase tracking-wider mb-2">Statuses</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {ALL_STATUSES.map((status) => {
+                      const checked = isStatusChecked(status);
+                      return (
+                        <label
+                          key={status}
+                          className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs cursor-pointer border transition-colors ${
+                            checked
+                              ? 'bg-green-50 border-green-300 text-forest-dark'
+                              : 'bg-gray-50 border-gray-200 text-gray-400 line-through'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleStatus(status)}
+                            className="sr-only"
+                          />
+                          <span
+                            className="w-2.5 h-2.5 rounded-full"
+                            style={{ backgroundColor: statusColors[status as ItemStatus] }}
+                          />
+                          {statusLabels[status as ItemStatus]}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+                {itemTypes.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-sage uppercase tracking-wider mb-2">Item Types</div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {itemTypes.map((type) => {
+                        const checked = isItemTypeChecked(type.id);
+                        return (
+                          <label
+                            key={type.id}
+                            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs cursor-pointer border transition-colors ${
+                              checked
+                                ? 'bg-green-50 border-green-300 text-forest-dark'
+                                : 'bg-gray-50 border-gray-200 text-gray-400 line-through'
+                            }`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() => toggleItemType(type.id)}
+                              className="sr-only"
+                            />
+                            <span>{type.icon}</span>
+                            {type.name}
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+                {isPropertyLevel && (config.legend?.statuses || config.legend?.itemTypeIds) && (
+                  <button
+                    type="button"
+                    onClick={() => onChange({ ...config, legend: undefined })}
+                    className="text-[10px] text-amber-700 underline hover:no-underline"
+                  >
+                    Reset legend to org default
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper && npx tsc --noEmit 2>&1 | tail -10`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/admin/MapDisplayConfigEditor.tsx
+git commit -m "feat: add MapDisplayConfigEditor admin component"
+```
+
+---
+
+### Task 6: Add Map Display Config to Org Settings
+
+**Files:**
+- Modify: `src/app/admin/settings/actions.ts`
+- Modify: `src/app/admin/settings/page.tsx`
+
+- [ ] **Step 1: Add map_display_config to org settings actions**
+
+In `src/app/admin/settings/actions.ts`:
+
+1. Add to the `OrgSettings` interface:
+
+```typescript
+  map_display_config: unknown | null;
+```
+
+2. Add `map_display_config` to the select query in `getOrgSettings` (line 28):
+
+Change:
+```typescript
+    .select('id, name, slug, tagline, pwa_name, logo_url, favicon_url, theme, subscription_tier, subscription_status')
+```
+To:
+```typescript
+    .select('id, name, slug, tagline, pwa_name, logo_url, favicon_url, theme, subscription_tier, subscription_status, map_display_config')
+```
+
+3. Add `map_display_config` to the return data object:
+
+```typescript
+      map_display_config: data.map_display_config,
+```
+
+4. Add to the `OrgSettingsUpdates` interface:
+
+```typescript
+  map_display_config?: unknown;
+```
+
+5. Add to the payload building in `updateOrgSettings`:
+
+```typescript
+  if (updates.map_display_config !== undefined) payload.map_display_config = updates.map_display_config;
+```
+
+- [ ] **Step 2: Add Map Display section to org settings page**
+
+In `src/app/admin/settings/page.tsx`:
+
+1. Add imports at top:
+
+```typescript
+import MapDisplayConfigEditor from '@/components/admin/MapDisplayConfigEditor';
+import type { MapDisplayConfig } from '@/lib/config/map-display';
+import type { ItemType } from '@/lib/types';
+```
+
+2. Add state for map display config and item types (after existing state declarations around line 60):
+
+```typescript
+  const [mapDisplayConfig, setMapDisplayConfig] = useState<MapDisplayConfig | null>(null);
+```
+
+3. Add a query to fetch item types for the legend editor (after the existing settings query):
+
+```typescript
+  const { data: itemTypes = [] } = useQuery({
+    queryKey: ['admin', 'itemTypes'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data: org } = await supabase.from('orgs').select('id').limit(1).single();
+      if (!org) return [];
+      const { data } = await supabase.from('item_types').select('*').eq('org_id', org.id).order('name');
+      return (data ?? []) as ItemType[];
+    },
+  });
+```
+
+4. Add import for createClient at top (if not already):
+
+```typescript
+import { createClient } from '@/lib/supabase/client';
+```
+
+5. Initialize mapDisplayConfig from settings (add to the existing `useEffect` that initializes form state, after `setThemeJson(...)`):
+
+```typescript
+      setMapDisplayConfig(settings.map_display_config as MapDisplayConfig | null);
+```
+
+6. Include mapDisplayConfig in the save handler (in `handleSave`, add to the `updates` object building, before `setSaving(true)`):
+
+```typescript
+    const currentMapConfig = JSON.stringify(settings?.map_display_config ?? null);
+    const newMapConfig = JSON.stringify(mapDisplayConfig);
+    if (newMapConfig !== currentMapConfig) updates.map_display_config = mapDisplayConfig;
+```
+
+7. Add the Map Display section in the form, between the Appearance section and the Subscription section:
+
+```tsx
+        {/* Map Display section */}
+        <section className="card space-y-5">
+          <h2 className="font-heading text-lg font-semibold text-forest-dark">
+            Map Display
+          </h2>
+          <p className="text-xs text-sage">
+            Configure which controls appear on the map. These defaults apply to all properties unless overridden.
+          </p>
+          <MapDisplayConfigEditor
+            value={mapDisplayConfig}
+            onChange={setMapDisplayConfig}
+            itemTypes={itemTypes}
+          />
+        </section>
+```
+
+- [ ] **Step 3: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper && npx tsc --noEmit 2>&1 | tail -10`
+Expected: No type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/settings/actions.ts src/app/admin/settings/page.tsx
+git commit -m "feat: add map display config to org settings admin"
+```
+
+---
+
+### Task 7: Add Map Display Config to Property Settings
+
+**Files:**
+- Modify: `src/app/admin/properties/[slug]/settings/actions.ts`
+- Modify: `src/app/admin/properties/[slug]/settings/page.tsx`
+
+- [ ] **Step 1: Add map_display_config to property settings actions**
+
+In `src/app/admin/properties/[slug]/settings/actions.ts`, add `map_display_config` to `PROPERTY_KEY_TO_COLUMN`:
+
+```typescript
+  map_display_config: 'map_display_config',
+```
+
+- [ ] **Step 2: Add Map Display section to the Appearance tab**
+
+In `src/app/admin/properties/[slug]/settings/page.tsx`:
+
+1. Add imports at top:
+
+```typescript
+import MapDisplayConfigEditor from '@/components/admin/MapDisplayConfigEditor';
+import type { MapDisplayConfig } from '@/lib/config/map-display';
+import type { ItemType } from '@/lib/types';
+```
+
+2. Add a query to fetch item types (inside `SettingsPage`, after the existing `orgId` query):
+
+```typescript
+  const { data: itemTypes = [] } = useQuery({
+    queryKey: ['admin', 'itemTypes', orgId],
+    queryFn: async () => {
+      if (!orgId) return [];
+      const supabase = createClient();
+      const { data } = await supabase.from('item_types').select('*').eq('org_id', orgId).order('name');
+      return (data ?? []) as ItemType[];
+    },
+    enabled: !!orgId,
+  });
+```
+
+3. Add queries for org and property map_display_config (after the itemTypes query):
+
+```typescript
+  const { data: orgMapDisplayConfig } = useQuery({
+    queryKey: ['admin', 'orgMapDisplayConfig'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data: org } = await supabase.from('orgs').select('map_display_config').limit(1).single();
+      return (org?.map_display_config as MapDisplayConfig | null) ?? null;
+    },
+  });
+
+  const { data: propertyMapDisplayConfig, refetch: refetchPropertyConfig } = useQuery({
+    queryKey: ['admin', 'property', slug, 'mapDisplayConfig'],
+    queryFn: async () => {
+      if (!propertyId) return null;
+      const supabase = createClient();
+      const { data } = await supabase.from('properties').select('map_display_config').eq('id', propertyId).single();
+      return (data?.map_display_config as MapDisplayConfig | null) ?? null;
+    },
+    enabled: !!propertyId,
+  });
+```
+
+4. Add state for the editor (after existing state declarations):
+
+```typescript
+  const [mapDisplayConfig, setMapDisplayConfig] = useState<MapDisplayConfig | null>(null);
+  const [mapDisplayInitialized, setMapDisplayInitialized] = useState(false);
+```
+
+5. Sync the property config into local state:
+
+```typescript
+  useEffect(() => {
+    if (propertyMapDisplayConfig !== undefined && !mapDisplayInitialized) {
+      setMapDisplayConfig(propertyMapDisplayConfig);
+      setMapDisplayInitialized(true);
+    }
+  }, [propertyMapDisplayConfig, mapDisplayInitialized]);
+```
+
+6. In the `{activeTab === 'appearance' && (...)}` block, add the Map Display section after the existing `<AppearanceTab>` and logo uploader, but still inside the `<div className="space-y-8">`:
+
+```tsx
+          <section className="card space-y-5">
+            <h2 className="font-heading text-lg font-semibold text-forest-dark">
+              Map Display
+            </h2>
+            <MapDisplayConfigEditor
+              value={mapDisplayConfig}
+              onChange={setMapDisplayConfig}
+              itemTypes={itemTypes}
+              orgDefaults={orgMapDisplayConfig}
+            />
+            <button
+              type="button"
+              disabled={saving}
+              onClick={async () => {
+                await handleSave([{ key: 'map_display_config', value: mapDisplayConfig }]);
+                refetchPropertyConfig();
+              }}
+              className="btn-primary"
+            >
+              {saving ? 'Saving...' : 'Save Map Display'}
+            </button>
+          </section>
+```
+
+- [ ] **Step 3: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper && npx tsc --noEmit 2>&1 | tail -10`
+Expected: No type errors.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd /Users/patrick/birdhousemapper && npx vitest run 2>&1 | tail -15`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/settings/actions.ts src/app/admin/properties/[slug]/settings/page.tsx
+git commit -m "feat: add map display config to property settings admin"
+```
+
+---
+
+### Task 8: Manual Verification
+
+- [ ] **Step 1: Start dev server and verify**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run dev`
+
+Verify manually:
+1. Visit org settings (`/admin/settings`) — see new Map Display section with 5 toggle cards
+2. Toggle legend off → save → visit map page → legend should be hidden
+3. Toggle back on, expand legend config, uncheck a status → save → legend should filter
+4. Visit property settings (`/admin/properties/[slug]/settings`) → Appearance tab → see Map Display with "Org default" labels
+5. Override a control at property level → see yellow highlight + "Reset" link
+6. Click Reset → value reverts to org default
+
+- [ ] **Step 2: Run build to check for issues**
+
+Run: `cd /Users/patrick/birdhousemapper && npm run build 2>&1 | tail -20`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Final commit if any cleanup was needed**
+
+```bash
+git add -A
+git commit -m "chore: map display config cleanup"
+```

--- a/docs/superpowers/plans/2026-04-05-parcel-lookup.md
+++ b/docs/superpowers/plans/2026-04-05-parcel-lookup.md
@@ -1,0 +1,2129 @@
+# Parcel Boundary Lookup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically look up US parcel boundaries from public ArcGIS sources given an address, and save results as geo layers.
+
+**Architecture:** Server-side pipeline: Census Geocoder → TIGERweb FIPS → ArcGIS auto-discovery → parcel query → GeoJSON results stored as geo layers via existing `createGeoLayer()`. A global `county_gis_registry` table caches discovered ArcGIS endpoints. The UI is a state-machine component (idle → searching → found → confirmed).
+
+**Tech Stack:** Next.js 14 server actions, Supabase PostgreSQL, Leaflet/react-leaflet, Turf.js, Census Geocoder API, ArcGIS REST API.
+
+**Spec:** `docs/superpowers/specs/2026-04-05-parcel-lookup-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `src/lib/geo/census-client.ts` | Census Geocoder (address→lat/lng) and TIGERweb (lat/lng→FIPS) API clients |
+| `src/lib/geo/field-matcher.ts` | Heuristic matching of ArcGIS field names to canonical parcel fields |
+| `src/lib/geo/arcgis-client.ts` | ArcGIS Hub search, FeatureServer metadata, and parcel queries |
+| `src/lib/geo/parcel-lookup.ts` | Orchestrator: chains census→FIPS→discovery→query into one pipeline |
+| `src/app/admin/properties/[slug]/parcel-lookup/actions.ts` | Server actions: `lookupParcel`, `confirmParcelSelection` |
+| `src/app/admin/properties/[slug]/parcel-lookup/page.tsx` | Page wrapper for parcel lookup |
+| `src/components/geo/ParcelLookup.tsx` | Main UI component (state machine) |
+| `src/components/geo/ParcelPreviewMap.tsx` | Leaflet map showing parcel candidates |
+| `supabase/migrations/034_county_gis_registry.sql` | `county_gis_registry` table |
+| `supabase/migrations/035_parcel_lookups.sql` | `parcel_lookups` audit table |
+| `supabase/migrations/036_geo_layer_source_parcel.sql` | Add `'parcel_lookup'` to source check constraint |
+| `src/__tests__/geo/census-client.test.ts` | Census client unit tests |
+| `src/__tests__/geo/field-matcher.test.ts` | Field matcher unit tests |
+| `src/__tests__/geo/arcgis-client.test.ts` | ArcGIS client unit tests |
+| `src/__tests__/geo/parcel-lookup.test.ts` | Pipeline orchestrator unit tests |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `src/lib/geo/types.ts` | Add `ParcelCandidate`, `ParcelLookupResult`, `CountyGISConfig`, `FieldMap` types; add `'parcel_lookup'` to `GeoLayerSource` |
+| `src/app/admin/properties/[slug]/layout.tsx` | Add "Parcel Lookup" nav item |
+| `src/app/admin/geo-layers/actions.ts` | Update `CreateGeoLayerInput.source` type to include `'parcel_lookup'` |
+
+---
+
+## Task 1: Database Migrations
+
+**Files:**
+- Create: `supabase/migrations/034_county_gis_registry.sql`
+- Create: `supabase/migrations/035_parcel_lookups.sql`
+- Create: `supabase/migrations/036_geo_layer_source_parcel.sql`
+
+- [ ] **Step 1: Create county_gis_registry migration**
+
+```sql
+-- supabase/migrations/034_county_gis_registry.sql
+CREATE TABLE county_gis_registry (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  fips text UNIQUE NOT NULL,
+  county_name text NOT NULL,
+  state text NOT NULL,
+  parcel_layer_url text NOT NULL,
+  address_layer_url text,
+  field_map jsonb NOT NULL DEFAULT '{}',
+  discovery_method text NOT NULL DEFAULT 'auto' CHECK (discovery_method IN ('manual', 'auto')),
+  confidence text NOT NULL DEFAULT 'low' CHECK (confidence IN ('high', 'medium', 'low')),
+  last_verified_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_county_gis_registry_fips ON county_gis_registry (fips);
+CREATE INDEX idx_county_gis_registry_state ON county_gis_registry (state);
+```
+
+- [ ] **Step 2: Create parcel_lookups migration**
+
+```sql
+-- supabase/migrations/035_parcel_lookups.sql
+CREATE TABLE parcel_lookups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES orgs(id),
+  property_id uuid NOT NULL REFERENCES properties(id),
+  input_address text,
+  input_lat numeric,
+  input_lng numeric,
+  county_fips text,
+  source text NOT NULL DEFAULT 'county_arcgis',
+  status text NOT NULL CHECK (status IN ('success', 'partial', 'not_found', 'error')),
+  parcels_found integer NOT NULL DEFAULT 0,
+  cost_cents integer NOT NULL DEFAULT 0,
+  result_geo_layer_id uuid REFERENCES geo_layers(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_parcel_lookups_org_id ON parcel_lookups (org_id);
+CREATE INDEX idx_parcel_lookups_property_id ON parcel_lookups (property_id);
+
+ALTER TABLE parcel_lookups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Org members can view parcel lookups"
+  ON parcel_lookups FOR SELECT
+  TO authenticated
+  USING (org_id IN (
+    SELECT org_id FROM org_memberships WHERE user_id = auth.uid() AND status = 'active'
+  ));
+
+CREATE POLICY "Org admins can insert parcel lookups"
+  ON parcel_lookups FOR INSERT
+  TO authenticated
+  WITH CHECK (org_id IN (
+    SELECT om.org_id FROM org_memberships om
+    JOIN roles r ON r.id = om.role_id
+    WHERE om.user_id = auth.uid() AND om.status = 'active'
+    AND r.base_role IN ('owner', 'admin', 'staff')
+  ));
+```
+
+- [ ] **Step 3: Create source constraint migration**
+
+```sql
+-- supabase/migrations/036_geo_layer_source_parcel.sql
+ALTER TABLE geo_layers DROP CONSTRAINT IF EXISTS geo_layers_source_check;
+ALTER TABLE geo_layers ADD CONSTRAINT geo_layers_source_check
+  CHECK (source IN ('manual', 'ai', 'discovered', 'parcel_lookup'));
+```
+
+- [ ] **Step 4: Run migrations**
+
+Run: `npx supabase db push` (or apply via your local Supabase workflow)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/034_county_gis_registry.sql supabase/migrations/035_parcel_lookups.sql supabase/migrations/036_geo_layer_source_parcel.sql
+git commit -m "feat(parcel-lookup): add county_gis_registry and parcel_lookups tables (#205)"
+```
+
+---
+
+## Task 2: Types
+
+**Files:**
+- Modify: `src/lib/geo/types.ts`
+- Modify: `src/app/admin/geo-layers/actions.ts:20` (source type)
+
+- [ ] **Step 1: Add parcel lookup types to `src/lib/geo/types.ts`**
+
+Add at the end of the file, after the `FeatureGroup` interface (after line 89):
+
+```typescript
+// --- Parcel Lookup Types ---
+
+export type GeoLayerSource = 'manual' | 'ai' | 'discovered' | 'parcel_lookup';
+
+export interface FieldMap {
+  parcel_id: string;
+  owner_name?: string;
+  site_address?: string;
+  house_number?: string;
+  street_name?: string;
+  acres?: string;
+  address_link_field?: string;
+}
+
+export interface CountyGISConfig {
+  id: string;
+  fips: string;
+  county_name: string;
+  state: string;
+  parcel_layer_url: string;
+  address_layer_url: string | null;
+  field_map: FieldMap;
+  discovery_method: 'manual' | 'auto';
+  confidence: 'high' | 'medium' | 'low';
+  last_verified_at: string | null;
+}
+
+export interface ParcelCandidate {
+  apn: string;
+  geometry: GeoJSON.Polygon | GeoJSON.MultiPolygon;
+  acres: number | null;
+  owner_of_record: string | null;
+  site_address: string | null;
+  source_url: string;
+}
+
+export type ParcelLookupStatus = 'found' | 'multiple' | 'not_found' | 'error';
+
+export interface ParcelLookupResult {
+  status: ParcelLookupStatus;
+  parcels: ParcelCandidate[];
+  source: 'county_arcgis' | null;
+  county_fips: string | null;
+  county_name: string | null;
+  error_message?: string;
+}
+```
+
+Note: this redefines `GeoLayerSource` — update the existing definition on line 6 to include `'parcel_lookup'`:
+
+Change line 6 from:
+```typescript
+export type GeoLayerSource = 'manual' | 'ai' | 'discovered';
+```
+to:
+```typescript
+export type GeoLayerSource = 'manual' | 'ai' | 'discovered' | 'parcel_lookup';
+```
+
+And do NOT add the duplicate `GeoLayerSource` in the new types block — just add `FieldMap`, `CountyGISConfig`, `ParcelCandidate`, `ParcelLookupStatus`, and `ParcelLookupResult`.
+
+- [ ] **Step 2: Update CreateGeoLayerInput source type in `src/app/admin/geo-layers/actions.ts`**
+
+Change line 20 from:
+```typescript
+  source?: 'manual' | 'ai' | 'discovered';
+```
+to:
+```typescript
+  source?: 'manual' | 'ai' | 'discovered' | 'parcel_lookup';
+```
+
+- [ ] **Step 3: Run type check**
+
+Run: `npm run type-check`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/geo/types.ts src/app/admin/geo-layers/actions.ts
+git commit -m "feat(parcel-lookup): add parcel lookup types and extend GeoLayerSource (#205)"
+```
+
+---
+
+## Task 3: Census Client (Geocoder + FIPS)
+
+**Files:**
+- Create: `src/lib/geo/census-client.ts`
+- Create: `src/__tests__/geo/census-client.test.ts`
+
+- [ ] **Step 1: Write failing tests for census client**
+
+Create `src/__tests__/geo/census-client.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { geocodeAddress, resolveCountyFips } from '@/lib/geo/census-client';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('geocodeAddress', () => {
+  it('returns lat/lng for a valid address', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: {
+          addressMatches: [
+            {
+              coordinates: { x: -122.555, y: 47.634 },
+              matchedAddress: '7550 FLETCHER BAY RD NE, BAINBRIDGE ISLAND, WA, 98110',
+            },
+          ],
+        },
+      }),
+    });
+
+    const result = await geocodeAddress('7550 Fletcher Bay Rd NE, Bainbridge Island, WA');
+    expect(result).toEqual({
+      lat: 47.634,
+      lng: -122.555,
+      matchedAddress: '7550 FLETCHER BAY RD NE, BAINBRIDGE ISLAND, WA, 98110',
+    });
+  });
+
+  it('returns null when no matches found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: { addressMatches: [] },
+      }),
+    });
+
+    const result = await geocodeAddress('nonexistent address');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on fetch error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    const result = await geocodeAddress('some address');
+    expect(result).toBeNull();
+  });
+});
+
+describe('resolveCountyFips', () => {
+  it('returns county FIPS and name for valid coordinates', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: {
+          geographies: {
+            Counties: [
+              { GEOID: '53035', NAME: 'Kitsap', STATE: '53', COUNTY: '035' },
+            ],
+          },
+        },
+      }),
+    });
+
+    const result = await resolveCountyFips(47.634, -122.555);
+    expect(result).toEqual({
+      fips: '53035',
+      county_name: 'Kitsap',
+      state_fips: '53',
+    });
+  });
+
+  it('returns null when no county found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: { geographies: { Counties: [] } },
+      }),
+    });
+
+    const result = await resolveCountyFips(0, 0);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on fetch error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    const result = await resolveCountyFips(47.634, -122.555);
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/__tests__/geo/census-client.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement census client**
+
+Create `src/lib/geo/census-client.ts`:
+
+```typescript
+const CENSUS_GEOCODER_BASE = 'https://geocoding.geo.census.gov/geocoder';
+
+export interface GeocodeResult {
+  lat: number;
+  lng: number;
+  matchedAddress: string;
+}
+
+export interface CountyFipsResult {
+  fips: string;
+  county_name: string;
+  state_fips: string;
+}
+
+export async function geocodeAddress(address: string): Promise<GeocodeResult | null> {
+  try {
+    const params = new URLSearchParams({
+      address,
+      benchmark: 'Public_AR_Current',
+      format: 'json',
+    });
+    const res = await fetch(`${CENSUS_GEOCODER_BASE}/locations/onelineaddress?${params}`);
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const matches = data?.result?.addressMatches;
+    if (!matches || matches.length === 0) return null;
+
+    const match = matches[0];
+    return {
+      lat: match.coordinates.y,
+      lng: match.coordinates.x,
+      matchedAddress: match.matchedAddress,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveCountyFips(
+  lat: number,
+  lng: number
+): Promise<CountyFipsResult | null> {
+  try {
+    const params = new URLSearchParams({
+      x: String(lng),
+      y: String(lat),
+      benchmark: 'Public_AR_Current',
+      vintage: 'Current_Current',
+      layers: 'Counties',
+      format: 'json',
+    });
+    const res = await fetch(`${CENSUS_GEOCODER_BASE}/geographies/coordinates?${params}`);
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const counties = data?.result?.geographies?.Counties;
+    if (!counties || counties.length === 0) return null;
+
+    const county = counties[0];
+    return {
+      fips: county.GEOID,
+      county_name: county.NAME,
+      state_fips: county.STATE,
+    };
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- src/__tests__/geo/census-client.test.ts`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/geo/census-client.ts src/__tests__/geo/census-client.test.ts
+git commit -m "feat(parcel-lookup): add Census geocoder and FIPS client (#205)"
+```
+
+---
+
+## Task 4: Field Matcher
+
+**Files:**
+- Create: `src/lib/geo/field-matcher.ts`
+- Create: `src/__tests__/geo/field-matcher.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/__tests__/geo/field-matcher.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { matchFields, type FieldMatchResult } from '@/lib/geo/field-matcher';
+
+describe('matchFields', () => {
+  it('matches Kitsap County field names', () => {
+    const fields = [
+      'OBJECTID', 'APN', 'RP_ACCT_ID', 'Shape__Area', 'Shape__Length',
+      'CONTACT_NAME', 'SITE_ADDR', 'POLY_ACRES', 'ZONE_CODE',
+    ];
+    const result = matchFields(fields);
+    expect(result.field_map.parcel_id).toBe('APN');
+    expect(result.field_map.owner_name).toBe('CONTACT_NAME');
+    expect(result.field_map.site_address).toBe('SITE_ADDR');
+    expect(result.field_map.acres).toBe('POLY_ACRES');
+    expect(result.confidence).toBe('high');
+  });
+
+  it('matches King County field names', () => {
+    const fields = [
+      'OBJECTID', 'PIN', 'MAJOR', 'MINOR', 'TAXPAYER_NAME',
+      'PROP_ADDR', 'GIS_ACRES', 'Shape',
+    ];
+    const result = matchFields(fields);
+    expect(result.field_map.parcel_id).toBe('PIN');
+    expect(result.field_map.owner_name).toBe('TAXPAYER_NAME');
+    expect(result.field_map.site_address).toBe('PROP_ADDR');
+    expect(result.field_map.acres).toBe('GIS_ACRES');
+    expect(result.confidence).toBe('high');
+  });
+
+  it('returns low confidence when only parcel_id matched', () => {
+    const fields = ['OBJECTID', 'PARCEL_NUM', 'Shape', 'GlobalID'];
+    const result = matchFields(fields);
+    expect(result.field_map.parcel_id).toBe('PARCEL_NUM');
+    expect(result.confidence).toBe('low');
+  });
+
+  it('returns medium confidence with parcel_id + one other', () => {
+    const fields = ['OBJECTID', 'APN', 'OWNER', 'Shape'];
+    const result = matchFields(fields);
+    expect(result.field_map.parcel_id).toBe('APN');
+    expect(result.field_map.owner_name).toBe('OWNER');
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('returns null when no parcel_id field found', () => {
+    const fields = ['OBJECTID', 'Shape', 'GlobalID', 'NAME'];
+    const result = matchFields(fields);
+    expect(result).toBeNull();
+  });
+
+  it('handles case-insensitive matching', () => {
+    const fields = ['objectid', 'apn', 'owner_name', 'site_addr', 'acres'];
+    const result = matchFields(fields);
+    expect(result).not.toBeNull();
+    expect(result!.field_map.parcel_id).toBe('apn');
+  });
+
+  it('prefers exact matches over substring matches', () => {
+    // APN is an exact match for parcel_id; APN_SUFFIX should not steal it
+    const fields = ['APN', 'APN_SUFFIX', 'OWNER'];
+    const result = matchFields(fields);
+    expect(result!.field_map.parcel_id).toBe('APN');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/__tests__/geo/field-matcher.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement field matcher**
+
+Create `src/lib/geo/field-matcher.ts`:
+
+```typescript
+import type { FieldMap } from './types';
+
+export interface FieldMatchResult {
+  field_map: FieldMap;
+  confidence: 'high' | 'medium' | 'low';
+  matched_count: number;
+}
+
+interface PatternEntry {
+  canonical: keyof FieldMap;
+  exact: string[];    // exact match (case-insensitive)
+  prefix: string[];   // prefix match (case-insensitive)
+}
+
+const PATTERNS: PatternEntry[] = [
+  {
+    canonical: 'parcel_id',
+    exact: ['APN', 'PIN', 'PARCEL_ID', 'PARCEL_NO', 'PARCEL_NUM', 'ACCT_ID', 'RP_ACCT_ID', 'TAX_ID', 'TAXLOT_ID', 'PARCELID', 'PARCEL_NUMBER'],
+    prefix: ['PARCEL', 'TAX_PARCEL'],
+  },
+  {
+    canonical: 'owner_name',
+    exact: ['OWNER', 'OWNER_NAME', 'OWN_NAME', 'CONTACT_NAME', 'TAXPAYER', 'TAXPAYER_NAME', 'OWNERNAME'],
+    prefix: ['OWNER', 'OWN_'],
+  },
+  {
+    canonical: 'site_address',
+    exact: ['SITE_ADDR', 'SITEADDRESS', 'SITE_ADDRESS', 'PROP_ADDR', 'ADDRESS', 'FULL_ADDR', 'FULL_ADDRESS', 'PROPADDR'],
+    prefix: ['SITE_ADDR', 'PROP_ADDR', 'FULL_ADDR'],
+  },
+  {
+    canonical: 'house_number',
+    exact: ['HOUSE_NO', 'HOUSE_NUM', 'ADDR_NUM', 'STREET_NO', 'HOUSE_NUMBER', 'ADDNO', 'ADDR_NO'],
+    prefix: ['HOUSE_N', 'ADDR_N'],
+  },
+  {
+    canonical: 'street_name',
+    exact: ['STREET_NAME', 'STREET', 'STREET_NM', 'ST_NAME', 'STREETNAME'],
+    prefix: ['STREET_N', 'ST_NAME'],
+  },
+  {
+    canonical: 'acres',
+    exact: ['ACRES', 'POLY_ACRES', 'GIS_ACRES', 'AREA_ACRES', 'CALC_ACRES', 'ACREAGE', 'TOTAL_ACRES'],
+    prefix: [],
+  },
+];
+
+export function matchFields(fields: string[]): FieldMatchResult | null {
+  const fieldMap: Partial<FieldMap> = {};
+  const usedFields = new Set<string>();
+
+  for (const pattern of PATTERNS) {
+    const match = findBestMatch(fields, pattern, usedFields);
+    if (match) {
+      fieldMap[pattern.canonical] = match;
+      usedFields.add(match.toUpperCase());
+    }
+  }
+
+  if (!fieldMap.parcel_id) return null;
+
+  // Count non-parcel_id matches
+  const otherMatches = Object.keys(fieldMap).filter((k) => k !== 'parcel_id').length;
+
+  let confidence: 'high' | 'medium' | 'low';
+  if (otherMatches >= 2) {
+    confidence = 'high';
+  } else if (otherMatches === 1) {
+    confidence = 'medium';
+  } else {
+    confidence = 'low';
+  }
+
+  return {
+    field_map: { parcel_id: fieldMap.parcel_id, ...fieldMap } as FieldMap,
+    confidence,
+    matched_count: otherMatches + 1,
+  };
+}
+
+function findBestMatch(
+  fields: string[],
+  pattern: PatternEntry,
+  usedFields: Set<string>
+): string | null {
+  // 1. Try exact matches first (case-insensitive)
+  for (const exact of pattern.exact) {
+    const found = fields.find(
+      (f) => f.toUpperCase() === exact.toUpperCase() && !usedFields.has(f.toUpperCase())
+    );
+    if (found) return found;
+  }
+
+  // 2. Try prefix matches (case-insensitive)
+  for (const prefix of pattern.prefix) {
+    const found = fields.find(
+      (f) => f.toUpperCase().startsWith(prefix.toUpperCase()) && !usedFields.has(f.toUpperCase())
+    );
+    if (found) return found;
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- src/__tests__/geo/field-matcher.test.ts`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/geo/field-matcher.ts src/__tests__/geo/field-matcher.test.ts
+git commit -m "feat(parcel-lookup): add heuristic ArcGIS field matcher (#205)"
+```
+
+---
+
+## Task 5: ArcGIS Client
+
+**Files:**
+- Create: `src/lib/geo/arcgis-client.ts`
+- Create: `src/__tests__/geo/arcgis-client.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/__tests__/geo/arcgis-client.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  searchArcGISHub,
+  fetchFeatureServerFields,
+  queryParcelsByPoint,
+  queryParcelsByEnvelope,
+} from '@/lib/geo/arcgis-client';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('searchArcGISHub', () => {
+  it('returns matching feature service URLs', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            title: 'Tax Parcel Polygons',
+            url: 'https://services6.arcgis.com/abc/arcgis/rest/services/Tax_Parcels/FeatureServer',
+            type: 'Feature Service',
+          },
+          {
+            title: 'Zoning Districts',
+            url: 'https://services6.arcgis.com/abc/arcgis/rest/services/Zoning/FeatureServer',
+            type: 'Feature Service',
+          },
+        ],
+      }),
+    });
+
+    const results = await searchArcGISHub('Kitsap', 'WA');
+    // Only parcel-related results returned
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe('Tax Parcel Polygons');
+  });
+
+  it('returns empty array on error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    const results = await searchArcGISHub('Test', 'WA');
+    expect(results).toEqual([]);
+  });
+});
+
+describe('fetchFeatureServerFields', () => {
+  it('returns field names from FeatureServer metadata', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        fields: [
+          { name: 'APN', type: 'esriFieldTypeString' },
+          { name: 'OWNER', type: 'esriFieldTypeString' },
+          { name: 'Shape', type: 'esriFieldTypeGeometry' },
+        ],
+        geometryType: 'esriGeometryPolygon',
+      }),
+    });
+
+    const result = await fetchFeatureServerFields(
+      'https://services6.arcgis.com/abc/arcgis/rest/services/Parcels/FeatureServer/0'
+    );
+    expect(result?.fields).toEqual(['APN', 'OWNER', 'Shape']);
+    expect(result?.geometryType).toBe('esriGeometryPolygon');
+  });
+
+  it('returns null on error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('fail'));
+    const result = await fetchFeatureServerFields('https://bad-url');
+    expect(result).toBeNull();
+  });
+});
+
+describe('queryParcelsByPoint', () => {
+  it('returns GeoJSON features for a point query', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: { APN: '1311562', POLY_ACRES: 2.96 },
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[[-122.56, 47.63], [-122.55, 47.63], [-122.55, 47.64], [-122.56, 47.64], [-122.56, 47.63]]],
+            },
+          },
+        ],
+      }),
+    });
+
+    const features = await queryParcelsByPoint(
+      'https://services6.arcgis.com/abc/arcgis/rest/services/Parcels/FeatureServer/0',
+      47.634,
+      -122.555
+    );
+    expect(features.length).toBe(1);
+    expect(features[0].properties?.APN).toBe('1311562');
+  });
+
+  it('returns empty array when no parcels found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        type: 'FeatureCollection',
+        features: [],
+      }),
+    });
+
+    const features = await queryParcelsByPoint(
+      'https://example.com/FeatureServer/0',
+      0,
+      0
+    );
+    expect(features).toEqual([]);
+  });
+});
+
+describe('queryParcelsByEnvelope', () => {
+  it('returns features within bounding box filtered by where clause', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: { APN: '1311273', CONTACT_NAME: 'ROLLING BAY LAND COMPANY' },
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[[-122.56, 47.63], [-122.54, 47.63], [-122.54, 47.64], [-122.56, 47.64], [-122.56, 47.63]]],
+            },
+          },
+        ],
+      }),
+    });
+
+    const features = await queryParcelsByEnvelope(
+      'https://services6.arcgis.com/abc/arcgis/rest/services/Parcels/FeatureServer/0',
+      [-122.562, 47.628, -122.548, 47.640],
+      "CONTACT_NAME LIKE '%ROLLING BAY%'"
+    );
+    expect(features.length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/__tests__/geo/arcgis-client.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement ArcGIS client**
+
+Create `src/lib/geo/arcgis-client.ts`:
+
+```typescript
+const ARCGIS_HUB_SEARCH = 'https://www.arcgis.com/sharing/rest/search';
+
+const PARCEL_KEYWORDS = ['parcel', 'tax', 'lot', 'cadastral', 'assessor'];
+
+export interface HubSearchResult {
+  title: string;
+  url: string;
+}
+
+export interface FeatureServerMeta {
+  fields: string[];
+  geometryType: string;
+}
+
+export async function searchArcGISHub(
+  countyName: string,
+  state: string
+): Promise<HubSearchResult[]> {
+  try {
+    const query = `${countyName} ${state} parcel polygon`;
+    const params = new URLSearchParams({
+      q: query,
+      type: 'Feature Service',
+      num: '20',
+      f: 'json',
+    });
+    const res = await fetch(`${ARCGIS_HUB_SEARCH}?${params}`);
+    if (!res.ok) return [];
+
+    const data = await res.json();
+    const results: HubSearchResult[] = (data.results ?? [])
+      .filter((r: { title: string; type: string }) => {
+        const titleLower = r.title.toLowerCase();
+        return PARCEL_KEYWORDS.some((kw) => titleLower.includes(kw));
+      })
+      .map((r: { title: string; url: string }) => ({
+        title: r.title,
+        url: r.url,
+      }));
+
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchFeatureServerFields(
+  layerUrl: string
+): Promise<FeatureServerMeta | null> {
+  try {
+    const res = await fetch(`${layerUrl}?f=json`);
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    if (!data.fields) return null;
+
+    return {
+      fields: data.fields.map((f: { name: string }) => f.name),
+      geometryType: data.geometryType ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function queryParcelsByPoint(
+  layerUrl: string,
+  lat: number,
+  lng: number
+): Promise<GeoJSON.Feature[]> {
+  try {
+    const params = new URLSearchParams({
+      geometry: `${lng},${lat}`,
+      geometryType: 'esriGeometryPoint',
+      spatialRel: 'esriSpatialRelIntersects',
+      outFields: '*',
+      outSR: '4326',
+      f: 'geojson',
+    });
+    const res = await fetch(`${layerUrl}/query?${params}`);
+    if (!res.ok) return [];
+
+    const data = await res.json();
+    return data.features ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function queryParcelsByEnvelope(
+  layerUrl: string,
+  bbox: [number, number, number, number],
+  where?: string
+): Promise<GeoJSON.Feature[]> {
+  try {
+    const [minLng, minLat, maxLng, maxLat] = bbox;
+    const params = new URLSearchParams({
+      geometry: `${minLng},${minLat},${maxLng},${maxLat}`,
+      geometryType: 'esriGeometryEnvelope',
+      spatialRel: 'esriSpatialRelIntersects',
+      where: where ?? '1=1',
+      outFields: '*',
+      outSR: '4326',
+      f: 'geojson',
+    });
+    const res = await fetch(`${layerUrl}/query?${params}`);
+    if (!res.ok) return [];
+
+    const data = await res.json();
+    return data.features ?? [];
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- src/__tests__/geo/arcgis-client.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/geo/arcgis-client.ts src/__tests__/geo/arcgis-client.test.ts
+git commit -m "feat(parcel-lookup): add ArcGIS Hub search and query client (#205)"
+```
+
+---
+
+## Task 6: Parcel Lookup Pipeline Orchestrator
+
+**Files:**
+- Create: `src/lib/geo/parcel-lookup.ts`
+- Create: `src/__tests__/geo/parcel-lookup.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/__tests__/geo/parcel-lookup.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runParcelLookup } from '@/lib/geo/parcel-lookup';
+
+// Mock all dependencies
+vi.mock('@/lib/geo/census-client', () => ({
+  geocodeAddress: vi.fn(),
+  resolveCountyFips: vi.fn(),
+}));
+
+vi.mock('@/lib/geo/arcgis-client', () => ({
+  searchArcGISHub: vi.fn(),
+  fetchFeatureServerFields: vi.fn(),
+  queryParcelsByPoint: vi.fn(),
+  queryParcelsByEnvelope: vi.fn(),
+}));
+
+vi.mock('@/lib/geo/field-matcher', () => ({
+  matchFields: vi.fn(),
+}));
+
+import { geocodeAddress, resolveCountyFips } from '@/lib/geo/census-client';
+import { searchArcGISHub, fetchFeatureServerFields, queryParcelsByPoint, queryParcelsByEnvelope } from '@/lib/geo/arcgis-client';
+import { matchFields } from '@/lib/geo/field-matcher';
+
+const mockGeocodeAddress = vi.mocked(geocodeAddress);
+const mockResolveCountyFips = vi.mocked(resolveCountyFips);
+const mockSearchArcGISHub = vi.mocked(searchArcGISHub);
+const mockFetchFields = vi.mocked(fetchFeatureServerFields);
+const mockQueryByPoint = vi.mocked(queryParcelsByPoint);
+const mockQueryByEnvelope = vi.mocked(queryParcelsByEnvelope);
+const mockMatchFields = vi.mocked(matchFields);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const MOCK_PARCEL_FEATURE: GeoJSON.Feature = {
+  type: 'Feature',
+  properties: { APN: '1311562', POLY_ACRES: 2.96, CONTACT_NAME: 'SMITH' },
+  geometry: {
+    type: 'Polygon',
+    coordinates: [[[-122.56, 47.63], [-122.55, 47.63], [-122.55, 47.64], [-122.56, 47.64], [-122.56, 47.63]]],
+  },
+};
+
+describe('runParcelLookup', () => {
+  it('returns not_found when geocoding fails', async () => {
+    mockGeocodeAddress.mockResolvedValueOnce(null);
+
+    const result = await runParcelLookup({ address: 'bad address', registryLookup: async () => null, registrySave: async () => {} });
+    expect(result.status).toBe('not_found');
+    expect(result.error_message).toContain('geocode');
+  });
+
+  it('returns not_found when FIPS resolution fails', async () => {
+    mockGeocodeAddress.mockResolvedValueOnce({ lat: 47.634, lng: -122.555, matchedAddress: 'test' });
+    mockResolveCountyFips.mockResolvedValueOnce(null);
+
+    const result = await runParcelLookup({ address: '123 Main St', registryLookup: async () => null, registrySave: async () => {} });
+    expect(result.status).toBe('not_found');
+    expect(result.error_message).toContain('county');
+  });
+
+  it('auto-discovers endpoint and returns found parcel', async () => {
+    // Step 1: geocode
+    mockGeocodeAddress.mockResolvedValueOnce({ lat: 47.634, lng: -122.555, matchedAddress: 'test' });
+    // Step 2: FIPS
+    mockResolveCountyFips.mockResolvedValueOnce({ fips: '53035', county_name: 'Kitsap', state_fips: '53' });
+    // Step 3: no registry entry, so auto-discover
+    // (registry lookup is via supabase — we mock the whole pipeline flow by having discovery succeed)
+    mockSearchArcGISHub.mockResolvedValueOnce([
+      { title: 'Tax Parcels', url: 'https://example.com/Parcels/FeatureServer' },
+    ]);
+    mockFetchFields.mockResolvedValueOnce({
+      fields: ['APN', 'CONTACT_NAME', 'POLY_ACRES', 'Shape'],
+      geometryType: 'esriGeometryPolygon',
+    });
+    mockMatchFields.mockReturnValueOnce({
+      field_map: { parcel_id: 'APN', owner_name: 'CONTACT_NAME', acres: 'POLY_ACRES' },
+      confidence: 'high',
+      matched_count: 3,
+    });
+    // Step 4: query parcels
+    mockQueryByPoint.mockResolvedValueOnce([MOCK_PARCEL_FEATURE]);
+    // Step 5: adjacent parcels (none found)
+    mockQueryByEnvelope.mockResolvedValueOnce([]);
+
+    const result = await runParcelLookup({
+      address: '7550 Fletcher Bay Rd',
+      registryLookup: async () => null,
+      registrySave: async () => {},
+    });
+
+    expect(result.status).toBe('found');
+    expect(result.parcels.length).toBe(1);
+    expect(result.parcels[0].apn).toBe('1311562');
+    expect(result.parcels[0].acres).toBe(2.96);
+    expect(result.county_fips).toBe('53035');
+  });
+
+  it('uses cached registry entry when available', async () => {
+    mockGeocodeAddress.mockResolvedValueOnce({ lat: 47.634, lng: -122.555, matchedAddress: 'test' });
+    mockResolveCountyFips.mockResolvedValueOnce({ fips: '53035', county_name: 'Kitsap', state_fips: '53' });
+    mockQueryByPoint.mockResolvedValueOnce([MOCK_PARCEL_FEATURE]);
+    mockQueryByEnvelope.mockResolvedValueOnce([]);
+
+    const cachedConfig = {
+      id: 'test-id',
+      fips: '53035',
+      county_name: 'Kitsap',
+      state: 'WA',
+      parcel_layer_url: 'https://example.com/Parcels/FeatureServer/0',
+      address_layer_url: null,
+      field_map: { parcel_id: 'APN', owner_name: 'CONTACT_NAME', acres: 'POLY_ACRES' },
+      discovery_method: 'auto' as const,
+      confidence: 'high' as const,
+      last_verified_at: null,
+    };
+
+    const result = await runParcelLookup({
+      address: '7550 Fletcher Bay Rd',
+      registryLookup: async () => cachedConfig,
+      registrySave: async () => {},
+    });
+
+    expect(result.status).toBe('found');
+    // Should NOT have called discovery
+    expect(mockSearchArcGISHub).not.toHaveBeenCalled();
+  });
+
+  it('returns multiple when adjacent same-owner parcels found', async () => {
+    mockGeocodeAddress.mockResolvedValueOnce({ lat: 47.634, lng: -122.555, matchedAddress: 'test' });
+    mockResolveCountyFips.mockResolvedValueOnce({ fips: '53035', county_name: 'Kitsap', state_fips: '53' });
+    mockQueryByPoint.mockResolvedValueOnce([MOCK_PARCEL_FEATURE]);
+
+    const adjacentFeature: GeoJSON.Feature = {
+      type: 'Feature',
+      properties: { APN: '1311273', POLY_ACRES: 19.89, CONTACT_NAME: 'SMITH' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-122.57, 47.63], [-122.55, 47.63], [-122.55, 47.65], [-122.57, 47.65], [-122.57, 47.63]]],
+      },
+    };
+    mockQueryByEnvelope.mockResolvedValueOnce([MOCK_PARCEL_FEATURE, adjacentFeature]);
+
+    const result = await runParcelLookup({
+      address: '7550 Fletcher Bay Rd',
+      registryLookup: async () => ({
+        id: 'test',
+        fips: '53035',
+        county_name: 'Kitsap',
+        state: 'WA',
+        parcel_layer_url: 'https://example.com/Parcels/FeatureServer/0',
+        address_layer_url: null,
+        field_map: { parcel_id: 'APN', owner_name: 'CONTACT_NAME', acres: 'POLY_ACRES' },
+        discovery_method: 'auto' as const,
+        confidence: 'high' as const,
+        last_verified_at: null,
+      }),
+      registrySave: async () => {},
+    });
+
+    expect(result.status).toBe('multiple');
+    expect(result.parcels.length).toBe(2);
+  });
+
+  it('returns not_found when discovery finds no parcel layers', async () => {
+    mockGeocodeAddress.mockResolvedValueOnce({ lat: 47.634, lng: -122.555, matchedAddress: 'test' });
+    mockResolveCountyFips.mockResolvedValueOnce({ fips: '53035', county_name: 'Kitsap', state_fips: '53' });
+    mockSearchArcGISHub.mockResolvedValueOnce([]);
+
+    const result = await runParcelLookup({
+      address: '123 Main St',
+      registryLookup: async () => null,
+      registrySave: async () => {},
+    });
+
+    expect(result.status).toBe('not_found');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/__tests__/geo/parcel-lookup.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the pipeline orchestrator**
+
+Create `src/lib/geo/parcel-lookup.ts`:
+
+```typescript
+import { geocodeAddress, resolveCountyFips } from './census-client';
+import { searchArcGISHub, fetchFeatureServerFields, queryParcelsByPoint, queryParcelsByEnvelope } from './arcgis-client';
+import { matchFields } from './field-matcher';
+import type { ParcelCandidate, ParcelLookupResult, CountyGISConfig, FieldMap } from './types';
+import bbox from '@turf/bbox';
+
+export interface ParcelLookupInput {
+  address: string;
+  /** Injected dependency: look up registry by FIPS. Null = not found. */
+  registryLookup: (fips: string) => Promise<CountyGISConfig | null>;
+  /** Injected dependency: save a discovered config to the registry. */
+  registrySave: (config: Omit<CountyGISConfig, 'id' | 'last_verified_at'>) => Promise<void>;
+}
+
+const ADJACENT_BUFFER_DEGREES = 0.01; // ~800m
+
+export async function runParcelLookup(input: ParcelLookupInput): Promise<ParcelLookupResult> {
+  const emptyResult = (status: ParcelLookupResult['status'], error_message?: string): ParcelLookupResult => ({
+    status,
+    parcels: [],
+    source: null,
+    county_fips: null,
+    county_name: null,
+    error_message,
+  });
+
+  // Step 1: Geocode
+  const geo = await geocodeAddress(input.address);
+  if (!geo) return emptyResult('not_found', 'Could not geocode address. Check the address and try again.');
+
+  // Step 2: Resolve county FIPS
+  const fipsResult = await resolveCountyFips(geo.lat, geo.lng);
+  if (!fipsResult) return emptyResult('not_found', 'Could not determine county for this location.');
+
+  // Step 3: Resolve ArcGIS endpoint
+  let config = await input.registryLookup(fipsResult.fips);
+
+  if (!config) {
+    // Auto-discover
+    config = await discoverEndpoint(fipsResult.county_name, fipsResult.state_fips, fipsResult.fips);
+    if (config) {
+      await input.registrySave(config);
+    }
+  }
+
+  if (!config) {
+    return emptyResult('not_found', `No parcel data source found for ${fipsResult.county_name} County.`);
+  }
+
+  // Step 4: Query parcels at point
+  const features = await queryParcelsByPoint(config.parcel_layer_url, geo.lat, geo.lng);
+  if (features.length === 0) {
+    return {
+      status: 'not_found',
+      parcels: [],
+      source: 'county_arcgis',
+      county_fips: fipsResult.fips,
+      county_name: fipsResult.county_name,
+      error_message: 'No parcels found at this location.',
+    };
+  }
+
+  const baseParcels = features.map((f) => featureToCandidate(f, config!.field_map, config!.parcel_layer_url));
+
+  // Step 5: Multi-parcel detection
+  const ownerField = config.field_map.owner_name;
+  const baseOwner = ownerField ? features[0].properties?.[ownerField] : null;
+
+  let allParcels = baseParcels;
+
+  if (baseOwner && ownerField) {
+    const baseBbox = bbox({ type: 'FeatureCollection', features });
+    const bufferedBbox: [number, number, number, number] = [
+      baseBbox[0] - ADJACENT_BUFFER_DEGREES,
+      baseBbox[1] - ADJACENT_BUFFER_DEGREES,
+      baseBbox[2] + ADJACENT_BUFFER_DEGREES,
+      baseBbox[3] + ADJACENT_BUFFER_DEGREES,
+    ];
+
+    const whereClause = `${ownerField} LIKE '%${escapeArcGIS(baseOwner)}%'`;
+    const adjacentFeatures = await queryParcelsByEnvelope(
+      config.parcel_layer_url,
+      bufferedBbox,
+      whereClause
+    );
+
+    if (adjacentFeatures.length > 0) {
+      const parcelIdField = config.field_map.parcel_id;
+      const seenApns = new Set(baseParcels.map((p) => p.apn));
+      const additional = adjacentFeatures
+        .filter((f) => {
+          const apn = String(f.properties?.[parcelIdField] ?? '');
+          return apn && !seenApns.has(apn);
+        })
+        .map((f) => featureToCandidate(f, config!.field_map, config!.parcel_layer_url));
+
+      allParcels = [...baseParcels, ...additional];
+    }
+  }
+
+  return {
+    status: allParcels.length > 1 ? 'multiple' : 'found',
+    parcels: allParcels,
+    source: 'county_arcgis',
+    county_fips: fipsResult.fips,
+    county_name: fipsResult.county_name,
+  };
+}
+
+function featureToCandidate(
+  feature: GeoJSON.Feature,
+  fieldMap: FieldMap,
+  sourceUrl: string
+): ParcelCandidate {
+  const props = feature.properties ?? {};
+  return {
+    apn: String(props[fieldMap.parcel_id] ?? ''),
+    geometry: feature.geometry as GeoJSON.Polygon | GeoJSON.MultiPolygon,
+    acres: fieldMap.acres ? Number(props[fieldMap.acres]) || null : null,
+    owner_of_record: fieldMap.owner_name ? String(props[fieldMap.owner_name] ?? '') || null : null,
+    site_address: fieldMap.site_address ? String(props[fieldMap.site_address] ?? '') || null : null,
+    source_url: sourceUrl,
+  };
+}
+
+// State FIPS to abbreviation mapping for discovery queries
+const STATE_FIPS_TO_ABBR: Record<string, string> = {
+  '53': 'WA', '06': 'CA', '41': 'OR', '36': 'NY', '48': 'TX',
+  '12': 'FL', '17': 'IL', '42': 'PA', '39': 'OH', '26': 'MI',
+  '13': 'GA', '37': 'NC', '34': 'NJ', '51': 'VA', '25': 'MA',
+  '04': 'AZ', '18': 'IN', '47': 'TN', '29': 'MO', '24': 'MD',
+  '55': 'WI', '27': 'MN', '08': 'CO', '01': 'AL', '45': 'SC',
+  '22': 'LA', '21': 'KY', '41': 'OR', '40': 'OK', '09': 'CT',
+  '56': 'WY', '16': 'ID', '15': 'HI', '02': 'AK', '23': 'ME',
+  '33': 'NH', '44': 'RI', '30': 'MT', '10': 'DE', '46': 'SD',
+  '38': 'ND', '50': 'VT', '11': 'DC', '54': 'WV', '31': 'NE',
+  '20': 'KS', '35': 'NM', '32': 'NV', '28': 'MS', '05': 'AR',
+  '49': 'UT', '19': 'IA',
+};
+
+async function discoverEndpoint(
+  countyName: string,
+  stateFips: string,
+  fips: string
+): Promise<CountyGISConfig | null> {
+  const stateAbbr = STATE_FIPS_TO_ABBR[stateFips] ?? '';
+  const hubResults = await searchArcGISHub(countyName, stateAbbr);
+
+  for (const result of hubResults) {
+    // Try layer 0 by default
+    const layerUrl = result.url.replace(/\/?$/, '/0');
+    const meta = await fetchFeatureServerFields(layerUrl);
+    if (!meta) continue;
+
+    // Only consider polygon layers
+    if (!meta.geometryType.includes('Polygon')) continue;
+
+    const match = matchFields(meta.fields);
+    if (!match) continue;
+
+    return {
+      id: '',
+      fips,
+      county_name: countyName,
+      state: stateAbbr,
+      parcel_layer_url: layerUrl,
+      address_layer_url: null,
+      field_map: match.field_map,
+      discovery_method: 'auto',
+      confidence: match.confidence,
+      last_verified_at: null,
+    };
+  }
+
+  return null;
+}
+
+function escapeArcGIS(value: string): string {
+  return value.replace(/'/g, "''");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- src/__tests__/geo/parcel-lookup.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Run type-check**
+
+Run: `npm run type-check`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/geo/parcel-lookup.ts src/__tests__/geo/parcel-lookup.test.ts
+git commit -m "feat(parcel-lookup): add pipeline orchestrator with auto-discovery (#205)"
+```
+
+---
+
+## Task 7: Server Actions
+
+**Files:**
+- Create: `src/app/admin/properties/[slug]/parcel-lookup/actions.ts`
+
+- [ ] **Step 1: Implement server actions**
+
+Create `src/app/admin/properties/[slug]/parcel-lookup/actions.ts`:
+
+```typescript
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { runParcelLookup } from '@/lib/geo/parcel-lookup';
+import { createGeoLayer, assignLayerToProperties, setPropertyBoundary } from '@/app/admin/geo-layers/actions';
+import type { CountyGISConfig, ParcelCandidate, ParcelLookupResult } from '@/lib/geo/types';
+import type { FeatureCollection, Feature } from 'geojson';
+import bbox from '@turf/bbox';
+
+export async function lookupParcel(input: {
+  address: string;
+  orgId: string;
+  propertyId: string;
+}): Promise<ParcelLookupResult | { error: string }> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const registryLookup = async (fips: string): Promise<CountyGISConfig | null> => {
+    const { data } = await supabase
+      .from('county_gis_registry')
+      .select('*')
+      .eq('fips', fips)
+      .single();
+    return data ?? null;
+  };
+
+  const registrySave = async (config: Omit<CountyGISConfig, 'id' | 'last_verified_at'>) => {
+    await supabase.from('county_gis_registry').upsert(
+      {
+        fips: config.fips,
+        county_name: config.county_name,
+        state: config.state,
+        parcel_layer_url: config.parcel_layer_url,
+        address_layer_url: config.address_layer_url,
+        field_map: config.field_map,
+        discovery_method: config.discovery_method,
+        confidence: config.confidence,
+        last_verified_at: new Date().toISOString(),
+      },
+      { onConflict: 'fips' }
+    );
+  };
+
+  const result = await runParcelLookup({
+    address: input.address,
+    registryLookup,
+    registrySave,
+  });
+
+  // Log the lookup
+  await supabase.from('parcel_lookups').insert({
+    org_id: input.orgId,
+    property_id: input.propertyId,
+    input_address: input.address,
+    county_fips: result.county_fips,
+    source: result.source ?? 'county_arcgis',
+    status: result.status === 'found' || result.status === 'multiple' ? 'success' : result.status,
+    parcels_found: result.parcels.length,
+  });
+
+  return result;
+}
+
+export async function confirmParcelSelection(input: {
+  parcels: ParcelCandidate[];
+  propertyId: string;
+  orgId: string;
+  setAsBoundary: boolean;
+  unionForBoundary: boolean;
+  layerName: string;
+}): Promise<{ success: true; geoLayerId: string } | { error: string }> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  // Build FeatureCollection from selected parcels
+  const features: Feature[] = input.parcels.map((p, i) => ({
+    type: 'Feature' as const,
+    properties: {
+      apn: p.apn,
+      acres: p.acres,
+      owner_of_record: p.owner_of_record,
+      site_address: p.site_address,
+      source_url: p.source_url,
+    },
+    geometry: p.geometry,
+  }));
+
+  // If union for boundary, compute merged outline and add as feature
+  if (input.unionForBoundary && features.length > 1) {
+    try {
+      const { default: union } = await import('@turf/union');
+      let merged = features[0];
+      for (let i = 1; i < features.length; i++) {
+        const result = union(merged, features[i]);
+        if (result) merged = result;
+      }
+      merged.properties = { role: 'boundary_outline' };
+      features.push(merged);
+    } catch {
+      // If union fails, proceed without it
+    }
+  }
+
+  const fc: FeatureCollection = { type: 'FeatureCollection', features };
+  const layerBbox = bbox(fc) as [number, number, number, number];
+
+  const totalAcres = input.parcels.reduce((sum, p) => sum + (p.acres ?? 0), 0);
+  const description = `${input.parcels.length} parcel(s), ${totalAcres.toFixed(2)} acres. APNs: ${input.parcels.map((p) => p.apn).join(', ')}`;
+
+  const result = await createGeoLayer({
+    orgId: input.orgId,
+    name: input.layerName,
+    description,
+    geojson: fc,
+    sourceFormat: 'geojson',
+    sourceFilename: 'parcel-lookup',
+    color: '#16a34a',
+    opacity: 0.5,
+    featureCount: features.length,
+    bbox: layerBbox,
+    isPropertyBoundary: input.setAsBoundary,
+    status: 'published',
+    source: 'parcel_lookup',
+  });
+
+  if ('error' in result) return result;
+
+  // Assign to property
+  await assignLayerToProperties(result.layerId, input.orgId, [input.propertyId], true);
+
+  // Set as property boundary if requested
+  if (input.setAsBoundary) {
+    await setPropertyBoundary(input.propertyId, result.layerId);
+  }
+
+  // Update audit log with result
+  await supabase
+    .from('parcel_lookups')
+    .update({ result_geo_layer_id: result.layerId })
+    .eq('property_id', input.propertyId)
+    .eq('org_id', input.orgId)
+    .is('result_geo_layer_id', null)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  return { success: true, geoLayerId: result.layerId };
+}
+```
+
+- [ ] **Step 2: Run type-check**
+
+Run: `npm run type-check`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/parcel-lookup/actions.ts
+git commit -m "feat(parcel-lookup): add lookupParcel and confirmParcelSelection server actions (#205)"
+```
+
+---
+
+## Task 8: ParcelPreviewMap Component
+
+**Files:**
+- Create: `src/components/geo/ParcelPreviewMap.tsx`
+
+- [ ] **Step 1: Implement the preview map component**
+
+Create `src/components/geo/ParcelPreviewMap.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { ParcelCandidate } from '@/lib/geo/types';
+
+interface ParcelPreviewMapProps {
+  parcels: ParcelCandidate[];
+  selectedApns: Set<string>;
+  onToggleParcel?: (apn: string) => void;
+  height?: string;
+}
+
+const PARCEL_COLORS = ['#16a34a', '#2563eb', '#d97706', '#dc2626', '#7c3aed'];
+
+export default function ParcelPreviewMap({
+  parcels,
+  selectedApns,
+  onToggleParcel,
+  height = '300px',
+}: ParcelPreviewMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const layersRef = useRef<L.GeoJSON[]>([]);
+
+  useEffect(() => {
+    if (!mapRef.current || typeof window === 'undefined') return;
+
+    const L = require('leaflet');
+    require('leaflet/dist/leaflet.css');
+
+    if (mapInstanceRef.current) {
+      mapInstanceRef.current.remove();
+    }
+
+    const map = L.map(mapRef.current);
+    mapInstanceRef.current = map;
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(map);
+
+    // Clear old layers
+    layersRef.current.forEach((l) => l.remove());
+    layersRef.current = [];
+
+    const allBounds = L.latLngBounds([]);
+
+    parcels.forEach((parcel, i) => {
+      const color = PARCEL_COLORS[i % PARCEL_COLORS.length];
+      const isSelected = selectedApns.has(parcel.apn);
+
+      const feature: GeoJSON.Feature = {
+        type: 'Feature',
+        properties: { apn: parcel.apn },
+        geometry: parcel.geometry,
+      };
+
+      const layer = L.geoJSON(feature, {
+        style: {
+          color: isSelected ? color : '#94a3b8',
+          fillColor: isSelected ? color : '#cbd5e1',
+          fillOpacity: isSelected ? 0.3 : 0.1,
+          weight: isSelected ? 3 : 1,
+        },
+        onEachFeature: (_: unknown, featureLayer: L.Layer) => {
+          if (onToggleParcel) {
+            featureLayer.on('click', () => onToggleParcel(parcel.apn));
+          }
+        },
+      }).addTo(map);
+
+      allBounds.extend(layer.getBounds());
+      layersRef.current.push(layer);
+    });
+
+    if (allBounds.isValid()) {
+      map.fitBounds(allBounds, { padding: [30, 30] });
+    }
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+    };
+  }, [parcels, selectedApns, onToggleParcel]);
+
+  return <div ref={mapRef} style={{ height, width: '100%', borderRadius: '8px' }} />;
+}
+```
+
+- [ ] **Step 2: Run type-check**
+
+Run: `npm run type-check`
+Expected: No errors (Leaflet types may need `@types/leaflet` which should already be installed)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/geo/ParcelPreviewMap.tsx
+git commit -m "feat(parcel-lookup): add ParcelPreviewMap Leaflet component (#205)"
+```
+
+---
+
+## Task 9: ParcelLookup UI Component
+
+**Files:**
+- Create: `src/components/geo/ParcelLookup.tsx`
+
+- [ ] **Step 1: Implement the ParcelLookup state machine component**
+
+Create `src/components/geo/ParcelLookup.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import { lookupParcel, confirmParcelSelection } from '@/app/admin/properties/[slug]/parcel-lookup/actions';
+import type { ParcelCandidate, ParcelLookupResult } from '@/lib/geo/types';
+
+const ParcelPreviewMap = dynamic(() => import('./ParcelPreviewMap'), { ssr: false });
+
+type LookupState =
+  | { step: 'idle' }
+  | { step: 'searching'; address: string }
+  | { step: 'found'; result: ParcelLookupResult }
+  | { step: 'confirming' }
+  | { step: 'confirmed'; geoLayerId: string; parcelCount: number; totalAcres: number }
+  | { step: 'error'; message: string };
+
+interface ParcelLookupProps {
+  propertyId: string;
+  propertyName: string;
+  orgId: string;
+}
+
+export default function ParcelLookup({ propertyId, propertyName, orgId }: ParcelLookupProps) {
+  const [state, setState] = useState<LookupState>({ step: 'idle' });
+  const [address, setAddress] = useState('');
+  const [selectedApns, setSelectedApns] = useState<Set<string>>(new Set());
+  const [setAsBoundary, setSetAsBoundary] = useState(false);
+  const [unionForBoundary, setUnionForBoundary] = useState(false);
+
+  const handleLookup = useCallback(async () => {
+    if (!address.trim()) return;
+    setState({ step: 'searching', address });
+
+    const result = await lookupParcel({ address, orgId, propertyId });
+
+    if ('error' in result) {
+      setState({ step: 'error', message: result.error });
+      return;
+    }
+
+    if (result.status === 'not_found' || result.status === 'error') {
+      setState({ step: 'error', message: result.error_message ?? 'No parcels found.' });
+      return;
+    }
+
+    // Auto-select all parcels
+    setSelectedApns(new Set(result.parcels.map((p) => p.apn)));
+    setState({ step: 'found', result });
+  }, [address, orgId, propertyId]);
+
+  const handleToggleParcel = useCallback((apn: string) => {
+    setSelectedApns((prev) => {
+      const next = new Set(prev);
+      if (next.has(apn)) {
+        next.delete(apn);
+      } else {
+        next.add(apn);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (state.step !== 'found') return;
+
+    const selected = state.result.parcels.filter((p) => selectedApns.has(p.apn));
+    if (selected.length === 0) return;
+
+    setState({ step: 'confirming' });
+
+    const layerName = `${propertyName} Parcels`;
+    const result = await confirmParcelSelection({
+      parcels: selected,
+      propertyId,
+      orgId,
+      setAsBoundary,
+      unionForBoundary,
+      layerName,
+    });
+
+    if ('error' in result) {
+      setState({ step: 'error', message: result.error });
+      return;
+    }
+
+    const totalAcres = selected.reduce((sum, p) => sum + (p.acres ?? 0), 0);
+    setState({
+      step: 'confirmed',
+      geoLayerId: result.geoLayerId,
+      parcelCount: selected.length,
+      totalAcres,
+    });
+  }, [state, selectedApns, propertyId, propertyName, orgId, setAsBoundary, unionForBoundary]);
+
+  const handleReset = useCallback(() => {
+    setState({ step: 'idle' });
+    setAddress('');
+    setSelectedApns(new Set());
+    setSetAsBoundary(false);
+    setUnionForBoundary(false);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      {/* Idle */}
+      {state.step === 'idle' && (
+        <div className="card">
+          <div className="mb-4">
+            <h3 className="text-lg font-semibold">Find Property Boundary</h3>
+            <p className="text-sm text-gray-500">
+              Look up parcel boundaries automatically from public GIS records
+            </p>
+          </div>
+          <div>
+            <label className="label">Property Address</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                className="input-field flex-1"
+                placeholder="e.g. 7550 Fletcher Bay Rd NE, Bainbridge Island, WA"
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleLookup()}
+              />
+              <button
+                className="btn-primary whitespace-nowrap"
+                onClick={handleLookup}
+                disabled={!address.trim()}
+              >
+                Look Up
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Searching */}
+      {state.step === 'searching' && (
+        <div className="card">
+          <div className="flex items-center gap-3 p-4">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+            <div>
+              <p className="font-medium">Searching county GIS records...</p>
+              <p className="text-sm text-gray-500">Looking up parcels for: {state.address}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Found */}
+      {state.step === 'found' && (
+        <div className="card space-y-4">
+          <div className="rounded-lg bg-green-50 p-3 border border-green-200">
+            <p className="font-semibold text-green-700">
+              {state.result.parcels.length === 1
+                ? 'Parcel Found'
+                : `Found ${state.result.parcels.length} parcels`}
+            </p>
+            {state.result.county_name && (
+              <p className="text-sm text-gray-500">
+                Source: {state.result.county_name} County ArcGIS
+              </p>
+            )}
+          </div>
+
+          <ParcelPreviewMap
+            parcels={state.result.parcels}
+            selectedApns={selectedApns}
+            onToggleParcel={handleToggleParcel}
+          />
+
+          {/* Parcel list */}
+          <div className="space-y-2">
+            {state.result.parcels.map((p) => (
+              <label
+                key={p.apn}
+                className="flex items-center gap-3 rounded-lg border p-3 text-sm cursor-pointer hover:bg-gray-50"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedApns.has(p.apn)}
+                  onChange={() => handleToggleParcel(p.apn)}
+                />
+                <div>
+                  <span className="font-medium">APN {p.apn}</span>
+                  {p.acres && <span className="text-gray-500"> · {p.acres} ac</span>}
+                  {p.site_address && (
+                    <span className="text-gray-500"> · {p.site_address}</span>
+                  )}
+                  {p.owner_of_record && (
+                    <span className="text-gray-400 block text-xs">
+                      Owner: {p.owner_of_record}
+                    </span>
+                  )}
+                </div>
+              </label>
+            ))}
+          </div>
+
+          {/* Options */}
+          <div className="space-y-2 border-t pt-3">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={setAsBoundary}
+                onChange={(e) => setSetAsBoundary(e.target.checked)}
+              />
+              Set as property boundary
+            </label>
+            {selectedApns.size > 1 && (
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={unionForBoundary}
+                  onChange={(e) => setUnionForBoundary(e.target.checked)}
+                />
+                Merge into unified boundary outline
+              </label>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-2">
+            <button
+              className="btn-primary flex-1"
+              onClick={handleConfirm}
+              disabled={selectedApns.size === 0}
+            >
+              Save Selected ({selectedApns.size})
+            </button>
+            <button className="btn-secondary" onClick={handleReset}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Confirming */}
+      {state.step === 'confirming' && (
+        <div className="card">
+          <div className="flex items-center gap-3 p-4">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-green-500 border-t-transparent" />
+            <p className="font-medium">Saving parcels as geo layer...</p>
+          </div>
+        </div>
+      )}
+
+      {/* Confirmed */}
+      {state.step === 'confirmed' && (
+        <div className="card text-center">
+          <div className="rounded-lg bg-green-50 p-6 border border-green-200">
+            <p className="text-2xl mb-2">&#10003;</p>
+            <p className="font-semibold text-green-700">Boundary Saved</p>
+            <p className="text-sm text-gray-500 mt-2">
+              {state.parcelCount} parcel(s) · {state.totalAcres.toFixed(2)} acres
+            </p>
+          </div>
+          <div className="flex gap-2 justify-center mt-4">
+            <a
+              href={`/admin/geo-layers`}
+              className="btn-secondary text-sm"
+            >
+              View in Geo Layers
+            </a>
+            <button className="btn-secondary text-sm" onClick={handleReset}>
+              Look Up Another
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Error / Not Found */}
+      {state.step === 'error' && (
+        <div className="card space-y-4">
+          <div className="rounded-lg bg-red-50 p-3 border border-red-200">
+            <p className="font-semibold text-red-700">No parcels found</p>
+            <p className="text-sm text-gray-500">{state.message}</p>
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-gray-700">Try another option:</p>
+            <button className="btn-secondary w-full text-left text-sm" onClick={handleReset}>
+              Try a different address
+            </button>
+            <a
+              href={`/admin/properties`}
+              className="btn-secondary w-full text-left text-sm block"
+            >
+              Draw boundary on map
+            </a>
+            <a
+              href={`/admin/geo-layers`}
+              className="btn-secondary w-full text-left text-sm block"
+            >
+              Upload boundary file
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run type-check**
+
+Run: `npm run type-check`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/geo/ParcelLookup.tsx
+git commit -m "feat(parcel-lookup): add ParcelLookup UI component with state machine (#205)"
+```
+
+---
+
+## Task 10: Page and Navigation
+
+**Files:**
+- Create: `src/app/admin/properties/[slug]/parcel-lookup/page.tsx`
+- Modify: `src/app/admin/properties/[slug]/layout.tsx:36`
+
+- [ ] **Step 1: Create the parcel lookup page**
+
+Create `src/app/admin/properties/[slug]/parcel-lookup/page.tsx`:
+
+```tsx
+import { createClient } from '@/lib/supabase/server';
+import { getTenantContext } from '@/lib/tenant/context';
+import { redirect } from 'next/navigation';
+import ParcelLookup from '@/components/geo/ParcelLookup';
+
+export default async function ParcelLookupPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login');
+
+  const tenant = await getTenantContext();
+  if (!tenant) redirect('/login');
+
+  const { data: property } = await supabase
+    .from('properties')
+    .select('id, name')
+    .eq('org_id', tenant.org_id)
+    .eq('slug', params.slug)
+    .single();
+
+  if (!property) redirect('/admin/properties');
+
+  return (
+    <div className="max-w-2xl">
+      <h2 className="text-xl font-semibold mb-4">Parcel Lookup</h2>
+      <p className="text-sm text-gray-500 mb-6">
+        Search for parcel boundaries from public county GIS records and save them as geo layers.
+      </p>
+      <ParcelLookup
+        propertyId={property.id}
+        propertyName={property.name}
+        orgId={tenant.org_id}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add Parcel Lookup to sidebar navigation**
+
+In `src/app/admin/properties/[slug]/layout.tsx`, find the `items` array and add a "Parcel Lookup" entry after "Geo Layers":
+
+Change:
+```typescript
+  { label: 'Geo Layers', href: `${base}/geo-layers/discover` },
+```
+to:
+```typescript
+  { label: 'Geo Layers', href: `${base}/geo-layers/discover` },
+  { label: 'Parcel Lookup', href: `${base}/parcel-lookup` },
+```
+
+- [ ] **Step 3: Run type-check**
+
+Run: `npm run type-check`
+Expected: No errors
+
+- [ ] **Step 4: Run dev server and verify page loads**
+
+Run: `npm run dev`
+
+Navigate to `/admin/properties/[any-property-slug]/parcel-lookup` and verify:
+- Page loads without errors
+- "Parcel Lookup" appears in sidebar navigation
+- Address input and "Look Up" button are visible
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/admin/properties/[slug]/parcel-lookup/page.tsx src/app/admin/properties/[slug]/layout.tsx
+git commit -m "feat(parcel-lookup): add parcel lookup page and sidebar nav entry (#205)"
+```
+
+---
+
+## Task 11: Post-Property-Creation Entry Point
+
+**Files:**
+- Modify: `src/app/admin/properties/page.tsx:134`
+
+- [ ] **Step 1: Update property creation redirect to include parcel lookup prompt**
+
+In `src/app/admin/properties/page.tsx`, change the redirect after property creation (line 134) from:
+```typescript
+    router.push(`/admin/properties/${result.slug}`);
+```
+to:
+```typescript
+    router.push(`/admin/properties/${result.slug}/parcel-lookup`);
+```
+
+This sends the admin directly to the parcel lookup page after creating a property, making boundary discovery the natural next step.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/page.tsx
+git commit -m "feat(parcel-lookup): redirect to parcel lookup after property creation (#205)"
+```
+
+---
+
+## Task 12: Install @turf/union Dependency (do this before Task 7)
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install @turf/union**
+
+Run: `npm install @turf/union`
+
+The `confirmParcelSelection` action uses `@turf/union` for merging multi-parcel boundaries. The other Turf packages (`@turf/bbox`, `@turf/helpers`, `@turf/intersect`, `@turf/boolean-point-in-polygon`) are already installed.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @turf/union dependency for parcel boundary merging (#205)"
+```
+
+---
+
+## Task 13: Run All Tests and Type-Check
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm run test`
+Expected: All tests pass, including new census-client, field-matcher, arcgis-client, and parcel-lookup tests.
+
+- [ ] **Step 2: Run type-check**
+
+Run: `npm run type-check`
+Expected: No errors
+
+- [ ] **Step 3: Fix any issues found**
+
+If any tests fail or type errors exist, fix them before proceeding.
+
+- [ ] **Step 4: Final commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix(parcel-lookup): resolve test and type-check issues (#205)"
+```

--- a/docs/superpowers/specs/2026-04-05-map-display-config-design.md
+++ b/docs/superpowers/specs/2026-04-05-map-display-config-design.md
@@ -1,0 +1,143 @@
+# Map Display Configuration
+
+Configurable map controls and legend content per property/org, with org-level defaults that cascade to all properties unless overridden.
+
+## Configurable Controls
+
+Five map controls can be toggled on/off:
+
+| Control | Component | Default |
+|---------|-----------|---------|
+| Legend | `MapLegend.tsx` (in `MapView.tsx`) | On |
+| Layer Selector | `LayerControlPanel.tsx` (in `MapView.tsx`) | On |
+| Current Position (Locate Me) | `LocateButton.tsx` (in `MapView.tsx`) | On |
+| View as List | `<Link>` in `HomeMapView.tsx` | On |
+| Quick Add FAB | FAB button in `MapView.tsx` | On |
+
+## Legend Detail Config
+
+When the legend is enabled, admins can further control what appears in it:
+
+- **Statuses**: Which status colors to show (Active, Planned, Needs Repair, Removed). If set, only listed statuses appear. If unset, all statuses shown.
+- **Item Types**: Which item types to show by ID. If set, only listed types appear in the legend. If unset, all types shown.
+
+Note: hiding a status or item type from the legend does not hide the items from the map — it only affects the legend display.
+
+## Data Model
+
+### TypeScript Interface
+
+```typescript
+interface MapDisplayConfig {
+  controls?: {
+    legend?: boolean;
+    layerSelector?: boolean;
+    locateMe?: boolean;
+    viewAsList?: boolean;
+    quickAdd?: boolean;
+  };
+  legend?: {
+    statuses?: string[];      // e.g. ['active', 'planned', 'damaged', 'removed']
+    itemTypeIds?: string[];   // UUIDs of item types to show
+  };
+}
+```
+
+### Database
+
+New `map_display_config JSONB` column on both `orgs` and `properties` tables. Nullable — `null` means "use defaults (everything visible)."
+
+Migration adds the column to both tables with `DEFAULT NULL`.
+
+## Config Cascade
+
+Follows the existing org → property cascade pattern used by theme, map style, and logo.
+
+### Control toggles (per-key merge)
+
+```
+resolved.controls.legend =
+  property.map_display_config?.controls?.legend
+  ?? org.map_display_config?.controls?.legend
+  ?? true
+```
+
+Each of the five control keys resolves independently. Unset at property level falls through to org. Unset at both levels defaults to `true`.
+
+### Legend detail lists (full replacement)
+
+```
+resolved.legend.statuses =
+  property.map_display_config?.legend?.statuses   // full replacement if set
+  ?? org.map_display_config?.legend?.statuses      // fall through to org
+  ?? undefined                                     // undefined = show all
+```
+
+If a property sets `legend.statuses`, that is the complete list — org's list is ignored for that property. Same for `legend.itemTypeIds`.
+
+### Integration with buildSiteConfig
+
+`buildSiteConfig` gains a new `mapDisplayConfig` field on `SiteConfig`. The merge logic described above runs inside `buildSiteConfig`, accepting the raw JSONB from both org and property rows.
+
+Components access the resolved config via `useConfig().mapDisplayConfig`.
+
+## Component Changes
+
+### MapView.tsx
+
+Conditionally render based on `mapDisplayConfig.controls`:
+
+- `<MapLegend>` — wrapped in `controls.legend` check
+- `<LocateButton>` — wrapped in `controls.locateMe` check
+- `<LayerControlPanel>` — wrapped in `controls.layerSelector` check
+- Quick Add FAB — wrapped in `controls.quickAdd` check
+
+### HomeMapView.tsx
+
+- "View as List" `<Link>` — wrapped in `controls.viewAsList` check
+
+### MapLegend.tsx
+
+- Filter `statusItems` array by `legend.statuses` (if set)
+- Filter `itemTypes` array by `legend.itemTypeIds` (if set)
+
+## Admin UI
+
+### Layout: Card-per-control with toggle switches
+
+Each control is a card with an icon, name, description, and toggle switch. The Legend card expands when enabled to show the status and item type checkboxes.
+
+### Org Settings (Appearance section)
+
+- Shows the five control cards with toggle switches
+- Legend card expands to show status checkboxes and item type checkboxes
+- Helper text: "These defaults apply to all properties unless overridden."
+
+### Property Settings (Appearance tab)
+
+- Same card layout as org settings
+- Each card shows "Org default: On/Off" beneath the control name
+- When a property's value differs from the org default, the card gets a yellow highlight (amber border + background) and a "Reset" link to revert to org default
+- Clicking "Reset" removes the property-level override for that control, falling back to org
+
+### Legend detail at property level
+
+When the property's legend card is expanded:
+- Status checkboxes and item type checkboxes work the same as org level
+- If the property has set its own statuses/itemTypeIds list, that's a full replacement of the org list
+- A "Reset to org default" option clears the property-level legend config
+
+### Server Actions
+
+- `updateOrgMapDisplayConfig(orgId, config: MapDisplayConfig)` — updates org's `map_display_config` column
+- `updatePropertyMapDisplayConfig(propertyId, config: MapDisplayConfig)` — updates property's `map_display_config` column
+
+Both actions validate the input shape and check permissions (org admin / property admin).
+
+## Scope
+
+This feature only configures visibility of existing map controls and legend content. It does not:
+- Add new map controls
+- Change the behavior of existing controls
+- Affect which items appear on the map (only the legend display)
+- Modify the list view page itself (only the link to it)

--- a/docs/superpowers/specs/2026-04-05-parcel-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-05-parcel-lookup-design.md
@@ -1,0 +1,269 @@
+# Parcel Boundary Lookup — Design Spec
+
+**Issue:** #205
+**Date:** 2026-04-05
+
+## Overview
+
+Automated parcel boundary lookup from public US county GIS sources. Given an address, the system geocodes it, identifies the county, discovers or looks up the county's ArcGIS parcel endpoint, queries for matching parcels, and returns GeoJSON candidates for the user to confirm. Results are stored as geo layers using the existing `geo_layers` table.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Map library | Leaflet (existing) | No migration now; possible future MapLibre support |
+| Registry scope | Global DB table | County endpoints are public infrastructure, shared across orgs |
+| Data model | Reuse geo_layers | Parcel results stored as geo layers with `source: 'parcel_lookup'`; user opts in to `is_property_boundary` |
+| Pipeline location | Server-side (server actions) | Centralizes caching, keeps door open for Regrid API keys |
+| Discovery | Auto-discover with registry cache | Query ArcGIS Hub, probe fields with heuristics, cache results |
+| Multi-parcel storage | Separate features in FeatureCollection | Preserves per-parcel metadata (APN, acres, owner) |
+| Boundary display | Optional Turf.js union | User can opt to merge parcels into unified boundary outline |
+| Boundary versioning | No explicit versioning | Old boundary becomes a regular geo layer when replaced |
+| Regrid fallback | Deferred to v2 | Free APIs (Census, ArcGIS) cover v1; Regrid adds cost/complexity |
+| Onboarding wizard | Not in v1 | Entry points: post-property-creation prompt + geo layers section |
+
+## Data Model
+
+### New table: `county_gis_registry` (global)
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | uuid PK | |
+| `fips` | text UNIQUE | County FIPS code, e.g. "53035" |
+| `county_name` | text | e.g. "Kitsap County" |
+| `state` | text | e.g. "WA" |
+| `parcel_layer_url` | text | ArcGIS FeatureServer URL for parcel polygons |
+| `address_layer_url` | text | Optional separate address points layer |
+| `field_map` | jsonb | Maps canonical names to county-specific field names |
+| `discovery_method` | text | `'manual'` or `'auto'` |
+| `confidence` | text | `'high'`, `'medium'`, or `'low'` |
+| `last_verified_at` | timestamptz | When endpoint was last confirmed working |
+| `created_at` | timestamptz | |
+| `updated_at` | timestamptz | |
+
+**`field_map` schema:**
+```json
+{
+  "parcel_id": "APN",
+  "owner_name": "CONTACT_NAME",
+  "site_address": "SITE_ADDR",
+  "house_number": "HOUSE_NO",
+  "street_name": "STREET_NAME",
+  "acres": "POLY_ACRES",
+  "address_link_field": "RP_ACCT_ID"
+}
+```
+
+### New table: `parcel_lookups` (per-org, audit log)
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | uuid PK | |
+| `org_id` | uuid FK | |
+| `property_id` | uuid FK | |
+| `input_address` | text | Address the user entered |
+| `input_lat` | numeric | Geocoded latitude |
+| `input_lng` | numeric | Geocoded longitude |
+| `county_fips` | text | Resolved county FIPS |
+| `source` | text | `'county_arcgis'` |
+| `status` | text | `'success'`, `'partial'`, `'not_found'`, `'error'` |
+| `parcels_found` | integer | Number of parcels returned |
+| `cost_cents` | integer | For future Regrid tracking |
+| `result_geo_layer_id` | uuid FK | Geo layer created from this lookup |
+| `created_at` | timestamptz | |
+
+### Modified: `geo_layers.source` column
+
+Add `'parcel_lookup'` as a valid value alongside existing `'manual'`, `'ai'`, `'discovered'`.
+
+### No new columns on `properties`
+
+The property boundary is represented by a geo_layer with `is_property_boundary: true`, linked via the existing `geo_layer_properties` join table.
+
+## Server-Side Pipeline
+
+### Entry point: `lookupParcel(input)`
+
+```
+Input: { address, propertyId, orgId }
+        |
+Step 1: Geocode address -> { lat, lng }
+  Census Geocoder API (free, no key)
+  GET https://geocoding.geo.census.gov/geocoder/locations/onelineaddress
+        |
+Step 2: Resolve county FIPS from lat/lng
+  Census TIGERweb API (free, no key)
+  GET https://geocoding.geo.census.gov/geocoder/geographies/coordinates
+        |
+Step 3: Resolve ArcGIS endpoint
+  Check county_gis_registry by FIPS
+  If not found -> auto-discover via ArcGIS Hub search
+  If discovered -> probe fields with heuristics, cache to registry
+  If discovery fails -> return { status: 'not_found' }
+        |
+Step 4: Query parcels
+  Query parcel polygons layer with spatial query (point intersection)
+  Or query address points layer to get parcel ID, then query polygons by ID
+  Return matching candidates with geometry + metadata
+        |
+Step 5: Multi-parcel detection
+  If parcel found, query for adjacent parcels with same owner
+  Use bbox envelope + owner name filter
+  Return all candidates for user selection
+        |
+Output: { status, parcels[], countyFips, source }
+```
+
+### Confirmation: `confirmParcelSelection(input)`
+
+The `lookupParcel` action returns full parcel candidate objects (GeoJSON geometry + metadata). The client holds these in state and passes back the user's selection:
+
+```
+Input: {
+  parcels: ParcelCandidate[],  -- full GeoJSON features selected by user
+  propertyId, orgId,
+  setAsBoundary: boolean,
+  unionForBoundary: boolean,
+  layerName: string            -- user-provided or auto-generated name
+}
+        |
+- Build FeatureCollection from selected parcels
+- If unionForBoundary: compute Turf.js union, store as additional
+  "_boundary" feature in the FeatureCollection with property
+  { role: "boundary_outline" }
+- Create geo_layer via existing createGeoLayer()
+- If setAsBoundary: set is_property_boundary on the geo_layer
+- Log to parcel_lookups audit table
+        |
+Output: { success: true, geoLayerId }
+```
+
+All external API calls are free (Census Geocoder, Census TIGERweb, ArcGIS public services). No API keys needed for v1.
+
+## Auto-Discovery & Field Matching
+
+### Discovery flow
+
+1. Search ArcGIS Hub: `https://www.arcgis.com/sharing/rest/search?q={county}+{state}+parcel&type=Feature+Service`
+2. Filter results for likely parcel layers (keywords: `parcel`, `tax`, `lot`, `cadastral`)
+3. For each candidate, fetch FeatureServer metadata (`/0?f=json`) to get field list
+4. Run heuristic field matcher against field list
+5. If confident match -> run test query (small bbox, limit 1) to validate
+6. Cache to `county_gis_registry` with `discovery_method: 'auto'`
+
+### Heuristic field matcher
+
+Pattern matching against common US county naming conventions:
+
+| Canonical field | Common patterns |
+|---|---|
+| `parcel_id` | `APN`, `PIN`, `PARCEL_ID`, `PARCEL_NO`, `ACCT_ID`, `RP_ACCT_ID`, `TAX_ID`, `PARCEL_NUM` |
+| `owner_name` | `OWNER`, `OWNER_NAME`, `CONTACT_NAME`, `TAXPAYER`, `OWN_NAME` |
+| `site_address` | `SITE_ADDR`, `SITEADDRESS`, `PROP_ADDR`, `ADDRESS`, `FULL_ADDR` |
+| `house_number` | `HOUSE_NO`, `HOUSE_NUM`, `ADDR_NUM`, `STREET_NO` |
+| `street_name` | `STREET_NAME`, `STREET`, `STREET_NM`, `ST_NAME` |
+| `acres` | `ACRES`, `POLY_ACRES`, `GIS_ACRES`, `AREA_ACRES`, `CALC_ACRES` |
+
+Minimum requirement: confident match on `parcel_id`. Without that, the endpoint is unusable.
+
+**Confidence levels:**
+- **High**: matched `parcel_id` + 2+ other fields + successful test query
+- **Medium**: matched `parcel_id` + 1 other field
+- **Low**: matched `parcel_id` only
+
+## UI Design
+
+### Component: `<ParcelLookup />`
+
+State machine with 5 states:
+
+1. **Idle** — Address input with "Look Up" button
+2. **Searching** — Spinner with county name feedback
+3. **Found** — Two variants:
+   - **Single parcel**: Map preview with highlighted polygon, "Save as Geo Layer" + "Find Adjacent Parcels" buttons, "Set as property boundary" checkbox
+   - **Multiple parcels**: Checkboxes per parcel with APN/acreage labels, "Save Selected" button, "Set as property boundary" checkbox, "Merge into unified boundary outline" checkbox
+4. **Not Found** — Fallback options: try different address, draw on map, upload file
+5. **Confirmed** — Summary (parcel count, acreage, geo layer name), links to view on map or edit in geo layers
+
+### Component: `<ParcelPreviewMap />`
+
+Leaflet map showing parcel candidates with:
+- Highlighted polygon fills (color-coded per parcel)
+- Fit bounds to show all candidates
+- Click to select/deselect individual parcels
+
+### Entry points
+
+1. **Post-property-creation**: After creating a property on `/admin/properties`, prompt with "Find boundary automatically" linking to parcel lookup
+2. **Geo Layers section**: "Parcel Lookup" button in `/admin/properties/[slug]/geo-layers/` alongside existing Import and Discover actions
+
+Fallback options (draw, upload) link to existing geo layer functionality — no new UI needed for those paths.
+
+## File Structure
+
+### New files
+
+```
+src/lib/geo/parcel-lookup.ts            -- Core pipeline (geocode, FIPS, discover, query)
+src/lib/geo/field-matcher.ts            -- Heuristic field name matching
+src/lib/geo/arcgis-client.ts            -- ArcGIS REST API client
+src/lib/geo/census-client.ts            -- Census geocoder + TIGERweb FIPS lookup
+
+src/app/admin/properties/[slug]/
+  parcel-lookup/
+    page.tsx                             -- Parcel lookup page
+    actions.ts                           -- Server actions (lookupParcel, confirmParcelSelection)
+
+src/components/geo/ParcelLookup.tsx      -- Main UI component (state machine)
+src/components/geo/ParcelPreviewMap.tsx   -- Leaflet map for parcel candidates
+
+supabase/migrations/
+  034_county_gis_registry.sql            -- Registry table
+  035_parcel_lookups.sql                 -- Audit log table
+  036_geo_layer_source_parcel.sql        -- Add 'parcel_lookup' to geo_layers.source
+
+src/__tests__/geo/parcel-lookup.test.ts  -- Pipeline unit tests
+src/__tests__/geo/field-matcher.test.ts  -- Field matcher unit tests
+```
+
+### Modified files
+
+```
+src/app/admin/properties/[slug]/layout.tsx  -- Add "Parcel Lookup" to sidebar nav
+src/lib/geo/types.ts                        -- Add parcel lookup types
+```
+
+## Testing Strategy
+
+- **Unit tests** for field matcher: known field lists from Kitsap County, King County, and synthetic edge cases
+- **Unit tests** for pipeline logic: mocked HTTP responses for Census and ArcGIS APIs
+- **Integration test** against live Kitsap County endpoint: skipped in CI, run manually with `LIVE_GIS_TEST=1`
+- **Component tests** for ParcelLookup state transitions
+
+## External APIs (all free, no keys)
+
+| API | Purpose | Rate limits |
+|---|---|---|
+| Census Geocoder | Address -> lat/lng | Undocumented, generous |
+| Census TIGERweb | lat/lng -> county FIPS | Undocumented, generous |
+| ArcGIS Hub Search | Discover county FeatureServer URLs | Public, no auth |
+| County ArcGIS FeatureServers | Query parcel polygons | Public, per-county |
+
+## Success Criteria
+
+- Given a US address, returns correct parcel boundary in <5 seconds for discoverable counties
+- Handles multi-parcel properties (detects adjacent same-owner parcels)
+- Falls back gracefully to manual draw / file upload with clear UX
+- Parcel data stored as geo_layer with source metadata
+- Works from both post-property-creation flow and geo layers admin
+- County registry auto-populates via discovery, no manual config required
+- No API keys or costs for v1
+
+## Out of Scope (v1)
+
+- Regrid API fallback (v2)
+- Onboarding wizard integration (v2)
+- Boundary versioning / history tracking
+- PMTiles cache triggering on boundary confirm (separate feature)
+- Non-US parcel systems
+- Admin UI for manually editing county registry entries

--- a/src/app/admin/properties/[slug]/settings/actions.ts
+++ b/src/app/admin/properties/[slug]/settings/actions.ts
@@ -23,6 +23,7 @@ const PROPERTY_KEY_TO_COLUMN: Record<string, string> = {
   footer_text: 'footer_text',
   footer_links: 'footer_links',
   custom_nav_items: 'custom_nav_items',
+  map_display_config: 'map_display_config',
 };
 
 /**

--- a/src/app/admin/properties/[slug]/settings/page.tsx
+++ b/src/app/admin/properties/[slug]/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useConfig } from '@/lib/config/client';
@@ -14,6 +14,9 @@ import { getPropertyGeoLayers, setPropertyBoundary } from '@/app/admin/geo-layer
 import LogoUploader from '@/components/admin/LogoUploader';
 import { getLogoUrl } from '@/lib/config/logo';
 import type { GeoLayerSummary, GeoLayerProperty } from '@/lib/geo/types';
+import MapDisplayConfigEditor from '@/components/admin/MapDisplayConfigEditor';
+import type { MapDisplayConfig } from '@/lib/config/map-display';
+import type { ItemType } from '@/lib/types';
 
 const CenterPicker = dynamic(() => import('@/components/manage/CenterPicker'), {
   ssr: false,
@@ -35,6 +38,8 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
   const [currentBoundaryId, setCurrentBoundaryId] = useState<string | null>(null);
+  const [mapDisplayConfig, setMapDisplayConfig] = useState<MapDisplayConfig | null>(null);
+  const [mapDisplayInitialized, setMapDisplayInitialized] = useState(false);
 
   const { data: propertyId } = useQuery({
     queryKey: ['admin', 'property', slug, 'id'],
@@ -61,6 +66,37 @@ export default function SettingsPage() {
     },
   });
 
+  const { data: itemTypes = [] } = useQuery({
+    queryKey: ['admin', 'itemTypes', orgId],
+    queryFn: async () => {
+      if (!orgId) return [];
+      const supabase = createClient();
+      const { data } = await supabase.from('item_types').select('*').eq('org_id', orgId).order('name');
+      return (data ?? []) as ItemType[];
+    },
+    enabled: !!orgId,
+  });
+
+  const { data: orgMapDisplayConfig } = useQuery({
+    queryKey: ['admin', 'orgMapDisplayConfig'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data: org } = await supabase.from('orgs').select('map_display_config').limit(1).single();
+      return (org?.map_display_config as MapDisplayConfig | null) ?? null;
+    },
+  });
+
+  const { data: propertyMapDisplayConfig, refetch: refetchPropertyConfig } = useQuery({
+    queryKey: ['admin', 'property', slug, 'mapDisplayConfig'],
+    queryFn: async () => {
+      if (!propertyId) return null;
+      const supabase = createClient();
+      const { data } = await supabase.from('properties').select('map_display_config').eq('id', propertyId).single();
+      return (data?.map_display_config as MapDisplayConfig | null) ?? null;
+    },
+    enabled: !!propertyId,
+  });
+
   const { data: geoLayerData } = useQuery({
     queryKey: ['admin', 'property', slug, 'geo-layers'],
     queryFn: async () => {
@@ -76,6 +112,13 @@ export default function SettingsPage() {
 
   const propertyGeoLayers: GeoLayerSummary[] = geoLayerData?.layers ?? [];
   const layerAssignments: GeoLayerProperty[] = geoLayerData?.assignments ?? [];
+
+  useEffect(() => {
+    if (propertyMapDisplayConfig !== undefined && !mapDisplayInitialized) {
+      setMapDisplayConfig(propertyMapDisplayConfig);
+      setMapDisplayInitialized(true);
+    }
+  }, [propertyMapDisplayConfig, mapDisplayInitialized]);
 
   const tabs: { id: SettingsTab; label: string }[] = [
     { id: 'general', label: 'General' },
@@ -158,6 +201,28 @@ export default function SettingsPage() {
               />
             </section>
           )}
+          <section className="card space-y-5">
+            <h2 className="font-heading text-lg font-semibold text-forest-dark">
+              Map Display
+            </h2>
+            <MapDisplayConfigEditor
+              value={mapDisplayConfig}
+              onChange={setMapDisplayConfig}
+              itemTypes={itemTypes}
+              orgDefaults={orgMapDisplayConfig}
+            />
+            <button
+              type="button"
+              disabled={saving}
+              onClick={async () => {
+                await handleSave([{ key: 'map_display_config', value: mapDisplayConfig }]);
+                refetchPropertyConfig();
+              }}
+              className="btn-primary"
+            >
+              {saving ? 'Saving...' : 'Save Map Display'}
+            </button>
+          </section>
         </div>
       )}
       {activeTab === 'custommap' && (

--- a/src/app/admin/properties/[slug]/settings/page.tsx
+++ b/src/app/admin/properties/[slug]/settings/page.tsx
@@ -78,12 +78,14 @@ export default function SettingsPage() {
   });
 
   const { data: orgMapDisplayConfig } = useQuery({
-    queryKey: ['admin', 'orgMapDisplayConfig'],
+    queryKey: ['admin', 'orgMapDisplayConfig', orgId],
     queryFn: async () => {
+      if (!orgId) return null;
       const supabase = createClient();
-      const { data: org } = await supabase.from('orgs').select('map_display_config').limit(1).single();
+      const { data: org } = await supabase.from('orgs').select('map_display_config').eq('id', orgId).single();
       return (org?.map_display_config as MapDisplayConfig | null) ?? null;
     },
+    enabled: !!orgId,
   });
 
   const { data: propertyMapDisplayConfig, refetch: refetchPropertyConfig } = useQuery({

--- a/src/app/admin/settings/actions.ts
+++ b/src/app/admin/settings/actions.ts
@@ -16,6 +16,7 @@ export interface OrgSettings {
   theme: unknown | null;
   subscription_tier: SubscriptionTier;
   subscription_status: SubscriptionStatus;
+  map_display_config: unknown | null;
 }
 
 export async function getOrgSettings(): Promise<{ data?: OrgSettings; error?: string }> {
@@ -25,7 +26,7 @@ export async function getOrgSettings(): Promise<{ data?: OrgSettings; error?: st
 
   const { data, error } = await supabase
     .from('orgs')
-    .select('id, name, slug, tagline, pwa_name, logo_url, favicon_url, theme, subscription_tier, subscription_status')
+    .select('id, name, slug, tagline, pwa_name, logo_url, favicon_url, theme, subscription_tier, subscription_status, map_display_config')
     .eq('id', tenant.orgId)
     .single();
 
@@ -45,6 +46,7 @@ export async function getOrgSettings(): Promise<{ data?: OrgSettings; error?: st
       theme: data.theme,
       subscription_tier: data.subscription_tier as SubscriptionTier,
       subscription_status: data.subscription_status as SubscriptionStatus,
+      map_display_config: data.map_display_config,
     },
   };
 }
@@ -56,6 +58,7 @@ export interface OrgSettingsUpdates {
   pwa_name?: string;
   logo_url?: string;
   theme?: unknown;
+  map_display_config?: unknown;
 }
 
 export async function updateOrgSettings(
@@ -84,6 +87,7 @@ export async function updateOrgSettings(
   if (updates.pwa_name !== undefined) payload.pwa_name = updates.pwa_name;
   if (updates.logo_url !== undefined) payload.logo_url = updates.logo_url;
   if (updates.theme !== undefined) payload.theme = updates.theme;
+  if (updates.map_display_config !== undefined) payload.map_display_config = updates.map_display_config;
 
   if (Object.keys(payload).length === 0) {
     return { success: true }; // nothing to update

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -8,6 +8,10 @@ import type { OrgSettingsUpdates } from './actions';
 import type { SubscriptionTier, SubscriptionStatus } from '@/lib/types';
 import LogoUploader from '@/components/admin/LogoUploader';
 import { getLogoUrl } from '@/lib/config/logo';
+import MapDisplayConfigEditor from '@/components/admin/MapDisplayConfigEditor';
+import type { MapDisplayConfig } from '@/lib/config/map-display';
+import type { ItemType } from '@/lib/types';
+import { createClient } from '@/lib/supabase/client';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,6 +63,7 @@ export default function OrgSettingsPage() {
   const [pwaName, setPwaName] = useState('');
   const [themeJson, setThemeJson] = useState('');
   const [themeJsonError, setThemeJsonError] = useState('');
+  const [mapDisplayConfig, setMapDisplayConfig] = useState<MapDisplayConfig | null>(null);
 
   const { data: settings, isLoading: loading } = useQuery({
     queryKey: ['admin', 'settings'],
@@ -72,6 +77,17 @@ export default function OrgSettingsPage() {
     },
   });
 
+  const { data: itemTypes = [] } = useQuery({
+    queryKey: ['admin', 'itemTypes'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data: org } = await supabase.from('orgs').select('id').limit(1).single();
+      if (!org) return [];
+      const { data } = await supabase.from('item_types').select('*').eq('org_id', org.id).order('name');
+      return (data ?? []) as ItemType[];
+    },
+  });
+
   useEffect(() => {
     if (settings && !initialized.current) {
       initialized.current = true;
@@ -80,6 +96,7 @@ export default function OrgSettingsPage() {
       setTagline(settings.tagline ?? '');
       setPwaName(settings.pwa_name ?? '');
       setThemeJson(settings.theme ? JSON.stringify(settings.theme, null, 2) : '');
+      setMapDisplayConfig(settings.map_display_config as MapDisplayConfig | null);
     }
   }, [settings]);
 
@@ -108,6 +125,10 @@ export default function OrgSettingsPage() {
       const newThemeStr = parsedTheme !== undefined ? JSON.stringify(parsedTheme) : '';
       if (newThemeStr !== currentThemeStr) updates.theme = parsedTheme ?? null;
     }
+
+    const currentMapConfig = JSON.stringify(settings?.map_display_config ?? null);
+    const newMapConfig = JSON.stringify(mapDisplayConfig);
+    if (newMapConfig !== currentMapConfig) updates.map_display_config = mapDisplayConfig;
 
     setSaving(true);
     setMessage('');
@@ -271,6 +292,21 @@ export default function OrgSettingsPage() {
               default theme.
             </p>
           </div>
+        </section>
+
+        {/* Map Display section */}
+        <section className="card space-y-5">
+          <h2 className="font-heading text-lg font-semibold text-forest-dark">
+            Map Display
+          </h2>
+          <p className="text-xs text-sage">
+            Configure which controls appear on the map. These defaults apply to all properties unless overridden.
+          </p>
+          <MapDisplayConfigEditor
+            value={mapDisplayConfig}
+            onChange={setMapDisplayConfig}
+            itemTypes={itemTypes}
+          />
         </section>
 
         {/* Subscription section (read-only) */}

--- a/src/components/admin/MapDisplayConfigEditor.tsx
+++ b/src/components/admin/MapDisplayConfigEditor.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { MapDisplayConfig } from '@/lib/config/map-display';
+import type { ItemType, ItemStatus } from '@/lib/types';
+import { statusColors, statusLabels } from '@/lib/utils';
+
+interface ControlDef {
+  key: keyof NonNullable<MapDisplayConfig['controls']>;
+  label: string;
+  description: string;
+  icon: string;
+}
+
+const CONTROLS: ControlDef[] = [
+  { key: 'legend', label: 'Legend', description: 'Status colors & item types', icon: '🗺️' },
+  { key: 'locateMe', label: 'Current Position', description: 'Center map on user location', icon: '📍' },
+  { key: 'viewAsList', label: 'View as List', description: 'Link to list view', icon: '📋' },
+  { key: 'layerSelector', label: 'Layer Selector', description: 'Toggle geo layer visibility', icon: '🗂️' },
+  { key: 'quickAdd', label: 'Quick Add', description: 'Floating add button', icon: '➕' },
+];
+
+const ALL_STATUSES: ItemStatus[] = ['active', 'planned', 'damaged', 'removed'];
+
+interface Props {
+  value: MapDisplayConfig | null;
+  onChange: (config: MapDisplayConfig | null) => void;
+  itemTypes: ItemType[];
+  /** Org-level config for showing defaults on property page. Omit for org-level editing. */
+  orgDefaults?: MapDisplayConfig | null;
+}
+
+export default function MapDisplayConfigEditor({ value, onChange, itemTypes, orgDefaults }: Props) {
+  const config = value ?? {};
+  const isPropertyLevel = orgDefaults !== undefined;
+
+  function getControlValue(key: keyof NonNullable<MapDisplayConfig['controls']>): boolean {
+    return config.controls?.[key] ?? (isPropertyLevel ? (orgDefaults?.controls?.[key] ?? true) : true);
+  }
+
+  function isControlOverridden(key: keyof NonNullable<MapDisplayConfig['controls']>): boolean {
+    if (!isPropertyLevel) return false;
+    return config.controls?.[key] !== undefined;
+  }
+
+  function getOrgDefault(key: keyof NonNullable<MapDisplayConfig['controls']>): boolean {
+    return orgDefaults?.controls?.[key] ?? true;
+  }
+
+  function setControl(key: keyof NonNullable<MapDisplayConfig['controls']>, val: boolean) {
+    const newControls = { ...config.controls, [key]: val };
+    onChange({ ...config, controls: newControls });
+  }
+
+  function resetControl(key: keyof NonNullable<MapDisplayConfig['controls']>) {
+    if (!config.controls) return;
+    const newControls = { ...config.controls };
+    delete newControls[key];
+    const hasKeys = Object.keys(newControls).length > 0;
+    onChange({ ...config, controls: hasKeys ? newControls : undefined });
+  }
+
+  function getLegendStatuses(): string[] | undefined {
+    return config.legend?.statuses ?? (isPropertyLevel ? orgDefaults?.legend?.statuses : undefined);
+  }
+
+  function getLegendItemTypeIds(): string[] | undefined {
+    return config.legend?.itemTypeIds ?? (isPropertyLevel ? orgDefaults?.legend?.itemTypeIds : undefined);
+  }
+
+  function setLegendStatuses(statuses: string[] | undefined) {
+    const newLegend = { ...config.legend, statuses };
+    if (!statuses) delete newLegend.statuses;
+    const hasKeys = Object.keys(newLegend).length > 0;
+    onChange({ ...config, legend: hasKeys ? newLegend : undefined });
+  }
+
+  function setLegendItemTypeIds(ids: string[] | undefined) {
+    const newLegend = { ...config.legend, itemTypeIds: ids };
+    if (!ids) delete newLegend.itemTypeIds;
+    const hasKeys = Object.keys(newLegend).length > 0;
+    onChange({ ...config, legend: hasKeys ? newLegend : undefined });
+  }
+
+  function toggleStatus(status: string) {
+    const current = getLegendStatuses();
+    if (!current) {
+      setLegendStatuses(ALL_STATUSES.filter((s) => s !== status));
+    } else if (current.includes(status)) {
+      const next = current.filter((s) => s !== status);
+      setLegendStatuses(next.length > 0 ? next : undefined);
+    } else {
+      setLegendStatuses([...current, status]);
+    }
+  }
+
+  function toggleItemType(typeId: string) {
+    const current = getLegendItemTypeIds();
+    if (!current) {
+      setLegendItemTypeIds(itemTypes.filter((t) => t.id !== typeId).map((t) => t.id));
+    } else if (current.includes(typeId)) {
+      const next = current.filter((id) => id !== typeId);
+      setLegendItemTypeIds(next.length > 0 ? next : undefined);
+    } else {
+      setLegendItemTypeIds([...current, typeId]);
+    }
+  }
+
+  function isStatusChecked(status: string): boolean {
+    const statuses = getLegendStatuses();
+    return !statuses || statuses.includes(status);
+  }
+
+  function isItemTypeChecked(typeId: string): boolean {
+    const ids = getLegendItemTypeIds();
+    return !ids || ids.includes(typeId);
+  }
+
+  const legendEnabled = getControlValue('legend');
+
+  return (
+    <div className="space-y-2">
+      {CONTROLS.map((ctrl) => {
+        const enabled = getControlValue(ctrl.key);
+        const overridden = isControlOverridden(ctrl.key);
+        const orgDefault = isPropertyLevel ? getOrgDefault(ctrl.key) : null;
+
+        return (
+          <div key={ctrl.key}>
+            <div
+              className={`flex items-center justify-between p-3 rounded-lg border transition-colors ${
+                overridden
+                  ? 'bg-amber-50 border-amber-300'
+                  : 'bg-sage-light/30 border-sage-light'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-base">{ctrl.icon}</span>
+                <div>
+                  <div className="text-sm font-medium text-forest-dark">{ctrl.label}</div>
+                  {isPropertyLevel && (
+                    <div className={`text-[10px] ${overridden ? 'text-amber-700' : 'text-sage'}`}>
+                      Org default: {orgDefault ? 'On' : 'Off'}
+                      {overridden && (
+                        <>
+                          {' · '}
+                          <button
+                            type="button"
+                            onClick={() => resetControl(ctrl.key)}
+                            className="underline hover:no-underline"
+                          >
+                            Reset
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  {!isPropertyLevel && (
+                    <div className="text-[10px] text-sage">{ctrl.description}</div>
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => setControl(ctrl.key, !enabled)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                  enabled ? 'bg-forest' : 'bg-gray-300'
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform ${
+                    enabled ? 'translate-x-4' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {ctrl.key === 'legend' && legendEnabled && (
+              <div className="ml-3 mt-2 p-3 rounded-lg border border-sage-light bg-white space-y-3">
+                <div>
+                  <div className="text-xs font-medium text-sage uppercase tracking-wider mb-2">Statuses</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {ALL_STATUSES.map((status) => {
+                      const checked = isStatusChecked(status);
+                      return (
+                        <label
+                          key={status}
+                          className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs cursor-pointer border transition-colors ${
+                            checked
+                              ? 'bg-green-50 border-green-300 text-forest-dark'
+                              : 'bg-gray-50 border-gray-200 text-gray-400 line-through'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleStatus(status)}
+                            className="sr-only"
+                          />
+                          <span
+                            className="w-2.5 h-2.5 rounded-full"
+                            style={{ backgroundColor: statusColors[status as ItemStatus] }}
+                          />
+                          {statusLabels[status as ItemStatus]}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+                {itemTypes.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-sage uppercase tracking-wider mb-2">Item Types</div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {itemTypes.map((type) => {
+                        const checked = isItemTypeChecked(type.id);
+                        return (
+                          <label
+                            key={type.id}
+                            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs cursor-pointer border transition-colors ${
+                              checked
+                                ? 'bg-green-50 border-green-300 text-forest-dark'
+                                : 'bg-gray-50 border-gray-200 text-gray-400 line-through'
+                            }`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() => toggleItemType(type.id)}
+                              className="sr-only"
+                            />
+                            <span>{type.icon}</span>
+                            {type.name}
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+                {isPropertyLevel && (config.legend?.statuses || config.legend?.itemTypeIds) && (
+                  <button
+                    type="button"
+                    onClick={() => onChange({ ...config, legend: undefined })}
+                    className="text-[10px] text-amber-700 underline hover:no-underline"
+                  >
+                    Reset legend to org default
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/admin/MapDisplayConfigEditor.tsx
+++ b/src/components/admin/MapDisplayConfigEditor.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import type { MapDisplayConfig } from '@/lib/config/map-display';
 import type { ItemType, ItemStatus } from '@/lib/types';
 import { statusColors, statusLabels } from '@/lib/utils';

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -60,6 +60,7 @@ function HomeMapViewContent() {
   const searchParams = useSearchParams();
   const deepLinkedRef = useRef(false);
   const config = useConfig();
+  const { controls: mapControls } = config.mapDisplayConfig;
   const propertyId = config.propertyId;
   const offlineStore = useOfflineStore();
 
@@ -293,12 +294,14 @@ function HomeMapViewContent() {
       />
 
       {/* List view link */}
-      <Link
-        href="/list"
-        className="absolute top-4 right-4 z-10 bg-white backdrop-blur-sm rounded-lg shadow-lg border border-sage-light px-3 py-2 text-xs font-medium text-forest-dark hover:bg-sage-light transition-colors"
-      >
-        View as List
-      </Link>
+      {mapControls.viewAsList && (
+        <Link
+          href="/list"
+          className="absolute top-4 right-4 z-10 bg-white backdrop-blur-sm rounded-lg shadow-lg border border-sage-light px-3 py-2 text-xs font-medium text-forest-dark hover:bg-sage-light transition-colors"
+        >
+          View as List
+        </Link>
+      )}
 
       {/* Detail panel */}
       <DetailPanel

--- a/src/components/map/MapLegend.tsx
+++ b/src/components/map/MapLegend.tsx
@@ -1,21 +1,29 @@
 'use client';
 
 import { useState } from 'react';
-import type { ItemType } from '@/lib/types';
-import { statusColors } from '@/lib/utils';
+import type { ItemType, ItemStatus } from '@/lib/types';
+import { statusColors, statusLabels } from '@/lib/utils';
 
 interface MapLegendProps {
   itemTypes: ItemType[];
+  legendConfig?: {
+    statuses?: string[];
+    itemTypeIds?: string[];
+  };
 }
 
-export default function MapLegend({ itemTypes }: MapLegendProps) {
+export default function MapLegend({ itemTypes, legendConfig }: MapLegendProps) {
   const [collapsed, setCollapsed] = useState(false);
 
-  const statusItems = [
-    { color: statusColors.active, label: 'Active' },
-    { color: statusColors.planned, label: 'Planned' },
-    { color: statusColors.damaged, label: 'Needs Repair' },
-  ];
+  const allStatuses: ItemStatus[] = ['active', 'planned', 'damaged', 'removed'];
+  const visibleStatuses = legendConfig?.statuses
+    ? allStatuses.filter((s) => legendConfig.statuses!.includes(s))
+    : allStatuses.filter((s) => s !== 'removed');
+
+  const statusItems = visibleStatuses.map((s) => ({
+    color: statusColors[s],
+    label: statusLabels[s],
+  }));
 
   return (
     <div className="absolute bottom-20 md:bottom-6 left-4 z-10">
@@ -56,21 +64,26 @@ export default function MapLegend({ itemTypes }: MapLegendProps) {
               </div>
             ))}
           </div>
-          {itemTypes.length > 1 && (
-            <>
-              <h4 className="text-[10px] font-medium text-sage uppercase tracking-wider mt-2 mb-1.5">
-                Types
-              </h4>
-              <div className="space-y-1">
-                {itemTypes.map((type) => (
-                  <div key={type.id} className="flex items-center gap-2">
-                    <span className="text-sm">{type.icon}</span>
-                    <span className="text-xs text-forest-dark">{type.name}</span>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
+          {(() => {
+            const visibleTypes = legendConfig?.itemTypeIds
+              ? itemTypes.filter((t) => legendConfig.itemTypeIds!.includes(t.id))
+              : itemTypes;
+            return visibleTypes.length > 1 ? (
+              <>
+                <h4 className="text-[10px] font-medium text-sage uppercase tracking-wider mt-2 mb-1.5">
+                  Types
+                </h4>
+                <div className="space-y-1">
+                  {visibleTypes.map((type) => (
+                    <div key={type.id} className="flex items-center gap-2">
+                      <span className="text-sm">{type.icon}</span>
+                      <span className="text-xs text-forest-dark">{type.name}</span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : null;
+          })()}
         </div>
       )}
     </div>

--- a/src/components/map/MapLegend.tsx
+++ b/src/components/map/MapLegend.tsx
@@ -25,6 +25,10 @@ export default function MapLegend({ itemTypes, legendConfig }: MapLegendProps) {
     label: statusLabels[s],
   }));
 
+  const visibleTypes = legendConfig?.itemTypeIds
+    ? itemTypes.filter((t) => legendConfig.itemTypeIds!.includes(t.id))
+    : itemTypes;
+
   return (
     <div className="absolute bottom-20 md:bottom-6 left-4 z-10">
       {collapsed ? (
@@ -64,26 +68,21 @@ export default function MapLegend({ itemTypes, legendConfig }: MapLegendProps) {
               </div>
             ))}
           </div>
-          {(() => {
-            const visibleTypes = legendConfig?.itemTypeIds
-              ? itemTypes.filter((t) => legendConfig.itemTypeIds!.includes(t.id))
-              : itemTypes;
-            return visibleTypes.length > 1 ? (
-              <>
-                <h4 className="text-[10px] font-medium text-sage uppercase tracking-wider mt-2 mb-1.5">
-                  Types
-                </h4>
-                <div className="space-y-1">
-                  {visibleTypes.map((type) => (
-                    <div key={type.id} className="flex items-center gap-2">
-                      <span className="text-sm">{type.icon}</span>
-                      <span className="text-xs text-forest-dark">{type.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </>
-            ) : null;
-          })()}
+          {visibleTypes.length > 1 && (
+            <>
+              <h4 className="text-[10px] font-medium text-sage uppercase tracking-wider mt-2 mb-1.5">
+                Types
+              </h4>
+              <div className="space-y-1">
+                {visibleTypes.map((type) => (
+                  <div key={type.id} className="flex items-center gap-2">
+                    <span className="text-sm">{type.icon}</span>
+                    <span className="text-xs text-forest-dark">{type.name}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -65,6 +65,7 @@ export default function MapView({
   sheetState,
 }: MapViewProps) {
   const config = useConfig();
+  const { controls: mapControls } = config.mapDisplayConfig;
   const theme = useTheme();
   const { position } = useUserLocation();
   const center: [number, number] = [config.mapCenter.lat, config.mapCenter.lng];
@@ -151,7 +152,7 @@ export default function MapView({
         })}
       </MapContainer>
 
-      {geoLayers && geoLayers.length > 0 && (
+      {mapControls.layerSelector && geoLayers && geoLayers.length > 0 && (
         <LayerControlPanel
           layers={geoLayers}
           visibleLayerIds={visibleGeoLayerIds ?? new Set()}
@@ -205,11 +206,11 @@ export default function MapView({
         )}
       </button>
 
-      <LocateButton onLocate={() => setFlyToUserTrigger((n) => n + 1)} />
-      <MapLegend itemTypes={itemTypes} />
+      {mapControls.locateMe && (<LocateButton onLocate={() => setFlyToUserTrigger((n) => n + 1)} />)}
+      {mapControls.legend && (<MapLegend itemTypes={itemTypes} legendConfig={config.mapDisplayConfig.legend} />)}
 
       {/* Quick-add FAB — hidden when sheet is half/full, raised above peek sheet */}
-      {sheetState !== 'half' && sheetState !== 'full' && (
+      {mapControls.quickAdd && sheetState !== 'half' && sheetState !== 'full' && (
         <button
           onClick={() => setQuickAddOpen(true)}
           className={`fixed right-4 z-30 bg-green-600 hover:bg-green-700 text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center text-3xl font-light transition-all duration-300 ${

--- a/src/lib/__tests__/multi-tenant-types.test.ts
+++ b/src/lib/__tests__/multi-tenant-types.test.ts
@@ -88,6 +88,7 @@ describe('Multi-tenant types', () => {
         tagline: null,
         setup_complete: false,
         default_property_id: null,
+        map_display_config: null,
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
       };

--- a/src/lib/__tests__/phase2-types.test.ts
+++ b/src/lib/__tests__/phase2-types.test.ts
@@ -47,6 +47,7 @@ describe('Phase 2 types', () => {
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
         deleted_at: null,
+        map_display_config: null,
       };
       expect(prop.org_id).toBe('org-1');
     });

--- a/src/lib/config/__tests__/config.test.ts
+++ b/src/lib/config/__tests__/config.test.ts
@@ -124,6 +124,46 @@ describe('buildSiteConfig', () => {
     expect(config.logoUrl).toBe('https://example.com/org-logo.png');
   });
 
+  it('resolves mapDisplayConfig from org and property', () => {
+    const org = {
+      name: 'Test',
+      tagline: null,
+      logo_url: null,
+      favicon_url: null,
+      theme: null,
+      setup_complete: false,
+      map_display_config: { controls: { legend: false, quickAdd: false } },
+    };
+    const property = {
+      description: null,
+      map_default_lat: null,
+      map_default_lng: null,
+      map_default_zoom: null,
+      map_style: null,
+      custom_map: null,
+      about_content: null,
+      about_page_enabled: null,
+      footer_text: null,
+      footer_links: null,
+      custom_nav_items: null,
+      landing_page: null,
+      logo_url: null,
+      puck_pages: null,
+      puck_root: null,
+      puck_template: null,
+      puck_pages_draft: null,
+      puck_root_draft: null,
+      puck_page_meta: null,
+      map_display_config: { controls: { legend: true } },
+    };
+
+    const config = buildSiteConfig(org, property);
+
+    expect(config.mapDisplayConfig.controls.legend).toBe(true);
+    expect(config.mapDisplayConfig.controls.quickAdd).toBe(false);
+    expect(config.mapDisplayConfig.controls.locateMe).toBe(true);
+  });
+
   it('uses defaults for null org/property fields', () => {
     const org = {
       name: 'Minimal',

--- a/src/lib/config/__tests__/map-display.test.ts
+++ b/src/lib/config/__tests__/map-display.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMapDisplayConfig } from '../map-display';
+import type { MapDisplayConfig, ResolvedMapDisplayConfig } from '../map-display';
+
+describe('resolveMapDisplayConfig', () => {
+  it('returns all-true defaults when both org and property are null', () => {
+    const result = resolveMapDisplayConfig(null, null);
+    expect(result.controls.legend).toBe(true);
+    expect(result.controls.layerSelector).toBe(true);
+    expect(result.controls.locateMe).toBe(true);
+    expect(result.controls.viewAsList).toBe(true);
+    expect(result.controls.quickAdd).toBe(true);
+    expect(result.legend.statuses).toBeUndefined();
+    expect(result.legend.itemTypeIds).toBeUndefined();
+  });
+
+  it('uses org config when property is null', () => {
+    const org: MapDisplayConfig = {
+      controls: { legend: false, quickAdd: false },
+      legend: { statuses: ['active', 'planned'] },
+    };
+    const result = resolveMapDisplayConfig(org, null);
+    expect(result.controls.legend).toBe(false);
+    expect(result.controls.layerSelector).toBe(true);
+    expect(result.controls.quickAdd).toBe(false);
+    expect(result.legend.statuses).toEqual(['active', 'planned']);
+  });
+
+  it('property controls override org controls per-key', () => {
+    const org: MapDisplayConfig = {
+      controls: { legend: false, locateMe: false },
+    };
+    const property: MapDisplayConfig = {
+      controls: { legend: true },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.controls.legend).toBe(true);    // property overrides
+    expect(result.controls.locateMe).toBe(false);  // falls through to org
+    expect(result.controls.layerSelector).toBe(true); // default
+  });
+
+  it('property legend statuses fully replace org legend statuses', () => {
+    const org: MapDisplayConfig = {
+      legend: { statuses: ['active', 'planned'] },
+    };
+    const property: MapDisplayConfig = {
+      legend: { statuses: ['active', 'damaged'] },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.legend.statuses).toEqual(['active', 'damaged']);
+  });
+
+  it('property legend itemTypeIds fully replace org itemTypeIds', () => {
+    const org: MapDisplayConfig = {
+      legend: { itemTypeIds: ['id-1', 'id-2'] },
+    };
+    const property: MapDisplayConfig = {
+      legend: { itemTypeIds: ['id-3'] },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.legend.itemTypeIds).toEqual(['id-3']);
+  });
+
+  it('falls through to org legend when property legend is undefined', () => {
+    const org: MapDisplayConfig = {
+      legend: { statuses: ['active'], itemTypeIds: ['id-1'] },
+    };
+    const property: MapDisplayConfig = {
+      controls: { quickAdd: false },
+    };
+    const result = resolveMapDisplayConfig(org, property);
+    expect(result.legend.statuses).toEqual(['active']);
+    expect(result.legend.itemTypeIds).toEqual(['id-1']);
+  });
+});

--- a/src/lib/config/defaults.ts
+++ b/src/lib/config/defaults.ts
@@ -1,4 +1,5 @@
 import type { SiteConfig } from './types';
+import { resolveMapDisplayConfig } from './map-display';
 
 export const DEFAULT_CONFIG: SiteConfig = {
   siteName: 'Field Mapper',
@@ -27,4 +28,5 @@ export const DEFAULT_CONFIG: SiteConfig = {
   puckPagesDraft: null,
   puckRootDraft: null,
   puckPageMeta: null,
+  mapDisplayConfig: resolveMapDisplayConfig(null, null),
 };

--- a/src/lib/config/map-display.ts
+++ b/src/lib/config/map-display.ts
@@ -1,0 +1,54 @@
+export interface MapDisplayConfig {
+  controls?: {
+    legend?: boolean;
+    layerSelector?: boolean;
+    locateMe?: boolean;
+    viewAsList?: boolean;
+    quickAdd?: boolean;
+  };
+  legend?: {
+    statuses?: string[];
+    itemTypeIds?: string[];
+  };
+}
+
+export interface ResolvedMapDisplayConfig {
+  controls: {
+    legend: boolean;
+    layerSelector: boolean;
+    locateMe: boolean;
+    viewAsList: boolean;
+    quickAdd: boolean;
+  };
+  legend: {
+    statuses?: string[];
+    itemTypeIds?: string[];
+  };
+}
+
+/**
+ * Merge org and property map display configs with cascade logic.
+ * Controls: property per-key overrides org per-key, unset defaults to true.
+ * Legend lists: property fully replaces org if set, otherwise falls through.
+ */
+export function resolveMapDisplayConfig(
+  orgConfig: MapDisplayConfig | null | undefined,
+  propertyConfig: MapDisplayConfig | null | undefined,
+): ResolvedMapDisplayConfig {
+  const orgControls = orgConfig?.controls;
+  const propControls = propertyConfig?.controls;
+
+  return {
+    controls: {
+      legend: propControls?.legend ?? orgControls?.legend ?? true,
+      layerSelector: propControls?.layerSelector ?? orgControls?.layerSelector ?? true,
+      locateMe: propControls?.locateMe ?? orgControls?.locateMe ?? true,
+      viewAsList: propControls?.viewAsList ?? orgControls?.viewAsList ?? true,
+      quickAdd: propControls?.quickAdd ?? orgControls?.quickAdd ?? true,
+    },
+    legend: {
+      statuses: propertyConfig?.legend?.statuses ?? orgConfig?.legend?.statuses,
+      itemTypeIds: propertyConfig?.legend?.itemTypeIds ?? orgConfig?.legend?.itemTypeIds,
+    },
+  };
+}

--- a/src/lib/config/server.ts
+++ b/src/lib/config/server.ts
@@ -29,7 +29,7 @@ export const getConfig = unstable_cache(
     // Get the first org and its default property
     const { data: org, error: orgError } = await supabase
       .from('orgs')
-      .select('name, pwa_name, tagline, logo_url, favicon_url, theme, setup_complete, default_property_id')
+      .select('name, pwa_name, tagline, logo_url, favicon_url, theme, setup_complete, default_property_id, map_display_config')
       .limit(1)
       .single();
 
@@ -46,7 +46,7 @@ export const getConfig = unstable_cache(
 
     const { data: property, error: propError } = await supabase
       .from('properties')
-      .select('id, name, pwa_name, description, map_default_lat, map_default_lng, map_default_zoom, map_style, custom_map, about_content, about_page_enabled, footer_text, footer_links, custom_nav_items, landing_page, logo_url, puck_pages, puck_root, puck_template, puck_pages_draft, puck_root_draft, puck_page_meta')
+      .select('id, name, pwa_name, description, map_default_lat, map_default_lng, map_default_zoom, map_style, custom_map, about_content, about_page_enabled, footer_text, footer_links, custom_nav_items, landing_page, logo_url, puck_pages, puck_root, puck_template, puck_pages_draft, puck_root_draft, puck_page_meta, map_display_config')
       .eq('id', propertyId)
       .single();
 

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -1,5 +1,5 @@
 import type { LandingPageConfig } from './landing-types';
-import { resolveMapDisplayConfig, type ResolvedMapDisplayConfig } from './map-display';
+import { resolveMapDisplayConfig, type ResolvedMapDisplayConfig, type MapDisplayConfig } from './map-display';
 
 export interface SiteConfig {
   siteName: string;
@@ -118,8 +118,8 @@ export function buildSiteConfig(
     puckRootDraft: property.puck_root_draft as Record<string, unknown> | null ?? null,
     puckPageMeta: property.puck_page_meta as Record<string, { title: string; slug: string; createdAt: string }> | null ?? null,
     mapDisplayConfig: resolveMapDisplayConfig(
-      org.map_display_config as import('./map-display').MapDisplayConfig | null,
-      property.map_display_config as import('./map-display').MapDisplayConfig | null,
+      org.map_display_config as MapDisplayConfig | null,
+      property.map_display_config as MapDisplayConfig | null,
     ),
   };
 }

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -1,4 +1,5 @@
 import type { LandingPageConfig } from './landing-types';
+import { resolveMapDisplayConfig, type ResolvedMapDisplayConfig } from './map-display';
 
 export interface SiteConfig {
   siteName: string;
@@ -41,6 +42,7 @@ export interface SiteConfig {
   puckPagesDraft: Record<string, unknown> | null;
   puckRootDraft: Record<string, unknown> | null;
   puckPageMeta: Record<string, { title: string; slug: string; createdAt: string }> | null;
+  mapDisplayConfig: ResolvedMapDisplayConfig;
 }
 
 /**
@@ -56,6 +58,7 @@ export function buildSiteConfig(
     favicon_url: string | null;
     theme: { preset: string; overrides?: Record<string, string> } | null;
     setup_complete: boolean;
+    map_display_config?: unknown | null;
   },
   property: {
     id?: string;
@@ -80,6 +83,7 @@ export function buildSiteConfig(
     puck_pages_draft: unknown | null;
     puck_root_draft: unknown | null;
     puck_page_meta: unknown | null;
+    map_display_config?: unknown | null;
   }
 ): SiteConfig {
   return {
@@ -113,5 +117,9 @@ export function buildSiteConfig(
     puckPagesDraft: property.puck_pages_draft as Record<string, unknown> | null ?? null,
     puckRootDraft: property.puck_root_draft as Record<string, unknown> | null ?? null,
     puckPageMeta: property.puck_page_meta as Record<string, { title: string; slug: string; createdAt: string }> | null ?? null,
+    mapDisplayConfig: resolveMapDisplayConfig(
+      org.map_display_config as import('./map-display').MapDisplayConfig | null,
+      property.map_display_config as import('./map-display').MapDisplayConfig | null,
+    ),
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,6 +142,7 @@ export interface Org {
   default_property_id: string | null;
   created_at: string;
   updated_at: string;
+  map_display_config: unknown | null;
 }
 
 export interface RolePermissions {
@@ -221,6 +222,7 @@ export interface Property {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  map_display_config: unknown | null;
 }
 
 export interface PropertyMembership {

--- a/supabase/migrations/034_map_display_config.sql
+++ b/supabase/migrations/034_map_display_config.sql
@@ -1,0 +1,9 @@
+-- Add map display configuration to orgs and properties
+-- Stores control visibility toggles and legend content filters as JSONB
+-- null = use all defaults (everything visible)
+
+ALTER TABLE orgs
+  ADD COLUMN IF NOT EXISTS map_display_config JSONB DEFAULT NULL;
+
+ALTER TABLE properties
+  ADD COLUMN IF NOT EXISTS map_display_config JSONB DEFAULT NULL;


### PR DESCRIPTION
## Summary

- Add `map_display_config` JSONB column to `orgs` and `properties` tables for configuring which map controls are visible
- Five configurable controls: Legend, Layer Selector, Current Position, View as List, Quick Add FAB
- Granular legend config: choose which statuses and item types appear in the legend
- Org-level defaults cascade to all properties unless overridden at property level
- Admin UI with card-per-control toggle switches in both Org Settings and Property Settings (Appearance tab)
- Property-level UI shows "Org default: On/Off" labels with amber highlight and Reset for overrides

## Test plan

- [ ] 876 unit tests pass, type check clean, build succeeds
- [ ] Visit `/admin/settings` — verify Map Display section with 5 toggle cards
- [ ] Toggle legend off at org level → save → map page should hide legend
- [ ] Expand legend card → uncheck a status → save → legend filters correctly
- [ ] Visit `/admin/properties/[slug]/settings` → Appearance tab → verify Map Display with org default labels
- [ ] Override a control at property level → verify amber highlight + Reset link
- [ ] Click Reset → value reverts to org default
- [ ] Toggle Quick Add off → save → FAB hidden on map

🤖 Generated with [Claude Code](https://claude.com/claude-code)