### PR TITLE
fix: palette drag-and-drop broken on desktop

### DIFF
--- a/src/components/layout/builder/DragOverlayContent.tsx
+++ b/src/components/layout/builder/DragOverlayContent.tsx
@@ -2,18 +2,33 @@
 
 import { useMemo } from 'react';
 import type { LayoutNode, TypeLayout } from '@/lib/layout/types';
-import type { LayoutNodeV2, TypeLayoutV2 } from '@/lib/layout/types-v2';
+import type { LayoutNodeV2, TypeLayoutV2, BlockTypeV2 } from '@/lib/layout/types-v2';
+import { isLayoutRowV2 } from '@/lib/layout/types-v2';
 import type { CustomField, ItemWithDetails } from '@/lib/types';
 import LayoutRendererDispatch from '../LayoutRendererDispatch';
+
+const BLOCK_LABELS: Record<BlockTypeV2, { icon: string; label: string }> = {
+  field_display: { icon: '📊', label: 'Field' },
+  photo_gallery: { icon: '📷', label: 'Photo' },
+  status_badge: { icon: '🏷', label: 'Status' },
+  entity_list: { icon: '🔗', label: 'Entities' },
+  timeline: { icon: '📋', label: 'Timeline' },
+  text_label: { icon: '✏️', label: 'Text' },
+  description: { icon: '📝', label: 'Description' },
+  divider: { icon: '➖', label: 'Divider' },
+  map_snippet: { icon: '📍', label: 'Map' },
+  action_buttons: { icon: '🔘', label: 'Actions' },
+};
 
 interface Props {
   node: LayoutNode | LayoutNodeV2;
   customFields: CustomField[];
   mockItem: ItemWithDetails;
   version?: 1 | 2;
+  isFromPalette?: boolean;
 }
 
-export default function DragOverlayContent({ node, customFields, mockItem, version = 1 }: Props) {
+export default function DragOverlayContent({ node, customFields, mockItem, version = 1, isFromPalette = false }: Props) {
   const overlayLayout = useMemo<TypeLayout | TypeLayoutV2>(() => {
     if (version === 2) {
       return {
@@ -30,6 +45,22 @@ export default function DragOverlayContent({ node, customFields, mockItem, versi
       peekBlockCount: 1,
     };
   }, [node, version]);
+
+  // For palette items, show a chip-style preview instead of rendering the
+  // (often empty) block content
+  if (isFromPalette && !isLayoutRowV2(node as LayoutNodeV2)) {
+    const blockType = (node as LayoutNodeV2).type as BlockTypeV2;
+    const meta = BLOCK_LABELS[blockType];
+    return (
+      <div
+        style={{ opacity: 0.85, pointerEvents: 'none' }}
+        className="flex items-center gap-2 rounded-lg border border-sage-light bg-white px-4 py-3 shadow-lg text-sm font-medium text-forest-dark"
+      >
+        <span>{meta?.icon ?? '📦'}</span>
+        <span>{meta?.label ?? blockType}</span>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/layout/builder/LayoutEditor.tsx
+++ b/src/components/layout/builder/LayoutEditor.tsx
@@ -113,6 +113,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
   // DnD overlay state
   const [activeNode, setActiveNode] = useState<LayoutNodeV2 | null>(null);
   const [activeType, setActiveType] = useState<'block' | 'row' | null>(null);
+  const [isFromPalette, setIsFromPalette] = useState(false);
   const isDragActive = activeNode !== null;
 
   // Block selection / config drawer
@@ -200,8 +201,8 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
   }, [layout.blocks]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { delay: 300, tolerance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 300, tolerance: 5 } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
@@ -233,6 +234,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
       const tempNode: LayoutNodeV2 = createBlock(paletteType);
       setActiveNode(tempNode);
       setActiveType('block');
+      setIsFromPalette(true);
       return;
     }
 
@@ -446,6 +448,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
     const { active, over } = event;
     setActiveNode(null);
     setActiveType(null);
+    setIsFromPalette(false);
 
     if (!over) return;
 
@@ -748,6 +751,7 @@ export default function LayoutEditor({ itemType, initialLayout, customFields, en
               customFields={allFields}
               mockItem={mockItem}
               version={2}
+              isFromPalette={isFromPalette}
             />
           ) : null}
         </DragOverlay>


### PR DESCRIPTION
## Summary

- **Root cause:** `PointerSensor` used `{ delay: 300, tolerance: 5 }` (designed for touch long-press) which prevented desktop mouse drags from activating — users naturally move >5px within 300ms when starting a drag
- Switch `PointerSensor` to `{ distance: 8 }` so click-to-select vs click-and-drag are properly distinguished on desktop
- Keep `TouchSensor` with delay-based activation (250ms) for mobile long-press
- Show chip-style drag preview (icon + label) for palette items instead of rendering empty block content in the `DragOverlay`

## Test plan

- [ ] Desktop: drag a component from the sidebar — drag should activate after ~8px of mouse movement with a labeled preview following the cursor
- [ ] Desktop: drop onto the layout — block should appear at the drop position
- [ ] Desktop: click (don't drag) an existing block — should select it and open ConfigDrawer, not start a drag
- [ ] Mobile: long-press a block to drag — should still require ~250ms hold before activating
- [ ] Mobile: tap a palette chip — should quick-add the component (no drag needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)