### PR TITLE
fix: enable drag from mobile ComponentDrawer bottom sheet

Three issues prevented dragging palette items from the mobile drawer:

1. Mobile DraggableChip lacked touch-none — browser scroll intercepted
   the touch event before the 300ms long-press delay could complete.
   Moved touch-none to be shared across mobile and desktop chips.

2. Drawer backdrop (z-40) and panel (z-50) blocked pointer events to
   the layout drop zones beneath. Now both fade out with opacity-0 and
   pointer-events-none when a palette drag is active.

3. Drawer stayed open during drag. Added useDndMonitor to detect
   palette drag start/end — hides drawer visually during drag (keeps
   DOM mounted so dnd-kit draggable stays registered), then closes
   fully on drop.

https://claude.ai/code/session_017azurM2k1ofdhod8Smbe2m

### DIFF
--- a/src/components/layout/builder/ComponentDrawer.tsx
+++ b/src/components/layout/builder/ComponentDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useDraggable } from '@dnd-kit/core';
+import { useDraggable, useDndMonitor } from '@dnd-kit/core';
 import { Plus, X } from 'lucide-react';
 import type { BlockTypeV2 } from '@/lib/layout/types-v2';
 
@@ -60,12 +60,12 @@ function DraggableChip({
         }
       }}
       aria-label={`${isMobile ? 'Tap to add' : 'Drag to add'} ${item.label}`}
-      className={`flex items-center gap-2 rounded-lg border border-sage-light bg-white text-sm font-medium text-forest-dark transition-colors select-none ${
+      className={`flex items-center gap-2 rounded-lg border border-sage-light bg-white text-sm font-medium text-forest-dark transition-colors select-none touch-none ${
         disabled
           ? 'opacity-40 cursor-not-allowed'
           : isMobile
             ? 'active:bg-sage-light/50 min-h-[44px] px-3 py-2'
-            : 'hover:bg-sage-light/50 cursor-grab active:cursor-grabbing touch-none px-3 py-2.5 w-full'
+            : 'hover:bg-sage-light/50 cursor-grab active:cursor-grabbing px-3 py-2.5 w-full'
       } ${isDragging ? 'opacity-40' : ''}`}
     >
       <span>{item.icon}</span>
@@ -76,6 +76,24 @@ function DraggableChip({
 
 export default function ComponentDrawer({ isMobile, disabledTypes, onQuickAdd }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isPaletteDragging, setIsPaletteDragging] = useState(false);
+
+  useDndMonitor({
+    onDragStart(event) {
+      if (event.active.data.current?.source === 'palette') {
+        setIsPaletteDragging(true);
+      }
+    },
+    onDragEnd() {
+      if (isPaletteDragging) {
+        setIsPaletteDragging(false);
+        setIsOpen(false);
+      }
+    },
+    onDragCancel() {
+      setIsPaletteDragging(false);
+    },
+  });
 
   if (!isMobile) {
     // Desktop: vertical sidebar
@@ -111,10 +129,10 @@ export default function ComponentDrawer({ isMobile, disabledTypes, onQuickAdd }:
       {isOpen && (
         <>
           <div
-            className="fixed inset-0 z-40 bg-black/20"
+            className={`fixed inset-0 z-40 bg-black/20 transition-opacity ${isPaletteDragging ? 'opacity-0 pointer-events-none' : ''}`}
             onClick={() => setIsOpen(false)}
           />
-          <div className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[50vh] overflow-y-auto"
+          <div className={`fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[50vh] overflow-y-auto transition-opacity ${isPaletteDragging ? 'opacity-0 pointer-events-none' : ''}`}
             style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
           >
             <div className="flex items-center justify-between px-4 py-3 border-b border-sage-light">


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

- [ ] Unit tests pass (`npm run test`)
- [ ] Type check passes (`npm run type-check`)
- [ ] E2E tests pass (if applicable)

## Memory & Decision Tracking

- [ ] Does this change introduce a lasting technical decision? If yes, create or update an ADR in `docs/adr/`.
- [ ] Should project or org memory be updated? Check `memory/decisions/`, `memory/patterns/`, or `memory/context/`.
- [ ] Files updated in `docs/adr/` or `memory/`: <!-- list them here -->

## Screenshots

<!-- If applicable, add before/after screenshots -->
