### PR TITLE
Fix: apply unified edit/preview to LayoutEditor

### DIFF
--- a/src/components/layout/builder/LayoutEditor.tsx
+++ b/src/components/layout/builder/LayoutEditor.tsx
@@ -40,7 +40,6 @@ import EditableLayoutRenderer from './EditableLayoutRenderer';
 import ConfigDrawer from './ConfigDrawer';
 import DragOverlayContent from './DragOverlayContent';
 import LayoutRendererDispatch from '../LayoutRendererDispatch';
-import FormPreview from '../preview/FormPreview';
 import { rowAwareCollision } from './collision';
 
 interface Props {
@@ -52,7 +51,6 @@ interface Props {
   onCancel: () => void;
 }
 
-type PreviewTab = 'detail' | 'form';
 
 function getDefaultConfig(type: BlockTypeV2): BlockConfigV2 {
   switch (type) {
@@ -110,9 +108,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
   const [pendingFields, setPendingFields] = useState<{ name: string; field_type: string; options: string[]; required: boolean; tempId: string }[]>([]);
   const [saving, setSaving] = useState(false);
   const [isEditing, setIsEditing] = useState(true);
-  const [previewTab, setPreviewTab] = useState<PreviewTab>('detail');
   const [isMobile, setIsMobile] = useState(false);
-  const [mobileTab, setMobileTab] = useState<PreviewTab>('detail');
 
   // DnD overlay state
   const [activeNode, setActiveNode] = useState<LayoutNodeV2 | null>(null);
@@ -629,7 +625,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
         Edit
       </button>
       <button
-        onClick={() => setIsEditing(false)}
+        onClick={() => { setIsEditing(false); setSelectedBlockId(null); }}
         className={`px-3 py-1.5 font-medium transition-colors ${!isEditing ? 'bg-forest text-white' : 'bg-white text-forest-dark hover:bg-sage-light/50'}`}
       >
         Preview
@@ -637,45 +633,31 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
     </div>
   );
 
-  const detailPreview = (
+  const previewView = (
     <div className="bg-gray-100 rounded-xl p-3">
-      <div className="bg-white rounded-xl shadow-lg p-4 max-h-[70vh] overflow-y-auto">
-        <div className="flex items-center gap-2 mb-3">
-          <span className="text-xl">{itemType.icon}</span>
-          <h2 className="font-heading font-semibold text-forest-dark text-xl">{mockItem.name}</h2>
+      <div className="bg-white rounded-t-2xl shadow-lg">
+        {/* Handle */}
+        <div className="flex justify-center py-3">
+          <div className="w-10 h-1 rounded-full bg-gray-300" />
         </div>
-        <LayoutRendererDispatch
-          layout={layout}
-          item={mockItem}
-          mode="preview"
-          context="preview"
-          customFields={allFields}
-        />
+
+        <div className="px-4 pb-4 max-h-[70vh] overflow-y-auto">
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-xl">{itemType.icon}</span>
+            <h2 className="font-heading font-semibold text-forest-dark text-xl">{mockItem.name}</h2>
+          </div>
+          <LayoutRendererDispatch
+            layout={layout}
+            item={mockItem}
+            mode="preview"
+            context="preview"
+            customFields={allFields}
+          />
+        </div>
       </div>
     </div>
   );
-
-  const formPreviewContent = (
-    <FormPreview layout={layout} customFields={allFields} itemTypeName={itemType.name} />
-  );
-
-  const previewTabBar = (
-    <div className="flex gap-1">
-      {(['detail', 'form'] as const).map((tab) => (
-        <button
-          key={tab}
-          onClick={() => setPreviewTab(tab)}
-          className={`px-3 py-1.5 rounded-md text-sm font-medium ${
-            previewTab === tab ? 'bg-forest text-white' : 'bg-sage-light text-forest-dark'
-          }`}
-        >
-          {tab === 'detail' ? 'Detail' : 'Form'}
-        </button>
-      ))}
-    </div>
-  );
-
-  const previewContent = previewTab === 'detail' ? detailPreview : formPreviewContent;
 
   // Config drawer (shown on top of everything on desktop, inline on mobile)
   const configDrawerProps = {
@@ -723,23 +705,6 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
             </div>
           </div>
 
-          {/* Mobile tab bar (detail / form) */}
-          <div className="flex border-b border-sage-light flex-shrink-0">
-            {(['detail', 'form'] as const).map((tab) => (
-              <button
-                key={tab}
-                onClick={() => setMobileTab(tab)}
-                className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
-                  mobileTab === tab
-                    ? 'text-forest border-b-2 border-forest'
-                    : 'text-sage'
-                }`}
-              >
-                {tab === 'detail' ? 'Detail' : 'Form'}
-              </button>
-            ))}
-          </div>
-
           {/* Scrollable content */}
           <div className="flex-1 overflow-y-auto p-4">
             {isEditing ? (
@@ -752,7 +717,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
                 onSelect={handleSelectBlock}
               />
             ) : (
-              mobileTab === 'detail' ? detailPreview : formPreviewContent
+              previewView
             )}
           </div>
 
@@ -822,7 +787,6 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
               <SpacingPicker value={layout.spacing} onChange={handleSpacingChange} />
             </div>
           )}
-          {!isEditing && previewTabBar}
         </div>
 
         {/* Desktop content area */}
@@ -851,12 +815,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
                   onSelect={handleSelectBlock}
                 />
               ) : (
-                <>
-                  {!isEditing && (
-                    <div className="mb-3">{previewTabBar}</div>
-                  )}
-                  {previewContent}
-                </>
+                previewView
               )}
             </div>
           </div>

--- a/src/components/layout/builder/__tests__/LayoutEditor.test.tsx
+++ b/src/components/layout/builder/__tests__/LayoutEditor.test.tsx
@@ -70,12 +70,12 @@ describe('LayoutEditor', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
-  it('shows detail/form preview tabs in preview mode', () => {
+  it('shows unified preview layout in preview mode (no detail/form tabs)', () => {
     render(<LayoutEditor {...defaultProps} />);
-    // Preview tab bar only appears when switching to preview mode
     fireEvent.click(screen.getByText('Preview'));
-    expect(screen.getAllByText('Detail').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Form').length).toBeGreaterThan(0);
+    // Should not show Detail/Form tab bar — unified preview only
+    expect(screen.queryByText('Detail')).not.toBeInTheDocument();
+    expect(screen.queryByText('Form')).not.toBeInTheDocument();
   });
 
   it('shows component sidebar in edit mode', () => {


### PR DESCRIPTION
## Summary

- PR #249 modified `LayoutBuilder.tsx`, but the app routes actually import `LayoutEditor.tsx` — so the changes were invisible
- This applies the same unification to `LayoutEditor.tsx`: removes Detail/Form preview tab split, preview mode now renders the same bottom-sheet layout as edit mode
- Clears block selection when switching to preview
- Removes unused `FormPreview` import, `PreviewTab` type, and `mobileTab` state

## Test plan

- [ ] Type-check passes
- [ ] All 1069 tests pass
- [ ] Toggle Edit/Preview — both show same layout (bottom-sheet style with handle bar, icon + title)
- [ ] No Detail/Form tab bar visible in preview mode
- [ ] Block selection clears when switching to Preview

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)