### PR TITLE
feat: replace BlockToolbar with long-press-to-drag on blocks

Remove the floating BlockToolbar popup (grip handle, config, delete
buttons) since all those actions are already available in the
ConfigDrawer which opens on tap/select. Instead, attach dnd-kit drag
listeners directly to the block element and switch both PointerSensor
and TouchSensor to delay-based activation (300ms long press).

- Tap/click: selects block and opens ConfigDrawer
- Long press (300ms): initiates drag
- Add touch-none CSS to prevent browser scroll during long press
- Add flex flex-col to EditableBlock so block content fills width
- Remove onOpenConfig/onDelete prop threading through EditableBlock,
  EditableRow, and EditableLayoutRenderer

https://claude.ai/code/session_017azurM2k1ofdhod8Smbe2m

### DIFF
--- a/src/components/layout/builder/EditableBlock.tsx
+++ b/src/components/layout/builder/EditableBlock.tsx
@@ -2,7 +2,6 @@
 
 import { useDraggable } from '@dnd-kit/core';
 import SideDropZone from './SideDropZone';
-import BlockToolbar from './BlockToolbar';
 
 interface EditableBlockProps {
   blockId: string;
@@ -12,8 +11,6 @@ interface EditableBlockProps {
   isDragDisabled: boolean;
   rowChildCount: number;
   onSelect: (blockId: string) => void;
-  onOpenConfig: (blockId: string) => void;
-  onDelete: (blockId: string) => void;
   children: React.ReactNode;
 }
 
@@ -25,8 +22,6 @@ export default function EditableBlock({
   isDragDisabled,
   rowChildCount,
   onSelect,
-  onOpenConfig,
-  onDelete,
   children,
 }: EditableBlockProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -40,11 +35,13 @@ export default function EditableBlock({
     <div
       data-block-id={blockId}
       ref={setNodeRef}
+      {...attributes}
+      {...listeners}
       onClick={(e) => {
         e.stopPropagation();
         onSelect(blockId);
       }}
-      className={`group relative flex flex-col rounded-lg transition-all duration-150 border-2 ${
+      className={`group relative flex flex-col rounded-lg transition-all duration-150 border-2 touch-none ${
         isDragging
           ? 'opacity-25 border-transparent'
           : isSelected
@@ -52,16 +49,6 @@ export default function EditableBlock({
             : 'border-transparent hover:border-dashed hover:border-sage/40'
       }`}
     >
-      {/* Floating toolbar — shown when selected */}
-      {isSelected && !isDragging && (
-        <BlockToolbar
-          onConfig={() => onOpenConfig(blockId)}
-          onDelete={() => onDelete(blockId)}
-          dragListeners={listeners}
-          dragAttributes={attributes}
-        />
-      )}
-
       {/* Side drop zones for auto-row creation */}
       <SideDropZone
         id={`side-left-${blockId}`}

--- a/src/components/layout/builder/EditableLayoutRenderer.tsx
+++ b/src/components/layout/builder/EditableLayoutRenderer.tsx
@@ -18,8 +18,6 @@ interface EditableLayoutRendererProps {
   selectedBlockId: string | null;
   isDragActive: boolean;
   onSelect: (blockId: string) => void;
-  onOpenConfig: (blockId: string) => void;
-  onDelete: (blockId: string) => void;
 }
 
 export default function EditableLayoutRenderer({
@@ -29,8 +27,6 @@ export default function EditableLayoutRenderer({
   selectedBlockId,
   isDragActive,
   onSelect,
-  onOpenConfig,
-  onDelete,
 }: EditableLayoutRendererProps) {
   const spacing = SPACING[layout.spacing];
 
@@ -57,8 +53,6 @@ export default function EditableLayoutRenderer({
       isDragDisabled={false}
       rowChildCount={rowChildCount}
       onSelect={onSelect}
-      onOpenConfig={onOpenConfig}
-      onDelete={onDelete}
     >
       <BlockErrorBoundary blockType={block.type}>
         {renderBlockContent(block, index, rendererProps)}
@@ -86,8 +80,6 @@ export default function EditableLayoutRenderer({
               selectedBlockId={selectedBlockId}
               isDragActive={isDragActive}
               onSelect={onSelect}
-              onOpenConfig={onOpenConfig}
-              onDelete={onDelete}
               renderBlock={renderEditableBlock}
             />
           ) : (

--- a/src/components/layout/builder/EditableRow.tsx
+++ b/src/components/layout/builder/EditableRow.tsx
@@ -10,8 +10,6 @@ interface EditableRowProps {
   selectedBlockId: string | null;
   isDragActive: boolean;
   onSelect: (blockId: string) => void;
-  onOpenConfig: (blockId: string) => void;
-  onDelete: (blockId: string) => void;
   renderBlock: (block: LayoutBlockV2, index: number, isInRow: boolean, rowChildCount: number) => React.ReactNode;
 }
 
@@ -21,8 +19,6 @@ export default function EditableRow({
   selectedBlockId,
   isDragActive,
   onSelect,
-  onOpenConfig,
-  onDelete,
   renderBlock,
 }: EditableRowProps) {
   const { attributes, listeners, setNodeRef: dragRef, isDragging } = useDraggable({

--- a/src/components/layout/builder/LayoutEditor.tsx
+++ b/src/components/layout/builder/LayoutEditor.tsx
@@ -192,8 +192,8 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
   }, [layout.blocks]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } }),
+    useSensor(PointerSensor, { activationConstraint: { delay: 300, tolerance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 300, tolerance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
@@ -201,10 +201,6 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
 
   const handleSelectBlock = useCallback((blockId: string) => {
     setSelectedBlockId((prev) => (prev === blockId ? null : blockId));
-  }, []);
-
-  const handleOpenConfig = useCallback((blockId: string) => {
-    setSelectedBlockId(blockId);
   }, []);
 
   // --- Quick add (mobile tap) ---
@@ -719,8 +715,6 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
                 selectedBlockId={selectedBlockId}
                 isDragActive={isDragActive}
                 onSelect={handleSelectBlock}
-                onOpenConfig={handleOpenConfig}
-                onDelete={handleDeleteBlock}
               />
             ) : (
               mobileTab === 'detail' ? detailPreview : formPreviewContent
@@ -820,8 +814,6 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
                   selectedBlockId={selectedBlockId}
                   isDragActive={isDragActive}
                   onSelect={handleSelectBlock}
-                  onOpenConfig={handleOpenConfig}
-                  onDelete={handleDeleteBlock}
                 />
               ) : (
                 <>

--- a/src/components/layout/builder/__tests__/EditableBlock.test.tsx
+++ b/src/components/layout/builder/__tests__/EditableBlock.test.tsx
@@ -23,8 +23,6 @@ describe('EditableBlock', () => {
     isDragDisabled: false,
     rowChildCount: 0,
     onSelect: vi.fn(),
-    onOpenConfig: vi.fn(),
-    onDelete: vi.fn(),
     children: <div data-testid="block-content">Content</div>,
   };
 
@@ -74,15 +72,10 @@ describe('EditableBlock', () => {
     expect(wrapper?.className).toContain('opacity-25');
   });
 
-  it('shows BlockToolbar when selected', () => {
-    render(<EditableBlock {...defaultProps} isSelected={true} />);
-    expect(screen.getByLabelText('Configure block')).toBeInTheDocument();
-    expect(screen.getByLabelText('Delete block')).toBeInTheDocument();
-  });
-
-  it('does not show BlockToolbar when not selected', () => {
-    render(<EditableBlock {...defaultProps} isSelected={false} />);
-    expect(screen.queryByLabelText('Configure block')).not.toBeInTheDocument();
+  it('applies touch-none for long-press drag', () => {
+    const { container } = render(<EditableBlock {...defaultProps} />);
+    const wrapper = container.querySelector('[data-block-id]');
+    expect(wrapper?.className).toContain('touch-none');
   });
 
   it('includes side drop zones', () => {

--- a/src/components/layout/builder/__tests__/EditableLayoutRenderer.test.tsx
+++ b/src/components/layout/builder/__tests__/EditableLayoutRenderer.test.tsx
@@ -48,8 +48,6 @@ describe('EditableLayoutRenderer', () => {
         selectedBlockId={null}
         isDragActive={false}
         onSelect={vi.fn()}
-        onOpenConfig={vi.fn()}
-        onDelete={vi.fn()}
       />
     );
     expect(screen.getByTestId('block-status_badge')).toBeInTheDocument();
@@ -67,8 +65,6 @@ describe('EditableLayoutRenderer', () => {
         selectedBlockId={null}
         isDragActive={true}
         onSelect={vi.fn()}
-        onOpenConfig={vi.fn()}
-        onDelete={vi.fn()}
       />
     );
     // 2 blocks = 3 drop zones (before, between, after)


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

- [ ] Unit tests pass (`npm run test`)
- [ ] Type check passes (`npm run type-check`)
- [ ] E2E tests pass (if applicable)

## Memory & Decision Tracking

- [ ] Does this change introduce a lasting technical decision? If yes, create or update an ADR in `docs/adr/`.
- [ ] Should project or org memory be updated? Check `memory/decisions/`, `memory/patterns/`, or `memory/context/`.
- [ ] Files updated in `docs/adr/` or `memory/`: <!-- list them here -->

## Screenshots

<!-- If applicable, add before/after screenshots -->
