### PR TITLE
fix: ConfigDrawer renders at full content height instead of scrolling

The drawer was very short because the inner measurement div had
height: 100%, constraining scrollHeight to the parent's initial 0px.
Content was forced to scroll in a tiny box.

- Remove height: 100% on inner content wrapper so scrollHeight
  reflects natural content size
- Use height: auto until first measurement completes to avoid
  0-height flash, then switch to explicit height for drag behavior
- Remove flex-1 overflow-y-auto from config content section so
  it renders at natural height instead of scrolling

https://claude.ai/code/session_017azurM2k1ofdhod8Smbe2m

### DIFF
--- a/src/components/layout/builder/ConfigDrawer.tsx
+++ b/src/components/layout/builder/ConfigDrawer.tsx
@@ -139,7 +139,7 @@ export default function ConfigDrawer({
       </div>
 
       {/* Config content */}
-      <div className="flex-1 overflow-y-auto px-4 py-3">
+      <div className="px-4 py-3">
         <BlockConfigPanel
           block={block as any}
           customFields={customFields}
@@ -187,22 +187,23 @@ export default function ConfigDrawer({
   if (isMobile) {
     // Visible height = content height minus how far user dragged down
     const visibleHeight = Math.max(0, contentHeight - dragOffset);
+    // Use auto height until first measurement to avoid 0-height flash
+    const hasBeenMeasured = contentHeight > 0;
 
     return (
       <div
         className="flex flex-col bg-white flex-shrink-0 shadow-[0_-4px_16px_rgba(0,0,0,0.08)] overflow-hidden"
         style={{
-          height: visibleHeight,
+          height: hasBeenMeasured ? visibleHeight : 'auto',
+          maxHeight: '70vh',
           transition: isSnapping ? 'height 250ms cubic-bezier(0.32, 0.72, 0, 1)' : 'none',
           paddingBottom: 'env(safe-area-inset-bottom)',
           opacity: isDismissing ? 0 : 1,
         }}
       >
-        {/* Hidden measurer — always renders full content to get natural height */}
         <div
           ref={contentRef}
           className="flex flex-col"
-          style={{ minHeight: 0, height: '100%' }}
         >
           {drawerInner}
         </div>


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI

## Testing

- [ ] Unit tests pass (`npm run test`)
- [ ] Type check passes (`npm run type-check`)
- [ ] E2E tests pass (if applicable)

## Memory & Decision Tracking

- [ ] Does this change introduce a lasting technical decision? If yes, create or update an ADR in `docs/adr/`.
- [ ] Should project or org memory be updated? Check `memory/decisions/`, `memory/patterns/`, or `memory/context/`.
- [ ] Files updated in `docs/adr/` or `memory/`: <!-- list them here -->

## Screenshots

<!-- If applicable, add before/after screenshots -->
