### PR TITLE
fix: enable RLS on county_gis_registry to block public writes

### DIFF
--- a/src/app/admin/properties/[slug]/parcel-lookup/actions.ts
+++ b/src/app/admin/properties/[slug]/parcel-lookup/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { runParcelLookup } from '@/lib/geo/parcel-lookup';
 import { createGeoLayer, assignLayerToProperties, setPropertyBoundary } from '@/app/admin/geo-layers/actions';
 import type { CountyGISConfig, ParcelCandidate, ParcelLookupResult } from '@/lib/geo/types';
@@ -26,7 +26,8 @@ export async function lookupParcel(input: {
   };
 
   const registrySave = async (config: Omit<CountyGISConfig, 'id' | 'last_verified_at'>) => {
-    await supabase.from('county_gis_registry').upsert(
+    const serviceClient = createServiceClient();
+    await serviceClient.from('county_gis_registry').upsert(
       {
         fips: config.fips,
         county_name: config.county_name,

--- a/src/components/layout/builder/__tests__/ComponentDrawer.test.tsx
+++ b/src/components/layout/builder/__tests__/ComponentDrawer.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@dnd-kit/core', () => ({
     setNodeRef: vi.fn(),
     isDragging: false,
   })),
+  useDndMonitor: vi.fn(),
 }));
 
 describe('ComponentDrawer', () => {

--- a/src/components/layout/builder/__tests__/LayoutEditor.test.tsx
+++ b/src/components/layout/builder/__tests__/LayoutEditor.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@dnd-kit/core', () => ({
   KeyboardSensor: vi.fn(),
   PointerSensor: vi.fn(),
   TouchSensor: vi.fn(),
+  useDndMonitor: vi.fn(),
 }));
 
 vi.mock('@dnd-kit/sortable', () => ({

--- a/supabase/migrations/042_county_gis_registry_rls.sql
+++ b/supabase/migrations/042_county_gis_registry_rls.sql
@@ -1,0 +1,27 @@
+-- Enable RLS on county_gis_registry (was missing)
+ALTER TABLE county_gis_registry ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can read registry entries (used during parcel lookups)
+CREATE POLICY "Authenticated users can read county_gis_registry"
+  ON county_gis_registry FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Only platform admins can insert/update/delete registry entries.
+-- Server actions that upsert use the service role, so authenticated
+-- end-user writes are correctly blocked.
+CREATE POLICY "Platform admins can insert county_gis_registry"
+  ON county_gis_registry FOR INSERT
+  TO authenticated
+  WITH CHECK (is_platform_admin());
+
+CREATE POLICY "Platform admins can update county_gis_registry"
+  ON county_gis_registry FOR UPDATE
+  TO authenticated
+  USING (is_platform_admin())
+  WITH CHECK (is_platform_admin());
+
+CREATE POLICY "Platform admins can delete county_gis_registry"
+  ON county_gis_registry FOR DELETE
+  TO authenticated
+  USING (is_platform_admin());


### PR DESCRIPTION
## Summary
- `county_gis_registry` was the only table missing Row Level Security, allowing anonymous/public writes
- Added RLS with read access for authenticated users, write access restricted to platform admins
- Updated parcel lookup server action to use service role client for registry upserts (shared cache table)

Closes #238

## Test plan
- [ ] Verify `county_gis_registry` rejects anonymous INSERT/UPDATE/DELETE
- [ ] Verify authenticated non-admin users can still SELECT from the registry
- [ ] Verify parcel lookup flow still works end-to-end (upsert uses service role)
- [ ] Run full test suite — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)