### PR TITLE
fix: add missing /org/entities route causing 404 on Manage

### DIFF
--- a/src/app/org/entities/[entityTypeId]/page.tsx
+++ b/src/app/org/entities/[entityTypeId]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/app/admin/properties/[slug]/entities/[entityTypeId]/page';


### PR DESCRIPTION
## Summary

- Clicking "Manage" on an entity type at `/org/entity-types` navigates to `/org/entities/{entityTypeId}`, which returned a 404 because the route didn't exist
- Added `src/app/org/entities/[entityTypeId]/page.tsx` as a re-export of the canonical admin page, matching the pattern used by `/org/entity-types` and `/p/[slug]/admin/entities/[entityTypeId]`

## Root cause

The "Manage" link in `EntityTypesPage` uses a relative href (`entities/${et.id}`). When rendered at `/org/entity-types`, this resolves to `/org/entities/{id}` — but only the property-scoped route (`/p/[slug]/admin/entities/[entityTypeId]`) existed.

## Test plan

- [ ] Navigate to `/org/entity-types`, create or find an entity type, click "Manage" — should load the entity management page instead of 404
- [ ] Verify entity CRUD (add, edit, delete) works on the new route
- [ ] Confirm `/p/[slug]/admin/entities/[entityTypeId]` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)