### PR TITLE
feat: knowledge editor spacing & paste controls

### DIFF
--- a/docs/superpowers/plans/2026-04-06-knowledge-layout.md
+++ b/docs/superpowers/plans/2026-04-06-knowledge-layout.md
@@ -1,0 +1,644 @@
+# Knowledge Editor Spacing & Paste Controls — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-paragraph line-height control and a paste formatting dialog to the TipTap-based knowledge editor, fixing the double-spaced content problem from pasted sources.
+
+**Architecture:** A custom TipTap extension (`LineHeight`) adds a `lineHeight` global attribute to block nodes, rendered as inline `style="line-height: ..."`. A toolbar dropdown sets/unsets line height. A paste handler detects rich HTML and shows a dialog offering "Keep" vs "Plain text". All state stays in TipTap's JSON document — no DB changes needed.
+
+**Tech Stack:** TipTap 3.x (`@tiptap/core`, `@tiptap/react`), React 18, Tailwind CSS, Vitest + @testing-library/react
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `src/lib/editor/LineHeightExtension.ts` | **New** — TipTap extension: global `lineHeight` attribute + commands |
+| `src/lib/editor/PasteFormatDialog.tsx` | **New** — floating dialog component for paste choice |
+| `src/lib/editor/extensions.ts` | **Modify** — register LineHeight extension |
+| `src/lib/editor/RichTextEditor.tsx` | **Modify** — add toolbar dropdown, paste handler, dialog integration |
+| `src/lib/editor/__tests__/LineHeightExtension.test.ts` | **New** — unit tests for extension |
+| `src/lib/editor/__tests__/PasteFormatDialog.test.tsx` | **New** — unit tests for paste dialog |
+| `src/lib/editor/__tests__/RichTextEditor.test.tsx` | **New** — integration tests for toolbar + paste |
+
+---
+
+### Task 1: LineHeight Extension — Tests
+
+**Files:**
+- Create: `src/lib/editor/__tests__/LineHeightExtension.test.ts`
+
+- [ ] **Step 1: Write tests for the LineHeight extension**
+
+```ts
+// src/lib/editor/__tests__/LineHeightExtension.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import Heading from '@tiptap/extension-heading';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import ListItem from '@tiptap/extension-list-item';
+import { LineHeight } from '../LineHeightExtension';
+import { generateHTML } from '@tiptap/html';
+
+function createEditor(content?: string) {
+  return new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      Heading.configure({ levels: [2, 3, 4] }),
+      BulletList,
+      OrderedList,
+      ListItem,
+      LineHeight,
+    ],
+    content: content ?? '<p>Hello world</p>',
+  });
+}
+
+describe('LineHeightExtension', () => {
+  it('registers setLineHeight and unsetLineHeight commands', () => {
+    const editor = createEditor();
+    expect(typeof editor.commands.setLineHeight).toBe('function');
+    expect(typeof editor.commands.unsetLineHeight).toBe('function');
+    editor.destroy();
+  });
+
+  it('sets lineHeight attribute on the current paragraph', () => {
+    const editor = createEditor();
+    editor.commands.setTextSelection(1);
+    editor.commands.setLineHeight('1.5');
+    const json = editor.getJSON();
+    expect(json.content?.[0].attrs?.lineHeight).toBe('1.5');
+    editor.destroy();
+  });
+
+  it('unsets lineHeight attribute', () => {
+    const editor = createEditor();
+    editor.commands.setTextSelection(1);
+    editor.commands.setLineHeight('1.5');
+    editor.commands.unsetLineHeight();
+    const json = editor.getJSON();
+    expect(json.content?.[0].attrs?.lineHeight).toBeNull();
+    editor.destroy();
+  });
+
+  it('generates HTML with inline line-height style', () => {
+    const extensions = [
+      Document,
+      Paragraph,
+      Text,
+      Heading.configure({ levels: [2, 3, 4] }),
+      BulletList,
+      OrderedList,
+      ListItem,
+      LineHeight,
+    ];
+    const json = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', attrs: { lineHeight: '1.15' }, content: [{ type: 'text', text: 'Tight text' }] },
+      ],
+    };
+    const html = generateHTML(json, extensions);
+    expect(html).toContain('style="line-height: 1.15"');
+    expect(html).toContain('Tight text');
+  });
+
+  it('does not add style attribute when lineHeight is null', () => {
+    const extensions = [
+      Document,
+      Paragraph,
+      Text,
+      Heading.configure({ levels: [2, 3, 4] }),
+      BulletList,
+      OrderedList,
+      ListItem,
+      LineHeight,
+    ];
+    const json = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Default text' }] },
+      ],
+    };
+    const html = generateHTML(json, extensions);
+    expect(html).not.toContain('line-height');
+  });
+
+  it('parses lineHeight from existing inline styles', () => {
+    const editor = createEditor('<p style="line-height: 2.0">Double spaced</p>');
+    const json = editor.getJSON();
+    expect(json.content?.[0].attrs?.lineHeight).toBe('2.0');
+    editor.destroy();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run src/lib/editor/__tests__/LineHeightExtension.test.ts`
+Expected: FAIL — `Cannot find module '../LineHeightExtension'`
+
+---
+
+### Task 2: LineHeight Extension — Implementation
+
+**Files:**
+- Create: `src/lib/editor/LineHeightExtension.ts`
+- Modify: `src/lib/editor/extensions.ts`
+
+- [ ] **Step 1: Create the LineHeight extension**
+
+```ts
+// src/lib/editor/LineHeightExtension.ts
+
+import { Extension } from '@tiptap/core';
+
+export interface LineHeightOptions {
+  types: string[];
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    lineHeight: {
+      setLineHeight: (lineHeight: string) => ReturnType;
+      unsetLineHeight: () => ReturnType;
+    };
+  }
+}
+
+export const LineHeight = Extension.create<LineHeightOptions>({
+  name: 'lineHeight',
+
+  addOptions() {
+    return {
+      types: ['paragraph', 'heading', 'bulletList', 'orderedList'],
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          lineHeight: {
+            default: null,
+            parseHTML: (element) => element.style.lineHeight || null,
+            renderHTML: (attributes) => {
+              if (!attributes.lineHeight) return {};
+              return { style: `line-height: ${attributes.lineHeight}` };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setLineHeight:
+        (lineHeight: string) =>
+        ({ commands }) => {
+          return this.options.types.every((type) =>
+            commands.updateAttributes(type, { lineHeight })
+          );
+        },
+      unsetLineHeight:
+        () =>
+        ({ commands }) => {
+          return this.options.types.every((type) =>
+            commands.resetAttributes(type, 'lineHeight')
+          );
+        },
+    };
+  },
+});
+```
+
+- [ ] **Step 2: Register the extension in `extensions.ts`**
+
+In `src/lib/editor/extensions.ts`, add the import and include `LineHeight` in the returned array:
+
+```ts
+import { LineHeight } from './LineHeightExtension';
+```
+
+Add `LineHeight,` after the `VaultImage` line (line 21), before `Placeholder.configure(...)`.
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run src/lib/editor/__tests__/LineHeightExtension.test.ts`
+Expected: All 6 tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-knowledge-layout
+git add src/lib/editor/LineHeightExtension.ts src/lib/editor/extensions.ts src/lib/editor/__tests__/LineHeightExtension.test.ts
+git commit -m "feat: add LineHeight TipTap extension with per-paragraph line spacing"
+```
+
+---
+
+### Task 3: Toolbar Line Height Dropdown
+
+**Files:**
+- Modify: `src/lib/editor/RichTextEditor.tsx`
+
+- [ ] **Step 1: Add the LineHeightDropdown component and integrate it into the toolbar**
+
+In `src/lib/editor/RichTextEditor.tsx`:
+
+1. Add a `LINE_HEIGHT_OPTIONS` constant above the component:
+
+```tsx
+const LINE_HEIGHT_OPTIONS = [
+  { value: '1', label: 'Compact' },
+  { value: '1.15', label: 'Normal' },
+  { value: '1.5', label: 'Relaxed' },
+  { value: '2', label: 'Double' },
+] as const;
+```
+
+2. Add a `LineHeightDropdown` component after the existing `ToolbarButton` component (after line 268):
+
+```tsx
+function LineHeightDropdown({ editor }: { editor: Editor }) {
+  const [open, setOpen] = useState(false);
+
+  const currentLineHeight = editor.getAttributes('paragraph').lineHeight
+    || editor.getAttributes('heading').lineHeight
+    || null;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        title="Line Spacing"
+        className={`px-2 py-1 rounded text-sm transition-colors ${
+          currentLineHeight
+            ? 'bg-sage text-white'
+            : 'text-forest-dark/70 hover:bg-sage-light hover:text-forest-dark'
+        }`}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <line x1="5" y1="3" x2="14" y2="3" />
+          <line x1="5" y1="8" x2="14" y2="8" />
+          <line x1="5" y1="13" x2="14" y2="13" />
+          <polyline points="2,5 2,1 2,5" />
+          <path d="M2 1L3.5 3M2 1L0.5 3" />
+          <polyline points="2,11 2,15 2,11" />
+          <path d="M2 15L3.5 13M2 15L0.5 13" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 bg-white border border-sage-light rounded-lg shadow-lg z-50 py-1 min-w-[140px]">
+          {LINE_HEIGHT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`w-full text-left px-3 py-1.5 text-sm hover:bg-sage-light transition-colors ${
+                currentLineHeight === opt.value ? 'bg-sage/10 text-forest-dark font-medium' : 'text-forest-dark/70'
+              }`}
+              onClick={() => {
+                if (currentLineHeight === opt.value) {
+                  editor.chain().focus().unsetLineHeight().run();
+                } else {
+                  editor.chain().focus().setLineHeight(opt.value).run();
+                }
+                setOpen(false);
+              }}
+            >
+              {opt.value} — {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+3. Add `import type { Editor } from '@tiptap/core';` to the imports at the top.
+
+4. Insert the dropdown into the toolbar JSX. After the blockquote `ToolbarButton` (line 196) and before the divider on line 198, add:
+
+```tsx
+          <LineHeightDropdown editor={editor} />
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-knowledge-layout
+git add src/lib/editor/RichTextEditor.tsx
+git commit -m "feat: add line height dropdown to knowledge editor toolbar"
+```
+
+---
+
+### Task 4: Paste Format Dialog — Tests
+
+**Files:**
+- Create: `src/lib/editor/__tests__/PasteFormatDialog.test.tsx`
+
+- [ ] **Step 1: Write tests for the PasteFormatDialog component**
+
+```tsx
+// src/lib/editor/__tests__/PasteFormatDialog.test.tsx
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PasteFormatDialog } from '../PasteFormatDialog';
+
+describe('PasteFormatDialog', () => {
+  it('renders the dialog with Keep and Plain text buttons', () => {
+    render(<PasteFormatDialog onKeep={vi.fn()} onPlainText={vi.fn()} />);
+    expect(screen.getByText('Pasted content contains formatting.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Plain text' })).toBeTruthy();
+  });
+
+  it('calls onKeep when Keep is clicked', () => {
+    const onKeep = vi.fn();
+    render(<PasteFormatDialog onKeep={onKeep} onPlainText={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Keep' }));
+    expect(onKeep).toHaveBeenCalledOnce();
+  });
+
+  it('calls onPlainText when Plain text is clicked', () => {
+    const onPlainText = vi.fn();
+    render(<PasteFormatDialog onKeep={vi.fn()} onPlainText={onPlainText} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Plain text' }));
+    expect(onPlainText).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run src/lib/editor/__tests__/PasteFormatDialog.test.tsx`
+Expected: FAIL — `Cannot find module '../PasteFormatDialog'`
+
+---
+
+### Task 5: Paste Format Dialog — Implementation
+
+**Files:**
+- Create: `src/lib/editor/PasteFormatDialog.tsx`
+
+- [ ] **Step 1: Create the PasteFormatDialog component**
+
+```tsx
+// src/lib/editor/PasteFormatDialog.tsx
+
+interface PasteFormatDialogProps {
+  onKeep: () => void;
+  onPlainText: () => void;
+}
+
+export function PasteFormatDialog({ onKeep, onPlainText }: PasteFormatDialogProps) {
+  return (
+    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-white border border-sage-light rounded-lg shadow-lg px-4 py-3 z-50 whitespace-nowrap">
+      <p className="text-sm text-forest-dark mb-2">Pasted content contains formatting.</p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onKeep}
+          className="px-3 py-1 text-sm rounded bg-sage-light text-forest-dark hover:bg-sage/20 transition-colors"
+        >
+          Keep
+        </button>
+        <button
+          type="button"
+          onClick={onPlainText}
+          className="px-3 py-1 text-sm rounded bg-forest text-white hover:bg-forest-dark transition-colors"
+        >
+          Plain text
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run src/lib/editor/__tests__/PasteFormatDialog.test.tsx`
+Expected: All 3 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-knowledge-layout
+git add src/lib/editor/PasteFormatDialog.tsx src/lib/editor/__tests__/PasteFormatDialog.test.tsx
+git commit -m "feat: add PasteFormatDialog component for paste formatting choice"
+```
+
+---
+
+### Task 6: Integrate Paste Handler into RichTextEditor
+
+**Files:**
+- Modify: `src/lib/editor/RichTextEditor.tsx`
+
+- [ ] **Step 1: Add paste detection state and handler**
+
+In `src/lib/editor/RichTextEditor.tsx`:
+
+1. Add import at the top:
+
+```tsx
+import { PasteFormatDialog } from './PasteFormatDialog';
+```
+
+2. Add paste state inside the `RichTextEditor` component, after the `showVaultPicker` state (after line 12):
+
+```tsx
+  const [pendingPaste, setPendingPaste] = useState<{ html: string; plain: string } | null>(null);
+```
+
+3. Replace the existing `handlePaste` in `editorProps` (lines 37-50) with this updated version that handles both images and rich text:
+
+```tsx
+      handlePaste: (view, event) => {
+        const items = event.clipboardData?.items;
+        if (items) {
+          for (const item of Array.from(items)) {
+            if (item.type.startsWith('image/')) {
+              event.preventDefault();
+              const file = item.getAsFile();
+              if (file) handleImageUpload(file);
+              return true;
+            }
+          }
+        }
+
+        const html = event.clipboardData?.getData('text/html') ?? '';
+        if (html && /style\s*=/i.test(html)) {
+          event.preventDefault();
+          const plain = event.clipboardData?.getData('text/plain') ?? '';
+          setPendingPaste({ html, plain });
+          return true;
+        }
+
+        return false;
+      },
+```
+
+4. Add a `handleKeepPaste` and `handlePlainPaste` callback after `handleVaultSelect` (after line 113):
+
+```tsx
+  function handleKeepPaste() {
+    if (!editor || !pendingPaste) return;
+    editor.commands.insertContent(pendingPaste.html);
+    setPendingPaste(null);
+  }
+
+  function handlePlainPaste() {
+    if (!editor || !pendingPaste) return;
+    editor.commands.insertContent(pendingPaste.plain);
+    setPendingPaste(null);
+  }
+```
+
+5. Add `useEffect` to auto-dismiss on keydown. Add to imports: `useEffect`. Add after the paste handlers:
+
+```tsx
+  useEffect(() => {
+    if (!pendingPaste) return;
+    function handleKeyDown() {
+      setPendingPaste((prev) => {
+        if (prev && editor) {
+          editor.commands.insertContent(prev.html);
+        }
+        return null;
+      });
+    }
+    document.addEventListener('keydown', handleKeyDown, { once: true });
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [pendingPaste, editor]);
+```
+
+6. Add the dialog to the JSX. Insert after `<EditorContent editor={editor} />` (after line 227):
+
+```tsx
+      {pendingPaste && (
+        <div className="relative">
+          <PasteFormatDialog onKeep={handleKeepPaste} onPlainText={handlePlainPaste} />
+        </div>
+      )}
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-knowledge-layout
+git add src/lib/editor/RichTextEditor.tsx
+git commit -m "feat: integrate paste format detection and dialog into editor"
+```
+
+---
+
+### Task 7: Full Integration Tests
+
+**Files:**
+- Create: `src/lib/editor/__tests__/RichTextEditor.test.tsx`
+
+- [ ] **Step 1: Write integration tests for the toolbar dropdown and paste dialog**
+
+```tsx
+// src/lib/editor/__tests__/RichTextEditor.test.tsx
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RichTextEditor from '../RichTextEditor';
+
+// Mock vault actions to avoid Supabase calls
+vi.mock('@/lib/vault/actions', () => ({
+  uploadToVault: vi.fn(),
+}));
+
+// Mock VaultPicker
+vi.mock('@/components/vault/VaultPicker', () => ({
+  default: () => <div data-testid="vault-picker" />,
+}));
+
+describe('RichTextEditor', () => {
+  it('renders the line height dropdown button', async () => {
+    render(<RichTextEditor content={null} onChange={vi.fn()} orgId="org-1" />);
+    await waitFor(() => {
+      expect(screen.getByTitle('Line Spacing')).toBeTruthy();
+    });
+  });
+
+  it('opens dropdown and shows line height options', async () => {
+    render(<RichTextEditor content={null} onChange={vi.fn()} orgId="org-1" />);
+    await waitFor(() => {
+      expect(screen.getByTitle('Line Spacing')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTitle('Line Spacing'));
+    expect(screen.getByText('1 — Compact')).toBeTruthy();
+    expect(screen.getByText('1.15 — Normal')).toBeTruthy();
+    expect(screen.getByText('1.5 — Relaxed')).toBeTruthy();
+    expect(screen.getByText('2 — Double')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run all editor tests**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run src/lib/editor/__tests__/`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run the full test suite to check for regressions**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run`
+Expected: All tests PASS (no regressions)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-knowledge-layout
+git add src/lib/editor/__tests__/RichTextEditor.test.tsx
+git commit -m "test: add integration tests for editor line height and paste dialog"
+```
+
+---
+
+### Task 8: Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run type check**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npx vitest run`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run build**
+
+Run: `cd /Users/patrick/birdhousemapper-knowledge-layout && npm run build`
+Expected: Build succeeds

--- a/docs/superpowers/specs/2026-04-06-knowledge-layout-design.md
+++ b/docs/superpowers/specs/2026-04-06-knowledge-layout-design.md
@@ -1,0 +1,124 @@
+# Knowledge Editor Spacing & Paste Controls
+
+**Issue:** [#220](https://github.com/patjackson52/birdhouse-mapper/issues/220)
+**Date:** 2026-04-06
+**Branch:** `feat/knowledge-layout`
+
+## Problem
+
+Content pasted into the knowledge editor (TipTap) from external sources (Word, Google Docs, web pages) brings in excessive line spacing that cannot be adjusted. Bullet lists and general paragraph content appear double-spaced with no way to fix it.
+
+## Solution
+
+Two features that work together:
+
+1. **Line Height Extension** — per-paragraph line spacing control via a toolbar dropdown
+2. **Paste Formatting Dialog** — prompt when rich content is pasted, offering "Keep formatting" or "Paste as plain text"
+
+## 1. Line Height Extension
+
+A custom TipTap extension (`LineHeight`) that adds a `lineHeight` attribute to block-level nodes.
+
+### Affected Node Types
+
+- `paragraph`
+- `heading`
+- `bulletList`
+- `orderedList`
+
+### Implementation
+
+- Uses `addGlobalAttributes` to add `lineHeight` to the above node types
+- Attribute renders as `style="line-height: <value>"` on the HTML element
+- Parses from existing inline styles (handles pasted content that already has line-height)
+- Commands: `setLineHeight(value: string)` and `unsetLineHeight()`
+- Preset values: `1.0`, `1.15`, `1.5`, `2.0`
+- Default: no attribute (inherits from Tailwind prose defaults, ~1.75)
+
+### Storage
+
+The `lineHeight` value lives in the TipTap JSON document per-node. It persists automatically when the document is saved. `generateHTML()` produces the inline styles, so KnowledgeRenderer displays them correctly with no renderer changes.
+
+### File
+
+`src/lib/editor/LineHeightExtension.ts`
+
+## 2. Toolbar Dropdown
+
+A dropdown button in the RichTextEditor toolbar for selecting line height.
+
+### Placement
+
+After the existing formatting controls, before the image/link buttons.
+
+### UI
+
+- Icon: line-spacing icon (stacked horizontal lines with vertical arrows, inline SVG)
+- Dropdown shows 4 options:
+  - `1.0` — Compact
+  - `1.15` — Normal
+  - `1.5` — Relaxed
+  - `2.0` — Double
+- Active value is highlighted
+- Selecting a value applies it; selecting the already-active value removes it (resets to default)
+
+### Behavior
+
+- Applies to the currently selected paragraph(s)/block(s)
+- If multiple blocks are selected with different values, no active indicator is shown
+- Works on paragraphs, headings, and list containers
+
+### File Changes
+
+`src/lib/editor/RichTextEditor.tsx` — add dropdown component and wire to `setLineHeight`/`unsetLineHeight` commands
+
+## 3. Paste Formatting Dialog
+
+When users paste content from external sources, detect rich formatting and offer a choice.
+
+### Detection
+
+Use TipTap's `handlePaste` editor prop. Check if the clipboard `text/html` content contains `style=` attributes or elements like `<table>`, `<div>`, `<span style=...>` that indicate formatting beyond basic semantic markup (bold, italic, links, lists). A simple heuristic: if the HTML contains any `style=` attribute, treat it as rich/formatted.
+
+### UX Flow
+
+1. User pastes content
+2. If rich HTML is detected, a small floating dialog appears near the paste location:
+   > "Pasted content contains formatting."
+   > **[Keep]** **[Plain text]**
+3. **Keep**: inserts HTML as-is (TipTap default behavior)
+4. **Plain text**: strips all HTML, inserts plain text preserving line breaks
+
+### Edge Cases
+
+- Plain text paste (no HTML in clipboard): paste normally, no dialog
+- Internal copy/paste (within the same editor): no dialog
+- Dialog auto-dismisses if user starts typing (treats as "Keep")
+
+### Implementation
+
+- Intercept paste in `handlePaste` editor prop
+- Use React state + portal to render the dialog
+- Hold clipboard data until user decides
+- "Plain text" path: `editor.commands.insertContent(clipboardData.getData('text/plain'))`
+
+### File Changes
+
+- `src/lib/editor/RichTextEditor.tsx` — add `handlePaste` prop and dialog state
+- `src/lib/editor/PasteFormatDialog.tsx` — new component for the floating dialog
+
+## Testing
+
+- Unit test: LineHeight extension applies and removes line-height attribute correctly
+- Unit test: `generateHTML` produces correct inline styles for line-height
+- Integration test: paste dialog appears for rich HTML, not for plain text
+- Manual verification: paste from Google Docs, Word, web browser — spacing is controllable
+
+## Files Changed (Summary)
+
+| File | Change |
+|------|--------|
+| `src/lib/editor/LineHeightExtension.ts` | New — custom TipTap extension |
+| `src/lib/editor/PasteFormatDialog.tsx` | New — floating paste choice dialog |
+| `src/lib/editor/RichTextEditor.tsx` | Modified — add toolbar dropdown, paste handler, dialog integration |
+| `src/lib/editor/extensions.ts` | Modified — register LineHeight extension |

--- a/src/lib/editor/LineHeightExtension.ts
+++ b/src/lib/editor/LineHeightExtension.ts
@@ -1,0 +1,63 @@
+// src/lib/editor/LineHeightExtension.ts
+
+import { Extension } from '@tiptap/core';
+
+export interface LineHeightOptions {
+  types: string[];
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    lineHeight: {
+      setLineHeight: (lineHeight: string) => ReturnType;
+      unsetLineHeight: () => ReturnType;
+    };
+  }
+}
+
+export const LineHeight = Extension.create<LineHeightOptions>({
+  name: 'lineHeight',
+
+  addOptions() {
+    return {
+      types: ['paragraph', 'heading', 'bulletList', 'orderedList'],
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          lineHeight: {
+            default: null,
+            parseHTML: (element) => element.style.lineHeight || null,
+            renderHTML: (attributes) => {
+              if (attributes.lineHeight == null) return {};
+              return { style: `line-height: ${attributes.lineHeight}` };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setLineHeight:
+        (lineHeight: string) =>
+        ({ commands }) => {
+          return this.options.types.some((type) =>
+            commands.updateAttributes(type, { lineHeight })
+          );
+        },
+      unsetLineHeight:
+        () =>
+        ({ commands }) => {
+          return this.options.types.some((type) =>
+            commands.resetAttributes(type, 'lineHeight')
+          );
+        },
+    };
+  },
+});

--- a/src/lib/editor/PasteFormatDialog.tsx
+++ b/src/lib/editor/PasteFormatDialog.tsx
@@ -1,0 +1,30 @@
+// src/lib/editor/PasteFormatDialog.tsx
+
+interface PasteFormatDialogProps {
+  onKeep: () => void;
+  onPlainText: () => void;
+}
+
+export function PasteFormatDialog({ onKeep, onPlainText }: PasteFormatDialogProps) {
+  return (
+    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-white border border-sage-light rounded-lg shadow-lg px-4 py-3 z-50 whitespace-nowrap">
+      <p className="text-sm text-forest-dark mb-2">Pasted content contains formatting.</p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onKeep}
+          className="px-3 py-1 text-sm rounded bg-sage-light text-forest-dark hover:bg-sage/20 transition-colors"
+        >
+          Keep
+        </button>
+        <button
+          type="button"
+          onClick={onPlainText}
+          className="px-3 py-1 text-sm rounded bg-forest text-white hover:bg-forest-dark transition-colors"
+        >
+          Plain text
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/editor/RichTextEditor.tsx
+++ b/src/lib/editor/RichTextEditor.tsx
@@ -7,6 +7,14 @@ import { uploadToVault } from '@/lib/vault/actions';
 import VaultPicker from '@/components/vault/VaultPicker';
 import type { VaultItem } from '@/lib/vault/types';
 import type { RichTextEditorProps } from './types';
+import type { Editor } from '@tiptap/core';
+
+const LINE_HEIGHT_OPTIONS = [
+  { value: '1', label: 'Compact' },
+  { value: '1.15', label: 'Normal' },
+  { value: '1.5', label: 'Relaxed' },
+  { value: '2', label: 'Double' },
+] as const;
 
 export default function RichTextEditor({ content, onChange, orgId, editable = true }: RichTextEditorProps) {
   const [showVaultPicker, setShowVaultPicker] = useState(false);
@@ -194,6 +202,7 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
           >
             &ldquo;
           </ToolbarButton>
+          <LineHeightDropdown editor={editor} />
 
           <div className="w-px bg-sage-light mx-1" />
 
@@ -235,6 +244,62 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
           defaultUploadCategory="photo"
           defaultUploadVisibility="public"
         />
+      )}
+    </div>
+  );
+}
+
+function LineHeightDropdown({ editor }: { editor: Editor }) {
+  const [open, setOpen] = useState(false);
+
+  const currentLineHeight = editor.getAttributes('paragraph').lineHeight
+    || editor.getAttributes('heading').lineHeight
+    || null;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        title="Line Spacing"
+        className={`px-2 py-1 rounded text-sm transition-colors ${
+          currentLineHeight
+            ? 'bg-sage text-white'
+            : 'text-forest-dark/70 hover:bg-sage-light hover:text-forest-dark'
+        }`}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <line x1="5" y1="3" x2="14" y2="3" />
+          <line x1="5" y1="8" x2="14" y2="8" />
+          <line x1="5" y1="13" x2="14" y2="13" />
+          <polyline points="2,5 2,1 2,5" />
+          <path d="M2 1L3.5 3M2 1L0.5 3" />
+          <polyline points="2,11 2,15 2,11" />
+          <path d="M2 15L3.5 13M2 15L0.5 13" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 bg-white border border-sage-light rounded-lg shadow-lg z-50 py-1 min-w-[140px]">
+          {LINE_HEIGHT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`w-full text-left px-3 py-1.5 text-sm hover:bg-sage-light transition-colors ${
+                currentLineHeight === opt.value ? 'bg-sage/10 text-forest-dark font-medium' : 'text-forest-dark/70'
+              }`}
+              onClick={() => {
+                if (currentLineHeight === opt.value) {
+                  editor.chain().focus().unsetLineHeight().run();
+                } else {
+                  editor.chain().focus().setLineHeight(opt.value).run();
+                }
+                setOpen(false);
+              }}
+            >
+              {opt.value} — {opt.label}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/lib/editor/RichTextEditor.tsx
+++ b/src/lib/editor/RichTextEditor.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEditor, EditorContent } from '@tiptap/react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { PasteFormatDialog } from './PasteFormatDialog';
 import { getEditorExtensions } from './extensions';
 import { uploadToVault } from '@/lib/vault/actions';
 import VaultPicker from '@/components/vault/VaultPicker';
@@ -18,6 +19,7 @@ const LINE_HEIGHT_OPTIONS = [
 
 export default function RichTextEditor({ content, onChange, orgId, editable = true }: RichTextEditorProps) {
   const [showVaultPicker, setShowVaultPicker] = useState(false);
+  const [pendingPaste, setPendingPaste] = useState<{ html: string; plain: string } | null>(null);
 
   const editor = useEditor({
     extensions: getEditorExtensions(),
@@ -54,6 +56,15 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
             }
           }
         }
+
+        const html = event.clipboardData?.getData('text/html') ?? '';
+        if (html && /style\s*=/i.test(html)) {
+          event.preventDefault();
+          const plain = event.clipboardData?.getData('text/plain') ?? '';
+          setPendingPaste({ html, plain });
+          return true;
+        }
+
         return false;
       },
     },
@@ -119,6 +130,32 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
 
     setShowVaultPicker(false);
   }
+
+  function handleKeepPaste() {
+    if (!editor || !pendingPaste) return;
+    editor.commands.insertContent(pendingPaste.html);
+    setPendingPaste(null);
+  }
+
+  function handlePlainPaste() {
+    if (!editor || !pendingPaste) return;
+    editor.commands.insertContent(pendingPaste.plain);
+    setPendingPaste(null);
+  }
+
+  useEffect(() => {
+    if (!pendingPaste) return;
+    function handleKeyDown() {
+      setPendingPaste((prev) => {
+        if (prev && editor) {
+          editor.commands.insertContent(prev.html);
+        }
+        return null;
+      });
+    }
+    document.addEventListener('keydown', handleKeyDown, { once: true });
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [pendingPaste, editor]);
 
   if (!editor) return null;
 
@@ -234,6 +271,12 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
       )}
 
       <EditorContent editor={editor} />
+
+      {pendingPaste && (
+        <div className="relative">
+          <PasteFormatDialog onKeep={handleKeepPaste} onPlainText={handlePlainPaste} />
+        </div>
+      )}
 
       {showVaultPicker && (
         <VaultPicker

--- a/src/lib/editor/RichTextEditor.tsx
+++ b/src/lib/editor/RichTextEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEditor, EditorContent } from '@tiptap/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PasteFormatDialog } from './PasteFormatDialog';
 import { getEditorExtensions } from './extensions';
 import { uploadToVault } from '@/lib/vault/actions';
@@ -58,6 +58,7 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
         }
 
         const html = event.clipboardData?.getData('text/html') ?? '';
+        if (html.includes('data-pm-slice')) return false;
         if (html && /style\s*=/i.test(html)) {
           event.preventDefault();
           const plain = event.clipboardData?.getData('text/plain') ?? '';
@@ -294,13 +295,26 @@ export default function RichTextEditor({ content, onChange, orgId, editable = tr
 
 function LineHeightDropdown({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
 
   const currentLineHeight = editor.getAttributes('paragraph').lineHeight
     || editor.getAttributes('heading').lineHeight
+    || editor.getAttributes('bulletList').lineHeight
+    || editor.getAttributes('orderedList').lineHeight
     || null;
 
   return (
-    <div className="relative">
+    <div className="relative" ref={ref}>
       <button
         type="button"
         onClick={() => setOpen(!open)}

--- a/src/lib/editor/__tests__/LineHeightExtension.test.ts
+++ b/src/lib/editor/__tests__/LineHeightExtension.test.ts
@@ -1,0 +1,108 @@
+// src/lib/editor/__tests__/LineHeightExtension.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import Heading from '@tiptap/extension-heading';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import ListItem from '@tiptap/extension-list-item';
+import { LineHeight } from '../LineHeightExtension';
+import { generateHTML } from '@tiptap/html';
+
+function createEditor(content?: string) {
+  return new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      Heading.configure({ levels: [2, 3, 4] }),
+      BulletList,
+      OrderedList,
+      ListItem,
+      LineHeight,
+    ],
+    content: content ?? '<p>Hello world</p>',
+  });
+}
+
+describe('LineHeightExtension', () => {
+  it('registers setLineHeight and unsetLineHeight commands', () => {
+    const editor = createEditor();
+    expect(typeof editor.commands.setLineHeight).toBe('function');
+    expect(typeof editor.commands.unsetLineHeight).toBe('function');
+    editor.destroy();
+  });
+
+  it('sets lineHeight attribute on the current paragraph', () => {
+    const editor = createEditor();
+    editor.commands.setTextSelection(1);
+    editor.commands.setLineHeight('1.5');
+    const json = editor.getJSON();
+    expect(json.content?.[0].attrs?.lineHeight).toBe('1.5');
+    editor.destroy();
+  });
+
+  it('unsets lineHeight attribute', () => {
+    const editor = createEditor();
+    editor.commands.setTextSelection(1);
+    editor.commands.setLineHeight('1.5');
+    editor.commands.unsetLineHeight();
+    const json = editor.getJSON();
+    expect(json.content?.[0].attrs?.lineHeight).toBeNull();
+    editor.destroy();
+  });
+
+  it('generates HTML with inline line-height style', () => {
+    const extensions = [
+      Document,
+      Paragraph,
+      Text,
+      Heading.configure({ levels: [2, 3, 4] }),
+      BulletList,
+      OrderedList,
+      ListItem,
+      LineHeight,
+    ];
+    const json = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', attrs: { lineHeight: '1.15' }, content: [{ type: 'text', text: 'Tight text' }] },
+      ],
+    };
+    const html = generateHTML(json, extensions);
+    expect(html).toContain('line-height: 1.15');
+    expect(html).toContain('Tight text');
+  });
+
+  it('does not add style attribute when lineHeight is null', () => {
+    const extensions = [
+      Document,
+      Paragraph,
+      Text,
+      Heading.configure({ levels: [2, 3, 4] }),
+      BulletList,
+      OrderedList,
+      ListItem,
+      LineHeight,
+    ];
+    const json = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Default text' }] },
+      ],
+    };
+    const html = generateHTML(json, extensions);
+    expect(html).not.toContain('line-height');
+  });
+
+  it('parses lineHeight from existing inline styles', () => {
+    const editor = createEditor('<p style="line-height: 2.0">Double spaced</p>');
+    const json = editor.getJSON();
+    // jsdom normalizes "2.0" → "2" when reading element.style.lineHeight
+    expect(json.content?.[0].attrs?.lineHeight).toBe('2');
+    editor.destroy();
+  });
+});

--- a/src/lib/editor/__tests__/PasteFormatDialog.test.tsx
+++ b/src/lib/editor/__tests__/PasteFormatDialog.test.tsx
@@ -1,0 +1,28 @@
+// src/lib/editor/__tests__/PasteFormatDialog.test.tsx
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PasteFormatDialog } from '../PasteFormatDialog';
+
+describe('PasteFormatDialog', () => {
+  it('renders the dialog with Keep and Plain text buttons', () => {
+    render(<PasteFormatDialog onKeep={vi.fn()} onPlainText={vi.fn()} />);
+    expect(screen.getByText('Pasted content contains formatting.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Plain text' })).toBeTruthy();
+  });
+
+  it('calls onKeep when Keep is clicked', () => {
+    const onKeep = vi.fn();
+    render(<PasteFormatDialog onKeep={onKeep} onPlainText={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Keep' }));
+    expect(onKeep).toHaveBeenCalledOnce();
+  });
+
+  it('calls onPlainText when Plain text is clicked', () => {
+    const onPlainText = vi.fn();
+    render(<PasteFormatDialog onKeep={vi.fn()} onPlainText={onPlainText} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Plain text' }));
+    expect(onPlainText).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/editor/__tests__/RichTextEditor.test.tsx
+++ b/src/lib/editor/__tests__/RichTextEditor.test.tsx
@@ -1,0 +1,36 @@
+// src/lib/editor/__tests__/RichTextEditor.test.tsx
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RichTextEditor from '../RichTextEditor';
+
+// Mock vault actions to avoid Supabase calls
+vi.mock('@/lib/vault/actions', () => ({
+  uploadToVault: vi.fn(),
+}));
+
+// Mock VaultPicker
+vi.mock('@/components/vault/VaultPicker', () => ({
+  default: () => <div data-testid="vault-picker" />,
+}));
+
+describe('RichTextEditor', () => {
+  it('renders the line height dropdown button', async () => {
+    render(<RichTextEditor content={null} onChange={vi.fn()} orgId="org-1" />);
+    await waitFor(() => {
+      expect(screen.getByTitle('Line Spacing')).toBeTruthy();
+    });
+  });
+
+  it('opens dropdown and shows line height options', async () => {
+    render(<RichTextEditor content={null} onChange={vi.fn()} orgId="org-1" />);
+    await waitFor(() => {
+      expect(screen.getByTitle('Line Spacing')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTitle('Line Spacing'));
+    expect(screen.getByText('1 — Compact')).toBeTruthy();
+    expect(screen.getByText('1.15 — Normal')).toBeTruthy();
+    expect(screen.getByText('1.5 — Relaxed')).toBeTruthy();
+    expect(screen.getByText('2 — Double')).toBeTruthy();
+  });
+});

--- a/src/lib/editor/extensions.ts
+++ b/src/lib/editor/extensions.ts
@@ -4,6 +4,7 @@ import TextAlign from '@tiptap/extension-text-align';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import { VaultImage } from './VaultImageExtension';
+import { LineHeight } from './LineHeightExtension';
 
 export function getEditorExtensions(placeholder?: string) {
   return [
@@ -19,6 +20,7 @@ export function getEditorExtensions(placeholder?: string) {
       autolink: true,
     }),
     VaultImage,
+    LineHeight,
     Placeholder.configure({
       placeholder: placeholder ?? 'Start writing…',
     }),


### PR DESCRIPTION
## Summary

Closes #220

- **Line height extension**: Custom TipTap extension adding per-paragraph `lineHeight` attribute to paragraph, heading, bulletList, and orderedList nodes with `setLineHeight`/`unsetLineHeight` commands
- **Toolbar dropdown**: Line spacing dropdown (Compact 1.0 / Normal 1.15 / Relaxed 1.5 / Double 2.0) with active state indicator and click-outside dismiss
- **Paste format dialog**: Detects rich formatting (`style=` attributes) in pasted HTML and prompts "Keep" or "Plain text" — skips dialog for plain text and internal TipTap copy/paste, auto-dismisses on typing

## Test plan

- [x] 11 new tests (6 extension unit, 3 dialog unit, 2 integration) — all pass
- [x] Full suite: 934/934 tests pass
- [x] TypeScript type check clean
- [x] Production build succeeds
- [ ] Manual: paste from Google Docs/Word — verify dialog appears and both options work
- [ ] Manual: verify line height dropdown applies spacing to paragraphs, headings, and lists
- [ ] Manual: verify click-outside closes dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)