### PR TITLE
fix: wire new LayoutEditor into /org/types and fix edit-mode block width

### DIFF
--- a/src/app/org/types/page.tsx
+++ b/src/app/org/types/page.tsx
@@ -10,10 +10,10 @@ import { createClient } from '@/lib/supabase/client';
 import type { ItemType, CustomField, EntityType } from '@/lib/types';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import ItemTypeEditor from '@/components/admin/ItemTypeEditor';
-// LayoutBuilder depends on @dnd-kit/sortable which may not be installed yet.
-// Dynamically import it to avoid build failures.
+// LayoutEditor depends on @dnd-kit which requires browser APIs.
+// Dynamically import it to avoid SSR failures.
 import dynamic from 'next/dynamic';
-const LayoutBuilderV2 = dynamic(() => import('@/components/layout/builder/LayoutBuilderV2'), { ssr: false });
+const LayoutEditor = dynamic(() => import('@/components/layout/builder/LayoutEditor'), { ssr: false });
 import { saveTypeWithLayout } from '@/app/admin/properties/[slug]/types/layout-actions';
 
 export default function OrgTypesPage() {
@@ -206,7 +206,7 @@ export default function OrgTypesPage() {
                   ))}
                 </div>
                 {activeTab === 'layout' && (
-                  <LayoutBuilderV2
+                  <LayoutEditor
                     itemType={type}
                     initialLayout={type.layout}
                     customFields={customFields.filter((f) => f.item_type_id === type.id)}

--- a/src/components/layout/builder/EditableBlock.tsx
+++ b/src/components/layout/builder/EditableBlock.tsx
@@ -44,7 +44,7 @@ export default function EditableBlock({
         e.stopPropagation();
         onSelect(blockId);
       }}
-      className={`group relative rounded-lg transition-all duration-150 border-2 ${
+      className={`group relative flex flex-col rounded-lg transition-all duration-150 border-2 ${
         isDragging
           ? 'opacity-25 border-transparent'
           : isSelected


### PR DESCRIPTION
## Summary

- **`/org/types` page still used old `LayoutBuilderV2`** — PR #239 updated the property-level types page (`/admin/properties/[slug]/types`) to use the new `LayoutEditor` but missed the org-level page (`/org/types`). Swapped the dynamic import to `LayoutEditor`.
- **Edit-mode blocks didn't match preview width** — In preview mode, block content (e.g. StatusBadge `<span>`) is a direct flex item of the column container and gets stretched full-width by default `align-items: stretch`. In edit mode, it was nested inside `EditableBlock`'s plain `<div>`, so `inline-flex` elements only took content width. Fixed by making `EditableBlock` a `flex flex-col` container.

## Test plan

- [ ] Navigate to `/org/types`, expand a type, confirm the new layout editor (with edit/preview toggle, undo/redo, component drawer) renders instead of the old split-panel builder
- [ ] In edit mode, verify status badge and other inline blocks render at full width, matching the preview
- [ ] Drag and drop blocks in the editor — confirm reordering, side-zone row creation, and palette drops still work
- [ ] Verify blocks inside rows still render at correct fractional widths

https://claude.ai/code/session_017azurM2k1ofdhod8Smbe2m