### PR TITLE
feat: inline ConfigDrawer on mobile with drag-to-resize handle

The config drawer was a fixed overlay that covered the layout preview
on mobile, hiding the block being configured. Now:

- Mobile: drawer renders inline at the bottom of the flex column,
  naturally pushing the scrollable content area up so the selected
  block stays visible. Spacing picker hides when drawer is open.
- Drag handle: the existing decorative bar is now a functional
  pointer-driven resize handle (drag up/down to grow/shrink drawer
  between 120px and 70vh).
- Auto-scroll: selecting a block on mobile scrolls it into view
  so it's not hidden behind the drawer.
- Desktop: unchanged (fixed overlay with backdrop).

https://claude.ai/code/session_017azurM2k1ofdhod8Smbe2m

### DIFF
--- a/src/components/layout/builder/ConfigDrawer.tsx
+++ b/src/components/layout/builder/ConfigDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { X, Trash2 } from 'lucide-react';
 import type { LayoutBlockV2, BlockConfigV2 } from '@/lib/layout/types-v2';
 import type { CustomField, EntityType } from '@/lib/types';
@@ -14,6 +14,7 @@ interface ConfigDrawerProps {
   onDelete: (blockId: string) => void;
   onClose: () => void;
   onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  isMobile?: boolean;
 }
 
 const BLOCK_LABELS: Record<string, string> = {
@@ -29,6 +30,9 @@ const BLOCK_LABELS: Record<string, string> = {
   action_buttons: 'Actions',
 };
 
+const MIN_HEIGHT = 120;
+const DEFAULT_HEIGHT = 260;
+
 export default function ConfigDrawer({
   block,
   customFields,
@@ -37,11 +41,122 @@ export default function ConfigDrawer({
   onDelete,
   onClose,
   onCreateField,
+  isMobile = false,
 }: ConfigDrawerProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [drawerHeight, setDrawerHeight] = useState(DEFAULT_HEIGHT);
+  const dragStartY = useRef(0);
+  const dragStartHeight = useRef(0);
+  const isDraggingHandle = useRef(false);
+
+  // Reset delete confirm when block changes
+  useEffect(() => {
+    setShowDeleteConfirm(false);
+  }, [block?.id]);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    isDraggingHandle.current = true;
+    dragStartY.current = e.clientY;
+    dragStartHeight.current = drawerHeight;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, [drawerHeight]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (!isDraggingHandle.current) return;
+    const delta = dragStartY.current - e.clientY;
+    const maxHeight = window.innerHeight * 0.7;
+    const newHeight = Math.min(maxHeight, Math.max(MIN_HEIGHT, dragStartHeight.current + delta));
+    setDrawerHeight(newHeight);
+  }, []);
+
+  const handlePointerUp = useCallback(() => {
+    isDraggingHandle.current = false;
+  }, []);
 
   if (!block) return null;
 
+  const drawerContent = (
+    <>
+      {/* Drag handle */}
+      <div
+        className="flex justify-center pt-2 pb-1 cursor-ns-resize touch-none"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        <div className="w-10 h-1 bg-sage-light rounded-full" />
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-sage-light">
+        <span className="font-medium text-forest-dark">
+          {BLOCK_LABELS[block.type] ?? block.type}
+        </span>
+        <button onClick={onClose} aria-label="Close">
+          <X size={20} className="text-sage" />
+        </button>
+      </div>
+
+      {/* Config content */}
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        <BlockConfigPanel
+          block={block as any}
+          customFields={customFields}
+          entityTypes={entityTypes}
+          onConfigChange={(id, config) => onConfigChange(id, config as BlockConfigV2)}
+          onCreateField={onCreateField}
+        />
+      </div>
+
+      {/* Delete */}
+      <div className="px-4 py-3 border-t border-sage-light flex-shrink-0">
+        {showDeleteConfirm ? (
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-red-600">Remove this block?</span>
+            <div className="flex gap-2">
+              <button onClick={() => setShowDeleteConfirm(false)} className="btn-secondary text-sm">
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  onDelete(block.id);
+                  setShowDeleteConfirm(false);
+                  onClose();
+                }}
+                className="px-3 py-1.5 rounded-md text-sm font-medium bg-red-500 text-white hover:bg-red-600"
+              >
+                Yes, Remove
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="flex items-center gap-2 text-sm text-red-500 hover:text-red-600"
+          >
+            <Trash2 size={14} />
+            Remove
+          </button>
+        )}
+      </div>
+    </>
+  );
+
+  // Mobile: inline drawer at bottom of flex layout, pushes content up
+  if (isMobile) {
+    return (
+      <div
+        className="flex flex-col border-t border-sage-light bg-white flex-shrink-0"
+        style={{ height: drawerHeight, paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        {drawerContent}
+      </div>
+    );
+  }
+
+  // Desktop: fixed overlay with backdrop
   return (
     <>
       {/* Backdrop */}
@@ -52,66 +167,10 @@ export default function ConfigDrawer({
       />
 
       {/* Drawer */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[50vh] overflow-y-auto mx-auto max-w-[480px]"
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[50vh] flex flex-col mx-auto max-w-[480px]"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
-        {/* Swipe handle */}
-        <div className="flex justify-center pt-2 pb-1">
-          <div className="w-10 h-1 bg-sage-light rounded-full" />
-        </div>
-
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2 border-b border-sage-light">
-          <span className="font-medium text-forest-dark">
-            {BLOCK_LABELS[block.type] ?? block.type}
-          </span>
-          <button onClick={onClose} aria-label="Close">
-            <X size={20} className="text-sage" />
-          </button>
-        </div>
-
-        {/* Config content — reuse existing BlockConfigPanel */}
-        <div className="px-4 py-3">
-          <BlockConfigPanel
-            block={block as any}
-            customFields={customFields}
-            entityTypes={entityTypes}
-            onConfigChange={(id, config) => onConfigChange(id, config as BlockConfigV2)}
-            onCreateField={onCreateField}
-          />
-        </div>
-
-        {/* Delete */}
-        <div className="px-4 py-3 border-t border-sage-light">
-          {showDeleteConfirm ? (
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-red-600">Remove this block?</span>
-              <div className="flex gap-2">
-                <button onClick={() => setShowDeleteConfirm(false)} className="btn-secondary text-sm">
-                  Cancel
-                </button>
-                <button
-                  onClick={() => {
-                    onDelete(block.id);
-                    setShowDeleteConfirm(false);
-                    onClose();
-                  }}
-                  className="px-3 py-1.5 rounded-md text-sm font-medium bg-red-500 text-white hover:bg-red-600"
-                >
-                  Yes, Remove
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              onClick={() => setShowDeleteConfirm(true)}
-              className="flex items-center gap-2 text-sm text-red-500 hover:text-red-600"
-            >
-              <Trash2 size={14} />
-              Remove
-            </button>
-          )}
-        </div>
+        {drawerContent}
       </div>
     </>
   );

--- a/src/components/layout/builder/LayoutEditor.tsx
+++ b/src/components/layout/builder/LayoutEditor.tsx
@@ -134,6 +134,17 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
     return () => window.removeEventListener('resize', check);
   }, []);
 
+  // Auto-scroll selected block into view on mobile
+  useEffect(() => {
+    if (!selectedBlockId || !isMobile) return;
+    const el = document.querySelector(`[data-block-id="${selectedBlockId}"]`);
+    if (el) {
+      requestAnimationFrame(() => {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    }
+  }, [selectedBlockId, isMobile]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -643,18 +654,16 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
 
   const previewContent = previewTab === 'detail' ? detailPreview : formPreviewContent;
 
-  // Config drawer (shown on top of everything)
-  const configDrawer = (
-    <ConfigDrawer
-      block={selectedBlock}
-      customFields={allFields}
-      entityTypes={entityTypes}
-      onConfigChange={handleConfigChange}
-      onDelete={handleDeleteBlock}
-      onClose={() => setSelectedBlockId(null)}
-      onCreateField={handleCreateField}
-    />
-  );
+  // Config drawer (shown on top of everything on desktop, inline on mobile)
+  const configDrawerProps = {
+    block: selectedBlock,
+    customFields: allFields,
+    entityTypes,
+    onConfigChange: handleConfigChange,
+    onDelete: handleDeleteBlock,
+    onClose: () => setSelectedBlockId(null),
+    onCreateField: handleCreateField,
+  };
 
   // --- Mobile layout ---
   if (isMobile) {
@@ -730,16 +739,16 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
             />
           )}
 
-          {/* Spacing picker strip (edit mode) */}
-          {isEditing && (
+          {/* Spacing picker strip (edit mode, hidden when config drawer is open) */}
+          {isEditing && !selectedBlock && (
             <div className="px-4 py-2 border-t border-sage-light flex-shrink-0">
               <SpacingPicker value={layout.spacing} onChange={handleSpacingChange} />
             </div>
           )}
-        </div>
 
-        {/* Config drawer */}
-        {configDrawer}
+          {/* Config drawer — inline, pushes content up */}
+          <ConfigDrawer {...configDrawerProps} isMobile />
+        </div>
 
         <DragOverlay>
           {activeNode ? (
@@ -828,8 +837,8 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
         </div>
       </div>
 
-      {/* Config drawer */}
-      {configDrawer}
+      {/* Config drawer — desktop overlay */}
+      <ConfigDrawer {...configDrawerProps} />
 
       <DragOverlay>
         {activeNode ? (


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

- [ ] Unit tests pass (`npm run test`)
- [ ] Type check passes (`npm run type-check`)
- [ ] E2E tests pass (if applicable)

## Memory & Decision Tracking

- [ ] Does this change introduce a lasting technical decision? If yes, create or update an ADR in `docs/adr/`.
- [ ] Should project or org memory be updated? Check `memory/decisions/`, `memory/patterns/`, or `memory/context/`.
- [ ] Files updated in `docs/adr/` or `memory/`: <!-- list them here -->

## Screenshots

<!-- If applicable, add before/after screenshots -->
