### PR TITLE
fix: item_types delta sync misses layout changes

### DIFF
--- a/src/lib/offline/__tests__/sync-engine.test.ts
+++ b/src/lib/offline/__tests__/sync-engine.test.ts
@@ -185,7 +185,7 @@ describe('Sync Engine — Inbound (syncPropertyData)', () => {
     expect(customFieldsGte).toHaveLength(0);
   });
 
-  it('applies timestamp filter for tables with created_at (e.g. item_types)', async () => {
+  it('applies timestamp filter for tables with updated_at (e.g. item_types)', async () => {
     const queryCalls: { table: string; method: string; args: any[] }[] = [];
 
     const supabase = {
@@ -203,10 +203,10 @@ describe('Sync Engine — Inbound (syncPropertyData)', () => {
 
     await syncPropertyData(db, supabase, 'prop-1', 'org-1');
 
-    // item_types SHOULD have a .gte('created_at', ...) call
+    // item_types SHOULD have a .gte('updated_at', ...) call (now has updated_at column)
     const itemTypesGte = queryCalls.filter(c => c.table === 'item_types' && c.method === 'gte');
     expect(itemTypesGte).toHaveLength(1);
-    expect(itemTypesGte[0].args[0]).toBe('created_at');
+    expect(itemTypesGte[0].args[0]).toBe('updated_at');
 
     // items SHOULD have a .gte('updated_at', ...) call (has updated_at)
     const itemsGte = queryCalls.filter(c => c.table === 'items' && c.method === 'gte');

--- a/src/lib/offline/sync-engine.ts
+++ b/src/lib/offline/sync-engine.ts
@@ -121,7 +121,7 @@ async function executeMutation(
 // Tables that have an `updated_at` column for delta sync.
 // Tables not listed here only have `created_at` — we use that instead.
 const TABLES_WITH_UPDATED_AT = new Set([
-  'items', 'properties', 'orgs', 'roles', 'org_memberships', 'entities', 'entity_types',
+  'items', 'item_types', 'properties', 'orgs', 'roles', 'org_memberships', 'entities', 'entity_types',
 ]);
 
 // Tables that have no timestamp column at all — always do a full sync.

--- a/supabase/migrations/041_item_types_updated_at.sql
+++ b/supabase/migrations/041_item_types_updated_at.sql
@@ -1,0 +1,14 @@
+-- Add updated_at column to item_types so delta sync picks up layout changes.
+-- Without this, editing an item_type (e.g. saving a layout) never propagates
+-- to clients that already cached the row, because delta sync used created_at.
+
+ALTER TABLE item_types
+  ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+
+-- Backfill: set updated_at = created_at for existing rows
+UPDATE item_types SET updated_at = created_at;
+
+-- Auto-update trigger (same pattern as items, entities, entity_types, etc.)
+CREATE TRIGGER item_types_updated_at
+  BEFORE UPDATE ON item_types
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
## Summary

- `item_types` table lacked an `updated_at` column, so the offline sync engine used `created_at` for delta sync
- When a layout was saved to an existing item_type, the `created_at` didn't change — so the sync engine never re-fetched the updated row
- Authenticated users with stale IndexedDB caches saw `layout: null` (old hardcoded detail panel), while fresh unauthenticated visitors got the correct type-builder layout

## Changes

- Migration `041_item_types_updated_at.sql` — adds `updated_at` column + auto-update trigger to `item_types`, backfills from `created_at`
- `sync-engine.ts` — added `item_types` to `TABLES_WITH_UPDATED_AT` so delta sync uses `updated_at`
- Updated sync engine test to reflect the new timestamp column

## Test plan

- [x] 944 unit tests passing
- [ ] Run migration `041_item_types_updated_at.sql` against Supabase
- [ ] Clear IndexedDB, reload as authenticated user — verify type-builder layout renders correctly
- [ ] Edit an item_type (e.g. change icon), verify sync picks up the change on next reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)