### PR TITLE
Unify edit/preview layout in Layout Builder

### DIFF
--- a/docs/superpowers/plans/2026-04-09-unified-edit-preview-layout.md
+++ b/docs/superpowers/plans/2026-04-09-unified-edit-preview-layout.md
@@ -1,0 +1,743 @@
+# Unified Edit/Preview Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Layout Builder's edit and preview modes visually identical — both render the detail preview layout, with edit mode adding block selection/highlighting and preview mode making fields interactive.
+
+**Architecture:** Extend `LayoutRenderer` with an `'edit'` mode that wraps each block in a clickable, highlightable container. `LayoutBuilder` replaces its split detail/form preview with a single unified panel that toggles between `edit` and `preview` modes. `BlockList` gains scroll-to-selection sync with the right panel.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, Vitest + React Testing Library
+
+---
+
+### Task 1: Extend LayoutRenderer with edit mode and block selection
+
+**Files:**
+- Modify: `src/components/layout/LayoutRenderer.tsx`
+
+- [ ] **Step 1: Write failing tests for edit mode**
+
+Add to `src/components/layout/__tests__/LayoutRenderer.test.tsx`:
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+// Add these tests inside the existing describe('LayoutRenderer') block:
+
+it('wraps blocks in clickable containers in edit mode', () => {
+  const onBlockSelect = vi.fn();
+  const layout = makeLayout([
+    makeBlock('status_badge', 'b1'),
+    makeBlock('text_label', 'b2'),
+  ]);
+
+  render(
+    <LayoutRenderer
+      layout={layout}
+      item={baseItem}
+      mode="edit"
+      context="preview"
+      customFields={[]}
+      onBlockSelect={onBlockSelect}
+    />
+  );
+
+  const wrappers = screen.getAllByTestId(/^edit-block-/);
+  expect(wrappers).toHaveLength(2);
+  expect(wrappers[0].dataset.testid).toBe('edit-block-b1');
+  expect(wrappers[1].dataset.testid).toBe('edit-block-b2');
+});
+
+it('calls onBlockSelect when a block is clicked in edit mode', async () => {
+  const user = userEvent.setup();
+  const onBlockSelect = vi.fn();
+  const layout = makeLayout([makeBlock('status_badge', 'b1')]);
+
+  render(
+    <LayoutRenderer
+      layout={layout}
+      item={baseItem}
+      mode="edit"
+      context="preview"
+      customFields={[]}
+      onBlockSelect={onBlockSelect}
+    />
+  );
+
+  await user.click(screen.getByTestId('edit-block-b1'));
+  expect(onBlockSelect).toHaveBeenCalledWith('b1');
+});
+
+it('calls onBlockSelect(null) when clicking the already-selected block', async () => {
+  const user = userEvent.setup();
+  const onBlockSelect = vi.fn();
+  const layout = makeLayout([makeBlock('status_badge', 'b1')]);
+
+  render(
+    <LayoutRenderer
+      layout={layout}
+      item={baseItem}
+      mode="edit"
+      context="preview"
+      customFields={[]}
+      selectedBlockId="b1"
+      onBlockSelect={onBlockSelect}
+    />
+  );
+
+  await user.click(screen.getByTestId('edit-block-b1'));
+  expect(onBlockSelect).toHaveBeenCalledWith(null);
+});
+
+it('applies highlight ring to the selected block', () => {
+  const layout = makeLayout([
+    makeBlock('status_badge', 'b1'),
+    makeBlock('text_label', 'b2'),
+  ]);
+
+  render(
+    <LayoutRenderer
+      layout={layout}
+      item={baseItem}
+      mode="edit"
+      context="preview"
+      customFields={[]}
+      selectedBlockId="b1"
+      onBlockSelect={vi.fn()}
+    />
+  );
+
+  const selected = screen.getByTestId('edit-block-b1');
+  expect(selected.className).toContain('ring-2');
+
+  const unselected = screen.getByTestId('edit-block-b2');
+  expect(unselected.className).not.toContain('ring-2');
+});
+
+it('does not wrap blocks in clickable containers in preview mode', () => {
+  const layout = makeLayout([makeBlock('status_badge', 'b1')]);
+
+  render(
+    <LayoutRenderer
+      layout={layout}
+      item={baseItem}
+      mode="preview"
+      context="preview"
+      customFields={[]}
+    />
+  );
+
+  expect(screen.queryByTestId('edit-block-b1')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/patrick/birdhousemapper-item-editor-improvements && npm test -- --run src/components/layout/__tests__/LayoutRenderer.test.tsx`
+
+Expected: FAIL — `mode="edit"` is not a valid value, `onBlockSelect`/`selectedBlockId` props don't exist.
+
+- [ ] **Step 3: Update LayoutRendererProps and renderBlock**
+
+In `src/components/layout/LayoutRenderer.tsx`, update the interface and rendering logic:
+
+```tsx
+export interface LayoutRendererProps {
+  layout: TypeLayout;
+  item: ItemWithDetails;
+  mode: 'live' | 'preview' | 'edit';
+  context: 'bottom-sheet' | 'side-panel' | 'preview';
+  sheetState?: 'peek' | 'half' | 'full';
+  customFields: CustomField[];
+  selectedBlockId?: string;
+  onBlockSelect?: (blockId: string | null) => void;
+}
+```
+
+Update the `renderBlock` function to wrap blocks in edit mode. Replace the existing `renderBlock` function:
+
+```tsx
+function renderBlock(
+  node: LayoutNode,
+  index: number,
+  props: LayoutRendererProps
+): React.ReactNode {
+  const { item, mode, context, customFields, selectedBlockId, onBlockSelect } = props;
+
+  if (isLayoutRow(node)) {
+    const children = node.children.map((child, childIndex) =>
+      renderBlock(child, childIndex, props)
+    );
+    const rowContent = (
+      <BlockErrorBoundary key={node.id} blockType="row">
+        <RowBlock row={node}>{children as React.ReactNode[]}</RowBlock>
+      </BlockErrorBoundary>
+    );
+
+    if (mode === 'edit') {
+      const isSelected = selectedBlockId === node.id;
+      return (
+        <div
+          key={node.id}
+          data-testid={`edit-block-${node.id}`}
+          className={`cursor-pointer rounded transition-all ${
+            isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
+          }`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onBlockSelect?.(isSelected ? null : node.id);
+          }}
+        >
+          {rowContent}
+        </div>
+      );
+    }
+
+    return rowContent;
+  }
+
+  const block = node as LayoutBlock;
+
+  if (block.hideWhenEmpty) {
+    if (block.type === 'field_display') {
+      const config = block.config as import('@/lib/layout/types').FieldDisplayConfig;
+      const value = item.custom_field_values[config.fieldId];
+      if (value === null || value === undefined) return null;
+    }
+  }
+
+  const rendered = renderBlockContent(block, index, props);
+  if (rendered === null) return null;
+
+  const blockContent = (
+    <BlockErrorBoundary key={block.id} blockType={block.type}>
+      {rendered}
+    </BlockErrorBoundary>
+  );
+
+  if (mode === 'edit') {
+    const isSelected = selectedBlockId === block.id;
+    return (
+      <div
+        key={block.id}
+        data-testid={`edit-block-${block.id}`}
+        className={`cursor-pointer rounded transition-all ${
+          isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
+        }`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onBlockSelect?.(isSelected ? null : block.id);
+        }}
+      >
+        {blockContent}
+      </div>
+    );
+  }
+
+  return blockContent;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/patrick/birdhousemapper-item-editor-improvements && npm test -- --run src/components/layout/__tests__/LayoutRenderer.test.tsx`
+
+Expected: All tests PASS (both new and existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-item-editor-improvements
+git add src/components/layout/LayoutRenderer.tsx src/components/layout/__tests__/LayoutRenderer.test.tsx
+git commit -m "feat: add edit mode with block selection to LayoutRenderer"
+```
+
+---
+
+### Task 2: Add scroll-to-selection to BlockList
+
+**Files:**
+- Modify: `src/components/layout/builder/BlockList.tsx`
+- Modify: `src/components/layout/builder/BlockListItem.tsx`
+
+- [ ] **Step 1: Add ref forwarding to BlockListItem**
+
+Update `src/components/layout/builder/BlockListItem.tsx` to accept and merge an external ref. The component already uses `useSortable`'s `setNodeRef`, so we need to merge refs:
+
+```tsx
+// At the top of the file, add forwardRef import:
+import { useState, forwardRef, useCallback } from 'react';
+
+// Change the component to use forwardRef. Replace the entire export default function:
+const BlockListItem = forwardRef<HTMLDivElement, Props>(function BlockListItem(
+  {
+    block,
+    customFields,
+    entityTypes,
+    fieldName,
+    onConfigChange,
+    onDelete,
+    onCreateField,
+    isExpanded,
+    onToggleExpand,
+  },
+  externalRef
+) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setSortableRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: block.id });
+
+  // Merge sortable ref with external ref
+  const mergedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setSortableRef(node);
+      if (typeof externalRef === 'function') {
+        externalRef(node);
+      } else if (externalRef) {
+        externalRef.current = node;
+      }
+    },
+    [setSortableRef, externalRef]
+  );
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const label = block.type === 'field_display' && fieldName
+    ? fieldName
+    : BLOCK_LABELS[block.type] ?? block.type;
+
+  return (
+    <div ref={mergedRef} style={style} className="border border-sage-light rounded-lg bg-white">
+      {/* Header row */}
+      <div className="flex items-center min-h-[48px]">
+        <button
+          {...attributes}
+          {...listeners}
+          className="p-3 cursor-grab active:cursor-grabbing touch-none"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="w-4 h-4 text-sage" />
+        </button>
+        <button
+          onClick={onToggleExpand}
+          className="flex-1 flex items-center gap-2 py-2 text-left"
+        >
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-sage" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-sage" />
+          )}
+          <span className="text-sm font-medium text-forest-dark">{label}</span>
+        </button>
+        {showDeleteConfirm ? (
+          <div className="flex items-center gap-1 pr-2">
+            <button onClick={() => onDelete(block.id)} className="text-xs text-red-600 font-medium px-2 py-1">
+              Delete
+            </button>
+            <button onClick={() => setShowDeleteConfirm(false)} className="text-xs text-sage px-2 py-1">
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="p-3 text-sage hover:text-red-500 transition-colors"
+            aria-label="Delete block"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Config panel (accordion) */}
+      {isExpanded && (
+        <div className="px-3 pb-3 border-t border-sage-light/50">
+          <BlockConfigPanel
+            block={block}
+            customFields={customFields}
+            entityTypes={entityTypes}
+            onConfigChange={onConfigChange}
+            onCreateField={onCreateField}
+          />
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default BlockListItem;
+```
+
+- [ ] **Step 2: Update BlockList to accept selectedBlockId and sync**
+
+Update `src/components/layout/builder/BlockList.tsx`. Add new props and scroll-to-selection logic:
+
+```tsx
+// Add to imports:
+import { useState, useEffect, useRef, createRef } from 'react';
+
+// Update the Props interface — add these two fields:
+interface Props {
+  nodes: LayoutNode[];
+  customFields: CustomField[];
+  entityTypes: EntityType[];
+  peekBlockCount: number;
+  selectedBlockId: string | null;
+  onBlockSelect: (blockId: string | null) => void;
+  onReorder: (activeId: string, overId: string) => void;
+  onConfigChange: (blockId: string, config: BlockConfig) => void;
+  onDeleteBlock: (blockId: string) => void;
+  onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
+  onPeekCountChange: (count: number) => void;
+  onRowChange: (rowId: string, update: Partial<Pick<LayoutRow, 'gap' | 'distribution'>>) => void;
+  onAddToRow: (rowId: string, blockType: string) => void;
+  onRemoveFromRow: (rowId: string, blockId: string) => void;
+}
+```
+
+Update the component function signature to destructure the new props:
+
+```tsx
+export default function BlockList({
+  nodes,
+  customFields,
+  entityTypes,
+  peekBlockCount,
+  selectedBlockId,
+  onBlockSelect,
+  onReorder,
+  onConfigChange,
+  onDeleteBlock,
+  onCreateField,
+  onPeekCountChange,
+  onRowChange,
+  onAddToRow,
+  onRemoveFromRow,
+}: Props) {
+```
+
+Replace the `expandedId` state with synced logic. Remove:
+
+```tsx
+const [expandedId, setExpandedId] = useState<string | null>(null);
+```
+
+Replace with:
+
+```tsx
+// Sync expandedId to selectedBlockId from the right panel
+const expandedId = selectedBlockId;
+
+const blockRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+// Scroll to selected block when selection changes
+useEffect(() => {
+  if (selectedBlockId) {
+    const el = blockRefs.current.get(selectedBlockId);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+}, [selectedBlockId]);
+```
+
+Update the `BlockListItem` usage to pass a ref callback and sync selection. Replace the `BlockListItem` render:
+
+```tsx
+<BlockListItem
+  ref={(el: HTMLDivElement | null) => {
+    if (el) blockRefs.current.set(node.id, el);
+    else blockRefs.current.delete(node.id);
+  }}
+  block={node}
+  customFields={customFields}
+  entityTypes={entityTypes}
+  fieldName={
+    node.type === 'field_display'
+      ? fieldMap.get((node.config as { fieldId: string }).fieldId)?.name
+      : undefined
+  }
+  onConfigChange={onConfigChange}
+  onDelete={onDeleteBlock}
+  onCreateField={onCreateField}
+  isExpanded={expandedId === node.id}
+  onToggleExpand={() => onBlockSelect(expandedId === node.id ? null : node.id)}
+/>
+```
+
+Update the `RowEditor` `onToggleExpand` similarly:
+
+```tsx
+onToggleExpand={(id) => onBlockSelect(expandedId === id ? null : id)}
+```
+
+- [ ] **Step 3: Run tests to verify nothing is broken**
+
+Run: `cd /Users/patrick/birdhousemapper-item-editor-improvements && npm test -- --run`
+
+Expected: All existing tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-item-editor-improvements
+git add src/components/layout/builder/BlockList.tsx src/components/layout/builder/BlockListItem.tsx
+git commit -m "feat: add ref forwarding to BlockListItem and scroll-to-selection in BlockList"
+```
+
+---
+
+### Task 3: Update LayoutBuilder to use unified edit/preview panel
+
+**Files:**
+- Modify: `src/components/layout/builder/LayoutBuilder.tsx`
+
+- [ ] **Step 1: Add selectedBlockId and rightPanelMode state**
+
+In `LayoutBuilder`, replace the existing preview state. Remove these lines:
+
+```tsx
+const [activeTab, setActiveTab] = useState<'build' | 'detail' | 'form'>('build');
+const [previewTab, setPreviewTab] = useState<PreviewTab>('detail');
+```
+
+And the `PreviewTab` type:
+
+```tsx
+type PreviewTab = 'detail' | 'form';
+```
+
+Replace with:
+
+```tsx
+const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+const [rightPanelMode, setRightPanelMode] = useState<'edit' | 'preview'>('edit');
+const [activeTab, setActiveTab] = useState<'build' | 'edit' | 'preview'>('build');
+```
+
+Add a handler to clear selection when switching to preview:
+
+```tsx
+const handleRightPanelModeChange = useCallback((mode: 'edit' | 'preview') => {
+  setRightPanelMode(mode);
+  if (mode === 'preview') {
+    setSelectedBlockId(null);
+  }
+}, []);
+```
+
+- [ ] **Step 2: Replace the right panel content**
+
+Remove the `detailPreview` and `formPreviewContent` variables (lines 232-252). Remove the `FormPreview` import.
+
+Replace with a single `unifiedPreview` variable:
+
+```tsx
+const unifiedPreview = (
+  <div className="bg-gray-100 rounded-xl p-3">
+    <div className="bg-white rounded-t-2xl shadow-lg">
+      {/* Handle */}
+      <div className="flex justify-center py-3">
+        <div className="w-10 h-1 rounded-full bg-gray-300" />
+      </div>
+
+      <div className="px-4 pb-4 max-h-[70vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xl">{itemType.icon}</span>
+          <h2 className="font-heading font-semibold text-forest-dark text-xl">
+            {mockItem.name}
+          </h2>
+        </div>
+
+        {/* Layout content */}
+        <LayoutRenderer
+          layout={layout}
+          item={mockItem}
+          mode={rightPanelMode}
+          context="preview"
+          customFields={allFields}
+          selectedBlockId={selectedBlockId}
+          onBlockSelect={setSelectedBlockId}
+        />
+      </div>
+    </div>
+  </div>
+);
+```
+
+- [ ] **Step 3: Update the desktop layout**
+
+Replace the desktop return block (the `return` starting around line 297). Replace the right panel section:
+
+```tsx
+{/* Preview panel */}
+<div className="flex-[2] overflow-y-auto">
+  <div className="flex gap-1 mb-3">
+    {(['edit', 'preview'] as const).map((tab) => (
+      <button
+        key={tab}
+        onClick={() => handleRightPanelModeChange(tab)}
+        className={`px-3 py-1.5 rounded-md text-sm font-medium ${
+          rightPanelMode === tab ? 'bg-forest text-white' : 'bg-sage-light text-forest-dark'
+        }`}
+      >
+        {tab === 'edit' ? 'Edit' : 'Preview'}
+      </button>
+    ))}
+  </div>
+  {unifiedPreview}
+</div>
+```
+
+- [ ] **Step 4: Update the mobile layout**
+
+Replace the mobile tabs from `['build', 'detail', 'form']` to `['build', 'edit', 'preview']`:
+
+```tsx
+{/* Tab toggle */}
+<div className="flex border-b border-sage-light">
+  {(['build', 'edit', 'preview'] as const).map((tab) => (
+    <button
+      key={tab}
+      onClick={() => {
+        setActiveTab(tab);
+        if (tab === 'edit') setRightPanelMode('edit');
+        if (tab === 'preview') {
+          setRightPanelMode('preview');
+          setSelectedBlockId(null);
+        }
+      }}
+      className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+        activeTab === tab
+          ? 'text-forest border-b-2 border-forest'
+          : 'text-sage'
+      }`}
+    >
+      {tab === 'build' ? 'Build' : tab === 'edit' ? 'Edit' : 'Preview'}
+    </button>
+  ))}
+</div>
+
+{/* Tab content */}
+<div className="flex-1 overflow-y-auto p-4">
+  {activeTab === 'build' && buildContent}
+  {(activeTab === 'edit' || activeTab === 'preview') && unifiedPreview}
+</div>
+```
+
+- [ ] **Step 5: Pass selectedBlockId and onBlockSelect to BlockList**
+
+In the `buildContent` variable, update the `BlockList` usage to pass the new props:
+
+```tsx
+<BlockList
+  nodes={layout.blocks}
+  customFields={allFields}
+  entityTypes={entityTypes}
+  peekBlockCount={layout.peekBlockCount}
+  selectedBlockId={selectedBlockId}
+  onBlockSelect={setSelectedBlockId}
+  onReorder={handleReorder}
+  onConfigChange={handleConfigChange}
+  onDeleteBlock={handleDeleteBlock}
+  onCreateField={handleCreateField}
+  onPeekCountChange={handlePeekCountChange}
+  onRowChange={handleRowChange}
+  onAddToRow={handleAddToRow}
+  onRemoveFromRow={handleRemoveFromRow}
+/>
+```
+
+- [ ] **Step 6: Add mobile edit-mode tap → switch to Build tab**
+
+Add a handler that wraps `setSelectedBlockId` on mobile to also switch tabs:
+
+```tsx
+const handleBlockSelectFromPreview = useCallback((blockId: string | null) => {
+  setSelectedBlockId(blockId);
+  if (isMobile && blockId) {
+    setActiveTab('build');
+  }
+}, [isMobile]);
+```
+
+In the `unifiedPreview`, replace `onBlockSelect={setSelectedBlockId}` with `onBlockSelect={handleBlockSelectFromPreview}`.
+
+- [ ] **Step 7: Remove unused FormPreview import**
+
+Remove from the top of `LayoutBuilder.tsx`:
+
+```tsx
+import FormPreview from '../preview/FormPreview';
+```
+
+- [ ] **Step 8: Run type-check and tests**
+
+Run: `cd /Users/patrick/birdhousemapper-item-editor-improvements && npm run type-check && npm test -- --run`
+
+Expected: No type errors, all tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/patrick/birdhousemapper-item-editor-improvements
+git add src/components/layout/builder/LayoutBuilder.tsx
+git commit -m "feat: replace split detail/form preview with unified edit/preview panel"
+```
+
+---
+
+### Task 4: Manual verification and cleanup
+
+**Files:**
+- Possibly modify: `src/components/layout/builder/LayoutBuilder.tsx` (if issues found)
+
+- [ ] **Step 1: Run the dev server**
+
+Run: `cd /Users/patrick/birdhousemapper-item-editor-improvements && npm run dev`
+
+- [ ] **Step 2: Verify desktop behavior**
+
+Navigate to an item type's layout builder. Verify:
+1. Right panel shows Edit/Preview toggle (not Detail/Form)
+2. Both Edit and Preview modes show the same detail preview layout (gray bg, white card, handle, icon + title)
+3. In Edit mode, clicking a block highlights it with a ring
+4. Clicking a highlighted block deselects it
+5. When a block is selected on the right, its config expands and scrolls into view on the left
+6. Clicking a block in the left BlockList highlights it on the right
+7. Switching to Preview mode clears selection and dismisses any highlight
+8. In Preview mode, the layout looks identical to Edit mode (no visible change except highlight gone)
+
+- [ ] **Step 3: Verify mobile behavior**
+
+Resize browser to mobile width. Verify:
+1. Three tabs: Build, Edit, Preview
+2. Edit tab shows the unified layout
+3. Tapping a block in Edit mode switches to Build tab with that block expanded
+4. Preview tab shows same layout, no selection, fields interactive
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd /Users/patrick/birdhousemapper-item-editor-improvements && npm test -- --run`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Final commit if any fixes were needed**
+
+```bash
+cd /Users/patrick/birdhousemapper-item-editor-improvements
+git add -u
+git commit -m "fix: address issues found during manual verification"
+```

--- a/docs/superpowers/specs/2026-04-09-unified-edit-preview-layout-design.md
+++ b/docs/superpowers/specs/2026-04-09-unified-edit-preview-layout-design.md
@@ -1,0 +1,127 @@
+# Unified Edit/Preview Layout Design
+
+## Problem
+
+The Layout Builder's right panel has separate Edit (Build) and Preview modes that look different. The Build tab shows a block list editor, while the Detail Preview tab shows the rendered layout. This disconnect makes it hard to understand what you're editing — the build UI bears no visual resemblance to the final output.
+
+## Goal
+
+Make the Edit and Preview modes visually identical. Both render the detail preview layout (bottom-sheet style card with icon, title, fields, same padding/background). The only differences:
+
+- **Edit mode**: clicking a block highlights it and scrolls to its config in the left Build panel
+- **Preview mode**: no highlights, no selection, fields are interactive (dropdowns open, inputs accept text)
+
+## Approach
+
+Extend `LayoutRenderer` with an `'edit'` mode. Each block gets a clickable wrapper in edit mode for selection/highlighting. The right panel always renders the detail preview layout, toggling between `mode="edit"` and `mode="preview"`.
+
+## Design
+
+### LayoutRenderer Changes
+
+Add new optional props to `LayoutRendererProps`:
+
+- `selectedBlockId?: string` — the currently selected block
+- `onBlockSelect?: (blockId: string | null) => void` — callback when a block is tapped
+
+Add `'edit'` as a valid value for the existing `mode` prop.
+
+In the `renderBlock` function, when `mode === 'edit'`:
+- Wrap each block's output in a clickable `<div>` that calls `onBlockSelect(block.id)` on click
+- When `block.id === selectedBlockId`, apply a highlight ring (`ring-2 ring-forest/40 rounded`)
+- Use `cursor-pointer` on all block wrappers
+- Clicking the already-selected block deselects it (`onBlockSelect(null)`)
+
+In `mode === 'preview'`:
+- No wrapper, no selection — identical to current behavior
+
+Block components themselves do not change. The wrapper in `renderBlock` handles all selection logic.
+
+### LayoutBuilder — State Changes
+
+Lift `selectedBlockId` to `LayoutBuilder` state:
+
+```ts
+const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+const [rightPanelMode, setRightPanelMode] = useState<'edit' | 'preview'>('edit');
+```
+
+When `rightPanelMode` changes to `'preview'`, clear `selectedBlockId`.
+
+Pass `selectedBlockId` down to both the right panel's `LayoutRenderer` and the left panel's `BlockList`, so selection is bidirectional.
+
+### Right Panel — Unified View
+
+Replace the current `detailPreview` / `formPreviewContent` split with a single unified view. The right panel always renders:
+
+```
+┌─ gray-100 outer container, rounded-xl, p-3 ─────────┐
+│ ┌─ white card, rounded-t-2xl, shadow-lg ───────────┐ │
+│ │  [handle bar]                                      │ │
+│ │  [icon] [Item Name]                                │ │
+│ │                                                    │ │
+│ │  <LayoutRenderer                                   │ │
+│ │    mode={rightPanelMode}                           │ │
+│ │    selectedBlockId={selectedBlockId}               │ │
+│ │    onBlockSelect={setSelectedBlockId}              │ │
+│ │    ...                                             │ │
+│ │  />                                                │ │
+│ └────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────┘
+```
+
+Toggle at the top of the right panel switches between Edit and Preview:
+
+```
+[Edit] [Preview]
+```
+
+Styled the same as the current Detail/Form tab toggle (`px-3 py-1.5 rounded-md text-sm font-medium`, active: `bg-forest text-white`, inactive: `bg-sage-light text-forest-dark`).
+
+### Left Panel — Scroll-to-Selection
+
+`BlockList` receives a new prop: `selectedBlockId?: string`.
+
+When `selectedBlockId` changes:
+- Auto-expand the matching block's config in BlockList (set `expandedId` to match)
+- Scroll the block's DOM element into view using `scrollIntoView({ behavior: 'smooth', block: 'nearest' })`
+- Use `useEffect` watching `selectedBlockId` + refs on each BlockListItem
+
+When a block is expanded/clicked in BlockList, also update `selectedBlockId` in LayoutBuilder (bidirectional sync). BlockList receives `onBlockSelect` prop for this.
+
+### Mobile Behavior
+
+Tabs change from `Build | Detail | Form` to `Build | Edit | Preview`.
+
+- **Build tab**: unchanged — BlockPalette, SpacingPicker, BlockList
+- **Edit tab**: unified detail preview layout with `mode="edit"`. Tapping a block switches to Build tab with that block's config expanded
+- **Preview tab**: unified detail preview layout with `mode="preview"`, fields interactive
+
+### Form Preview
+
+The Form Preview tab/functionality is removed from the right panel toggle. The unified view only shows the detail preview layout. If Form Preview is needed later, it can be re-added as a separate feature.
+
+### What Gets Removed
+
+- `DetailPreview` component is no longer used by LayoutBuilder (may still be used elsewhere)
+- The `detailPreview` variable in LayoutBuilder
+- The `formPreviewContent` variable and Form Preview tab in LayoutBuilder
+- The `previewTab` state (`'detail' | 'form'`) — replaced by `rightPanelMode` (`'edit' | 'preview'`)
+- Desktop: the Detail Preview / Form Preview tab toggle
+- Mobile: the three-tab `build | detail | form` layout
+
+### What Stays the Same
+
+- All block components (StatusBadgeBlock, FieldDisplayBlock, etc.) — unchanged
+- BlockPalette — unchanged
+- SpacingPicker — unchanged
+- The detail preview visual layout (gray outer, white card, handle, icon + title header)
+- LayoutRenderer's existing `'live'` and `'preview'` modes
+- All layout data structures and types
+
+## Files Modified
+
+1. **`src/components/layout/LayoutRenderer.tsx`** — add `'edit'` mode, `selectedBlockId`, `onBlockSelect` props, block wrapper logic
+2. **`src/components/layout/builder/LayoutBuilder.tsx`** — lift `selectedBlockId` state, replace right panel with unified view, update tabs
+3. **`src/components/layout/builder/BlockList.tsx`** — accept `selectedBlockId` and `onBlockSelect`, auto-expand and scroll-to on selection change
+4. **`src/components/layout/builder/BlockListItem.tsx`** — add ref forwarding for scroll-to support

--- a/src/components/layout/LayoutRenderer.tsx
+++ b/src/components/layout/LayoutRenderer.tsx
@@ -31,6 +31,34 @@ export interface LayoutRendererProps {
   onBlockSelect?: (blockId: string | null) => void;
 }
 
+function EditBlockWrapper({
+  id,
+  selectedBlockId,
+  onBlockSelect,
+  children,
+}: {
+  id: string;
+  selectedBlockId?: string;
+  onBlockSelect?: (blockId: string | null) => void;
+  children: React.ReactNode;
+}) {
+  const isSelected = selectedBlockId === id;
+  return (
+    <div
+      data-testid={`edit-block-${id}`}
+      className={`cursor-pointer rounded transition-all ${
+        isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
+      }`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onBlockSelect?.(isSelected ? null : id);
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
 function renderBlock(
   node: LayoutNode,
   index: number,
@@ -49,21 +77,15 @@ function renderBlock(
     );
 
     if (mode === 'edit') {
-      const isSelected = selectedBlockId === node.id;
       return (
-        <div
+        <EditBlockWrapper
           key={node.id}
-          data-testid={`edit-block-${node.id}`}
-          className={`cursor-pointer rounded transition-all ${
-            isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
-          }`}
-          onClick={(e) => {
-            e.stopPropagation();
-            onBlockSelect?.(isSelected ? null : node.id);
-          }}
+          id={node.id}
+          selectedBlockId={selectedBlockId}
+          onBlockSelect={onBlockSelect}
         >
           {rowContent}
-        </div>
+        </EditBlockWrapper>
       );
     }
 
@@ -91,21 +113,15 @@ function renderBlock(
   );
 
   if (mode === 'edit') {
-    const isSelected = selectedBlockId === block.id;
     return (
-      <div
+      <EditBlockWrapper
         key={block.id}
-        data-testid={`edit-block-${block.id}`}
-        className={`cursor-pointer rounded transition-all ${
-          isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
-        }`}
-        onClick={(e) => {
-          e.stopPropagation();
-          onBlockSelect?.(isSelected ? null : block.id);
-        }}
+        id={block.id}
+        selectedBlockId={selectedBlockId}
+        onBlockSelect={onBlockSelect}
       >
         {blockContent}
-      </div>
+      </EditBlockWrapper>
     );
   }
 

--- a/src/components/layout/LayoutRenderer.tsx
+++ b/src/components/layout/LayoutRenderer.tsx
@@ -20,13 +20,15 @@ import type { EntityDisplay } from './blocks/EntityListBlock';
 export interface LayoutRendererProps {
   layout: TypeLayout;
   item: ItemWithDetails;
-  mode: 'live' | 'preview';
+  mode: 'live' | 'preview' | 'edit';
   context: 'bottom-sheet' | 'side-panel' | 'preview';
   sheetState?: 'peek' | 'half' | 'full';
   customFields: CustomField[];
   canEdit?: boolean;
   canAddUpdate?: boolean;
   isAuthenticated?: boolean;
+  selectedBlockId?: string;
+  onBlockSelect?: (blockId: string | null) => void;
 }
 
 function renderBlock(
@@ -34,17 +36,38 @@ function renderBlock(
   index: number,
   props: LayoutRendererProps
 ): React.ReactNode {
-  const { item, mode, context, customFields } = props;
+  const { item, mode, context, customFields, selectedBlockId, onBlockSelect } = props;
 
   if (isLayoutRow(node)) {
     const children = node.children.map((child, childIndex) =>
       renderBlock(child, childIndex, props)
     );
-    return (
+    const rowContent = (
       <BlockErrorBoundary key={node.id} blockType="row">
         <RowBlock row={node}>{children as React.ReactNode[]}</RowBlock>
       </BlockErrorBoundary>
     );
+
+    if (mode === 'edit') {
+      const isSelected = selectedBlockId === node.id;
+      return (
+        <div
+          key={node.id}
+          data-testid={`edit-block-${node.id}`}
+          className={`cursor-pointer rounded transition-all ${
+            isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
+          }`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onBlockSelect?.(isSelected ? null : node.id);
+          }}
+        >
+          {rowContent}
+        </div>
+      );
+    }
+
+    return rowContent;
   }
 
   const block = node as LayoutBlock;
@@ -61,11 +84,32 @@ function renderBlock(
   const rendered = renderBlockContent(block, index, props);
   if (rendered === null) return null;
 
-  return (
+  const blockContent = (
     <BlockErrorBoundary key={block.id} blockType={block.type}>
       {rendered}
     </BlockErrorBoundary>
   );
+
+  if (mode === 'edit') {
+    const isSelected = selectedBlockId === block.id;
+    return (
+      <div
+        key={block.id}
+        data-testid={`edit-block-${block.id}`}
+        className={`cursor-pointer rounded transition-all ${
+          isSelected ? 'ring-2 ring-forest/40' : 'hover:ring-1 hover:ring-sage-light'
+        }`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onBlockSelect?.(isSelected ? null : block.id);
+        }}
+      >
+        {blockContent}
+      </div>
+    );
+  }
+
+  return blockContent;
 }
 
 function renderBlockContent(
@@ -116,7 +160,7 @@ function renderBlockContent(
           canEdit={props.canEdit ?? false}
           canAddUpdate={props.canAddUpdate ?? false}
           isAuthenticated={props.isAuthenticated ?? false}
-          mode={mode}
+          mode={mode === 'edit' ? 'preview' : mode}
         />
       );
     }

--- a/src/components/layout/__tests__/LayoutRenderer.test.tsx
+++ b/src/components/layout/__tests__/LayoutRenderer.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { TypeLayout, LayoutNode } from '@/lib/layout/types';
 import type { ItemWithDetails, CustomField } from '@/lib/types';
 
@@ -361,5 +362,111 @@ describe('LayoutRenderer', () => {
     expect(block.getAttribute('data-can-edit')).toBe('false');
     expect(block.getAttribute('data-can-add-update')).toBe('false');
     expect(block.getAttribute('data-is-authenticated')).toBe('false');
+  });
+
+  it('wraps blocks in clickable containers in edit mode', () => {
+    const onBlockSelect = vi.fn();
+    const layout = makeLayout([
+      makeBlock('status_badge', 'b1'),
+      makeBlock('text_label', 'b2'),
+    ]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="edit"
+        context="preview"
+        customFields={[]}
+        onBlockSelect={onBlockSelect}
+      />
+    );
+
+    const wrappers = screen.getAllByTestId(/^edit-block-/);
+    expect(wrappers).toHaveLength(2);
+    expect(wrappers[0].dataset.testid).toBe('edit-block-b1');
+    expect(wrappers[1].dataset.testid).toBe('edit-block-b2');
+  });
+
+  it('calls onBlockSelect when a block is clicked in edit mode', async () => {
+    const user = userEvent.setup();
+    const onBlockSelect = vi.fn();
+    const layout = makeLayout([makeBlock('status_badge', 'b1')]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="edit"
+        context="preview"
+        customFields={[]}
+        onBlockSelect={onBlockSelect}
+      />
+    );
+
+    await user.click(screen.getByTestId('edit-block-b1'));
+    expect(onBlockSelect).toHaveBeenCalledWith('b1');
+  });
+
+  it('calls onBlockSelect(null) when clicking the already-selected block', async () => {
+    const user = userEvent.setup();
+    const onBlockSelect = vi.fn();
+    const layout = makeLayout([makeBlock('status_badge', 'b1')]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="edit"
+        context="preview"
+        customFields={[]}
+        selectedBlockId="b1"
+        onBlockSelect={onBlockSelect}
+      />
+    );
+
+    await user.click(screen.getByTestId('edit-block-b1'));
+    expect(onBlockSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('applies highlight ring to the selected block', () => {
+    const layout = makeLayout([
+      makeBlock('status_badge', 'b1'),
+      makeBlock('text_label', 'b2'),
+    ]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="edit"
+        context="preview"
+        customFields={[]}
+        selectedBlockId="b1"
+        onBlockSelect={vi.fn()}
+      />
+    );
+
+    const selected = screen.getByTestId('edit-block-b1');
+    expect(selected.className).toContain('ring-2');
+
+    const unselected = screen.getByTestId('edit-block-b2');
+    expect(unselected.className).not.toContain('ring-2');
+  });
+
+  it('does not wrap blocks in clickable containers in preview mode', () => {
+    const layout = makeLayout([makeBlock('status_badge', 'b1')]);
+
+    render(
+      <LayoutRenderer
+        layout={layout}
+        item={baseItem}
+        mode="preview"
+        context="preview"
+        customFields={[]}
+      />
+    );
+
+    expect(screen.queryByTestId('edit-block-b1')).toBeNull();
   });
 });

--- a/src/components/layout/builder/BlockList.tsx
+++ b/src/components/layout/builder/BlockList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -19,6 +19,8 @@ interface Props {
   entityTypes: EntityType[];
   peekBlockCount: number;
   activeType: 'block' | 'row' | null;
+  selectedBlockId?: string | null;
+  onBlockSelect?: (blockId: string | null) => void;
   onConfigChange: (blockId: string, config: BlockConfig) => void;
   onDeleteBlock: (blockId: string) => void;
   onCreateField: (field: { name: string; field_type: string; options: string[]; required: boolean }) => void;
@@ -33,6 +35,8 @@ export default function BlockList({
   entityTypes,
   peekBlockCount,
   activeType,
+  selectedBlockId,
+  onBlockSelect,
   onConfigChange,
   onDeleteBlock,
   onCreateField,
@@ -40,7 +44,22 @@ export default function BlockList({
   onRowChange,
   onRemoveFromRow,
 }: Props) {
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [internalExpandedId, setInternalExpandedId] = useState<string | null>(null);
+
+  // Use external selection if provided, otherwise fall back to internal state
+  const expandedId = selectedBlockId !== undefined ? selectedBlockId : internalExpandedId;
+  const handleToggle = onBlockSelect ?? setInternalExpandedId;
+
+  const blockRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  useEffect(() => {
+    if (selectedBlockId) {
+      const el = blockRefs.current.get(selectedBlockId);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+  }, [selectedBlockId]);
 
   const fieldMap = useMemo(() => new Map(customFields.map((f) => [f.id, f])), [customFields]);
   const nodeIds = nodes.map((n) => n.id);
@@ -69,7 +88,7 @@ export default function BlockList({
                 entityTypes={entityTypes}
                 fieldMap={fieldMap}
                 expandedId={expandedId}
-                onToggleExpand={(id) => setExpandedId(expandedId === id ? null : id)}
+                onToggleExpand={(id) => handleToggle(expandedId === id ? null : id)}
                 onConfigChange={onConfigChange}
                 onDeleteBlock={onDeleteBlock}
                 onCreateField={onCreateField}
@@ -79,6 +98,10 @@ export default function BlockList({
               />
             ) : (
               <BlockListItem
+                ref={(el: HTMLDivElement | null) => {
+                  if (el) blockRefs.current.set(node.id, el);
+                  else blockRefs.current.delete(node.id);
+                }}
                 block={node}
                 customFields={customFields}
                 entityTypes={entityTypes}
@@ -91,7 +114,7 @@ export default function BlockList({
                 onDelete={onDeleteBlock}
                 onCreateField={onCreateField}
                 isExpanded={expandedId === node.id}
-                onToggleExpand={() => setExpandedId(expandedId === node.id ? null : node.id)}
+                onToggleExpand={() => handleToggle(expandedId === node.id ? null : node.id)}
               />
             )}
             <DropZone

--- a/src/components/layout/builder/BlockListItem.tsx
+++ b/src/components/layout/builder/BlockListItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, forwardRef, useCallback } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { LayoutBlock } from '@/lib/layout/types';
@@ -33,27 +33,32 @@ interface Props {
   onToggleExpand: () => void;
 }
 
-export default function BlockListItem({
-  block,
-  customFields,
-  entityTypes,
-  fieldName,
-  onConfigChange,
-  onDelete,
-  onCreateField,
-  isExpanded,
-  onToggleExpand,
-}: Props) {
+const BlockListItem = forwardRef<HTMLDivElement, Props>(function BlockListItem(
+  { block, customFields, entityTypes, fieldName, onConfigChange, onDelete, onCreateField, isExpanded, onToggleExpand },
+  externalRef
+) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const {
     attributes,
     listeners,
-    setNodeRef,
+    setNodeRef: setSortableRef,
     transform,
     transition,
     isDragging,
   } = useSortable({ id: block.id });
+
+  const mergedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setSortableRef(node);
+      if (typeof externalRef === 'function') {
+        externalRef(node);
+      } else if (externalRef) {
+        externalRef.current = node;
+      }
+    },
+    [setSortableRef, externalRef]
+  );
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -67,7 +72,7 @@ export default function BlockListItem({
 
   return (
     <div
-      ref={setNodeRef}
+      ref={mergedRef}
       style={style}
       className="border border-sage-light rounded-lg bg-white cursor-grab active:cursor-grabbing touch-none"
       {...attributes}
@@ -120,4 +125,6 @@ export default function BlockListItem({
       )}
     </div>
   );
-}
+});
+
+export default BlockListItem;

--- a/src/components/layout/builder/LayoutBuilder.tsx
+++ b/src/components/layout/builder/LayoutBuilder.tsx
@@ -23,7 +23,6 @@ import BlockPalette from './BlockPalette';
 import BlockList from './BlockList';
 import SpacingPicker from './SpacingPicker';
 import LayoutRenderer from '../LayoutRenderer';
-import FormPreview from '../preview/FormPreview';
 import DragOverlayContent from './DragOverlayContent';
 import { rowAwareCollision } from './collision';
 
@@ -36,7 +35,6 @@ interface Props {
   onCancel: () => void;
 }
 
-type PreviewTab = 'detail' | 'form';
 
 function getDefaultConfig(type: BlockType): BlockConfig {
   switch (type) {
@@ -84,8 +82,9 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
   const [pendingFields, setPendingFields] = useState<{ name: string; field_type: string; options: string[]; required: boolean; tempId: string }[]>([]);
   const [saving, setSaving] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const [activeTab, setActiveTab] = useState<'build' | 'detail' | 'form'>('build');
-  const [previewTab, setPreviewTab] = useState<PreviewTab>('detail');
+  const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+  const [rightPanelMode, setRightPanelMode] = useState<'edit' | 'preview'>('edit');
+  const [activeTab, setActiveTab] = useState<'build' | 'edit' | 'preview'>('build');
   const [activeNode, setActiveNode] = useState<LayoutNode | null>(null);
   const [activeType, setActiveType] = useState<'block' | 'row' | null>(null);
 
@@ -101,6 +100,20 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
     window.addEventListener('resize', check);
     return () => window.removeEventListener('resize', check);
   }, []);
+
+  const handleRightPanelModeChange = useCallback((mode: 'edit' | 'preview') => {
+    setRightPanelMode(mode);
+    if (mode === 'preview') {
+      setSelectedBlockId(null);
+    }
+  }, []);
+
+  const handleBlockSelectFromPreview = useCallback((blockId: string | null) => {
+    setSelectedBlockId(blockId);
+    if (isMobile && blockId) {
+      setActiveTab('build');
+    }
+  }, [isMobile]);
 
   const allFields: CustomField[] = [
     ...customFields,
@@ -359,6 +372,8 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
         entityTypes={entityTypes}
         peekBlockCount={layout.peekBlockCount}
         activeType={activeType}
+        selectedBlockId={selectedBlockId}
+        onBlockSelect={setSelectedBlockId}
         onConfigChange={handleConfigChange}
         onDeleteBlock={handleDeleteBlock}
         onCreateField={handleCreateField}
@@ -369,26 +384,36 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
     </div>
   );
 
-  const detailPreview = (
+  const unifiedPreview = (
     <div className="bg-gray-100 rounded-xl p-3">
-      <div className="bg-white rounded-xl shadow-lg p-4 max-h-[70vh] overflow-y-auto">
-        <div className="flex items-center gap-2 mb-3">
-          <span className="text-xl">{itemType.icon}</span>
-          <h2 className="font-heading font-semibold text-forest-dark text-xl">{mockItem.name}</h2>
+      <div className="bg-white rounded-t-2xl shadow-lg">
+        {/* Handle */}
+        <div className="flex justify-center py-3">
+          <div className="w-10 h-1 rounded-full bg-gray-300" />
         </div>
-        <LayoutRenderer
-          layout={layout}
-          item={mockItem}
-          mode="preview"
-          context="preview"
-          customFields={allFields}
-        />
+
+        <div className="px-4 pb-4 max-h-[70vh] overflow-y-auto">
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-xl">{itemType.icon}</span>
+            <h2 className="font-heading font-semibold text-forest-dark text-xl">
+              {mockItem.name}
+            </h2>
+          </div>
+
+          {/* Layout content */}
+          <LayoutRenderer
+            layout={layout}
+            item={mockItem}
+            mode={rightPanelMode}
+            context="preview"
+            customFields={allFields}
+            selectedBlockId={selectedBlockId ?? undefined}
+            onBlockSelect={handleBlockSelectFromPreview}
+          />
+        </div>
       </div>
     </div>
-  );
-
-  const formPreviewContent = (
-    <FormPreview layout={layout} customFields={allFields} itemTypeName={itemType.name} />
   );
 
   const dndWrapped = (content: React.ReactNode) => (
@@ -424,26 +449,34 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
           </button>
         </div>
 
+        {/* Tab toggle */}
         <div className="flex border-b border-sage-light">
-          {(['build', 'detail', 'form'] as const).map((tab) => (
+          {(['build', 'edit', 'preview'] as const).map((tab) => (
             <button
               key={tab}
-              onClick={() => setActiveTab(tab)}
+              onClick={() => {
+                setActiveTab(tab);
+                if (tab === 'edit') setRightPanelMode('edit');
+                if (tab === 'preview') {
+                  setRightPanelMode('preview');
+                  setSelectedBlockId(null);
+                }
+              }}
               className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
                 activeTab === tab
                   ? 'text-forest border-b-2 border-forest'
                   : 'text-sage'
               }`}
             >
-              {tab === 'build' ? 'Build' : tab === 'detail' ? 'Detail' : 'Form'}
+              {tab === 'build' ? 'Build' : tab === 'edit' ? 'Edit' : 'Preview'}
             </button>
           ))}
         </div>
 
+        {/* Tab content */}
         <div className="flex-1 overflow-y-auto p-4">
           {activeTab === 'build' && dndWrapped(buildContent)}
-          {activeTab === 'detail' && detailPreview}
-          {activeTab === 'form' && formPreviewContent}
+          {(activeTab === 'edit' || activeTab === 'preview') && unifiedPreview}
         </div>
       </div>
     );
@@ -464,21 +497,22 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
         {dndWrapped(buildContent)}
       </div>
 
+      {/* Preview panel */}
       <div className="flex-[2] overflow-y-auto">
         <div className="flex gap-1 mb-3">
-          {(['detail', 'form'] as const).map((tab) => (
+          {(['edit', 'preview'] as const).map((tab) => (
             <button
               key={tab}
-              onClick={() => setPreviewTab(tab)}
+              onClick={() => handleRightPanelModeChange(tab)}
               className={`px-3 py-1.5 rounded-md text-sm font-medium ${
-                previewTab === tab ? 'bg-forest text-white' : 'bg-sage-light text-forest-dark'
+                rightPanelMode === tab ? 'bg-forest text-white' : 'bg-sage-light text-forest-dark'
               }`}
             >
-              {tab === 'detail' ? 'Detail Preview' : 'Form Preview'}
+              {tab === 'edit' ? 'Edit' : 'Preview'}
             </button>
           ))}
         </div>
-        {previewTab === 'detail' ? detailPreview : formPreviewContent}
+        {unifiedPreview}
       </div>
     </div>
   );

--- a/src/components/layout/builder/LayoutBuilder.tsx
+++ b/src/components/layout/builder/LayoutBuilder.tsx
@@ -301,6 +301,7 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
   }, []);
 
   const handleDeleteBlock = useCallback((blockId: string) => {
+    setSelectedBlockId((prev) => prev === blockId ? null : prev);
     setLayout((prev) => ({
       ...prev,
       blocks: prev.blocks.filter((b) => b.id !== blockId),
@@ -341,6 +342,7 @@ export default function LayoutBuilder({ itemType, initialLayout, customFields, e
   }, []);
 
   const handleRemoveFromRow = useCallback((rowId: string, blockId: string) => {
+    setSelectedBlockId((prev) => prev === blockId ? null : prev);
     setLayout((prev) => ({
       ...prev,
       blocks: prev.blocks.flatMap((node) => {


### PR DESCRIPTION
## Summary

- **Unified layout**: Edit and Preview modes now render the same detail preview layout (bottom-sheet style card with icon, title, fields, same padding/background). The only differences are block selection highlighting (edit) vs interactive fields (preview).
- **Bidirectional block selection**: Clicking a block in the right preview panel highlights it and scrolls to its config in the left Build panel. Clicking a block in the Build panel highlights it in the preview.
- **Mobile UX**: Tapping a block in Edit mode switches to Build tab with that block's config expanded. Tabs changed from Build/Detail/Form to Build/Edit/Preview.

## Changes

- `LayoutRenderer` — new `'edit'` mode wraps blocks in clickable, highlightable `EditBlockWrapper` containers
- `BlockListItem` — `forwardRef` with merged sortable + external ref for scroll-to-selection
- `BlockList` — accepts `selectedBlockId`/`onBlockSelect` for bidirectional sync and scroll-to-selection
- `LayoutBuilder` — unified right panel replaces split Detail/Form preview; Edit/Preview toggle; `selectedBlockId` state lifted; cleared on block delete

## Test plan

- [ ] Verify type-check passes (`npm run type-check`)
- [ ] Verify all 1069 tests pass (`npm test -- --run`)
- [ ] Desktop: Edit/Preview toggle shows same layout, Edit highlights blocks on click, Preview removes highlights
- [ ] Desktop: Clicking a block in preview scrolls to and expands its config in the left Build panel
- [ ] Desktop: Clicking a block in Build panel highlights it in the preview
- [ ] Mobile: Build/Edit/Preview tabs work correctly
- [ ] Mobile: Tapping a block in Edit switches to Build tab with config expanded
- [ ] Switching to Preview mode clears all block selection
- [ ] Deleting a selected block clears the selection

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)