### PR TITLE
fix: handle legacy string icons in cached item_types / entity_types

### DIFF
--- a/src/components/shared/IconPicker/IconPicker.tsx
+++ b/src/components/shared/IconPicker/IconPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { IconValue } from '@/lib/types';
+import { normalizeIcon } from '@/lib/types';
 import { IconRenderer } from './IconRenderer';
 import { searchIcons, getLucideIcons, getHeroicons, getEmojis, type IconEntry } from './icon-catalog';
 import { getAllEmojis } from './emoji-catalog';
@@ -79,10 +80,11 @@ export function IconPicker({ value, onChange, className }: IconPickerProps) {
     setQuery('');
   }
 
-  const displayName = value
-    ? value.set === 'emoji'
-      ? emojiDisplayName(value.name)
-      : value.name.replace(/([A-Z])/g, ' $1').trim()
+  const normalizedValue = normalizeIcon(value);
+  const displayName = normalizedValue
+    ? normalizedValue.set === 'emoji'
+      ? emojiDisplayName(normalizedValue.name)
+      : normalizedValue.name.replace(/([A-Z])/g, ' $1').trim()
     : null;
 
   return (
@@ -93,17 +95,17 @@ export function IconPicker({ value, onChange, className }: IconPickerProps) {
           onClick={() => setIsOpen(!isOpen)}
           className="flex items-center gap-2 input-field text-sm w-full text-left"
         >
-          {value ? (
+          {normalizedValue ? (
             <>
-              <IconRenderer icon={value} size={18} />
+              <IconRenderer icon={normalizedValue} size={18} />
               <span className="text-forest-dark">{displayName}</span>
-              <span className="text-sage text-xs ml-auto">{value.set}</span>
+              <span className="text-sage text-xs ml-auto">{normalizedValue.set}</span>
             </>
           ) : (
             <span className="text-sage">No icon</span>
           )}
         </button>
-        {value && (
+        {normalizedValue && (
           <button
             type="button"
             onClick={() => onChange(undefined)}

--- a/src/components/shared/IconPicker/IconRenderer.tsx
+++ b/src/components/shared/IconPicker/IconRenderer.tsx
@@ -2,19 +2,21 @@
 
 import { useState, useEffect } from 'react';
 import type { IconValue } from '@/lib/types';
+import { normalizeIcon } from '@/lib/types';
 import type { ComponentType, SVGProps } from 'react';
 
 interface IconRendererProps {
-  icon: IconValue | undefined;
+  icon: IconValue | string | null | undefined;
   size?: number;
   className?: string;
 }
 
 export function IconRenderer({ icon, size = 20, className }: IconRendererProps) {
+  const normalized = normalizeIcon(icon);
   const [IconComponent, setIconComponent] = useState<ComponentType<SVGProps<SVGSVGElement>> | null>(null);
 
   useEffect(() => {
-    if (!icon || icon.set === 'emoji') {
+    if (!normalized || normalized.set === 'emoji') {
       setIconComponent(null);
       return;
     }
@@ -25,17 +27,17 @@ export function IconRenderer({ icon, size = 20, className }: IconRendererProps) 
       try {
         let Component: ComponentType<SVGProps<SVGSVGElement>> | undefined;
 
-        if (icon!.set === 'lucide') {
+        if (normalized!.set === 'lucide') {
           const mod = await import('lucide-react');
-          Component = (mod.icons as Record<string, ComponentType<any>>)[icon!.name];
-        } else if (icon!.set === 'heroicons') {
-          const style = icon!.style || 'outline';
+          Component = (mod.icons as Record<string, ComponentType<any>>)[normalized!.name];
+        } else if (normalized!.set === 'heroicons') {
+          const style = normalized!.style || 'outline';
           if (style === 'solid') {
             const mod = await import('@heroicons/react/24/solid');
-            Component = (mod as unknown as Record<string, ComponentType<any>>)[`${icon!.name}Icon`];
+            Component = (mod as unknown as Record<string, ComponentType<any>>)[`${normalized!.name}Icon`];
           } else {
             const mod = await import('@heroicons/react/24/outline');
-            Component = (mod as unknown as Record<string, ComponentType<any>>)[`${icon!.name}Icon`];
+            Component = (mod as unknown as Record<string, ComponentType<any>>)[`${normalized!.name}Icon`];
           }
         }
 
@@ -49,14 +51,14 @@ export function IconRenderer({ icon, size = 20, className }: IconRendererProps) 
 
     load();
     return () => { cancelled = true; };
-  }, [icon?.set, icon?.name, icon?.style]);
+  }, [normalized?.set, normalized?.name, normalized?.style]);
 
-  if (!icon) return null;
+  if (!normalized) return null;
 
-  if (icon.set === 'emoji') {
+  if (normalized.set === 'emoji') {
     return (
       <span style={{ fontSize: `${size}px`, lineHeight: 1 }} className={className}>
-        {icon.name}
+        {normalized.name}
       </span>
     );
   }
@@ -70,26 +72,28 @@ export function IconRenderer({ icon, size = 20, className }: IconRendererProps) 
  * Returns an HTML string for an icon. Used by Leaflet DivIcon markers
  * and other contexts that need raw HTML instead of React components.
  */
-export async function iconToHtml(icon: IconValue, size: number): Promise<string> {
-  if (icon.set === 'emoji') {
-    return icon.name;
+export async function iconToHtml(icon: IconValue | string | null | undefined, size: number): Promise<string> {
+  const normalized = normalizeIcon(icon);
+  if (!normalized) return '';
+  if (normalized.set === 'emoji') {
+    return normalized.name;
   }
 
   // For SVG icons, dynamically import and render to string
   const { renderToStaticMarkup } = await import('react-dom/server');
 
-  if (icon.set === 'lucide') {
+  if (normalized.set === 'lucide') {
     const mod = await import('lucide-react');
-    const Component = (mod.icons as Record<string, ComponentType<any>>)[icon.name];
+    const Component = (mod.icons as Record<string, ComponentType<any>>)[normalized.name];
     if (Component) {
       return renderToStaticMarkup(<Component width={size} height={size} />);
     }
-  } else if (icon.set === 'heroicons') {
-    const style = icon.style || 'outline';
+  } else if (normalized.set === 'heroicons') {
+    const style = normalized.style || 'outline';
     const mod = style === 'solid'
       ? await import('@heroicons/react/24/solid')
       : await import('@heroicons/react/24/outline');
-    const Component = (mod as unknown as Record<string, ComponentType<any>>)[`${icon.name}Icon`];
+    const Component = (mod as unknown as Record<string, ComponentType<any>>)[`${normalized.name}Icon`];
     if (Component) {
       return renderToStaticMarkup(<Component width={size} height={size} />);
     }

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -5,6 +5,7 @@ import type {
   EntityType, EntityTypeField, Entity, ItemEntity, UpdateEntity,
   EntityFieldType, EntityLinkTarget,
 } from '../types';
+import { iconDisplayName, normalizeIcon } from '../types';
 
 describe('Item type structure', () => {
   it('accepts a valid Item object', () => {
@@ -359,5 +360,47 @@ describe('ItemWithDetails with entities', () => {
     expect(detailed.entities[0].name).toBe('Chickadee');
     expect(detailed.entities[0].entity_type.name).toBe('Species');
     expect(detailed.updates[0].entities).toHaveLength(1);
+  });
+});
+
+describe('normalizeIcon', () => {
+  it('passes a valid IconValue object through unchanged', () => {
+    const icon = { set: 'lucide' as const, name: 'Home' };
+    expect(normalizeIcon(icon)).toEqual(icon);
+  });
+
+  it('wraps a legacy string into an emoji IconValue', () => {
+    expect(normalizeIcon('📍')).toEqual({ set: 'emoji', name: '📍' });
+  });
+
+  it('trims whitespace around legacy string icons', () => {
+    expect(normalizeIcon('👀 ')).toEqual({ set: 'emoji', name: '👀' });
+  });
+
+  it('returns null for empty string, whitespace, null, or undefined', () => {
+    expect(normalizeIcon('')).toBeNull();
+    expect(normalizeIcon('   ')).toBeNull();
+    expect(normalizeIcon(null)).toBeNull();
+    expect(normalizeIcon(undefined)).toBeNull();
+  });
+});
+
+describe('iconDisplayName', () => {
+  it('returns the emoji character for emoji IconValues', () => {
+    expect(iconDisplayName({ set: 'emoji', name: '📍' })).toBe('📍');
+  });
+
+  it('formats PascalCase lucide names with spaces', () => {
+    expect(iconDisplayName({ set: 'lucide', name: 'HomeHeart' })).toBe('Home Heart');
+  });
+
+  it('handles legacy string icons without crashing (pre-migration 044 cache)', () => {
+    expect(iconDisplayName('📍')).toBe('📍');
+    expect(iconDisplayName('👀 ')).toBe('👀');
+  });
+
+  it('returns empty string for nullish inputs', () => {
+    expect(iconDisplayName(null)).toBe('');
+    expect(iconDisplayName(undefined)).toBe('');
   });
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -438,9 +438,31 @@ export interface ItemWithDetails extends Item {
  * For emoji icons, returns the emoji character.
  * For library icons, returns the icon name in a readable format.
  */
-export function iconDisplayName(icon: IconValue): string {
-  if (icon.set === 'emoji') return icon.name;
-  return icon.name.replace(/([A-Z])/g, ' $1').trim();
+export function iconDisplayName(icon: IconValue | string | null | undefined): string {
+  const normalized = normalizeIcon(icon);
+  if (!normalized) return '';
+  if (normalized.set === 'emoji') return normalized.name;
+  return normalized.name.replace(/([A-Z])/g, ' $1').trim();
+}
+
+/**
+ * Coerces a legacy string icon (pre-migration 044) to an IconValue object.
+ * Migration 044 changed item_types.icon and entity_types.icon from text to jsonb,
+ * but `ALTER COLUMN TYPE` doesn't bump `updated_at`, so clients whose IndexedDB
+ * cache synced before the migration still hold plain strings. All display code
+ * should route icon values through this normalizer.
+ */
+export function normalizeIcon(icon: IconValue | string | null | undefined): IconValue | null {
+  if (icon == null) return null;
+  if (typeof icon === 'string') {
+    const trimmed = icon.trim();
+    if (trimmed.length === 0) return null;
+    return { set: 'emoji', name: trimmed };
+  }
+  if (typeof icon === 'object' && typeof icon.set === 'string' && typeof icon.name === 'string') {
+    return icon;
+  }
+  return null;
 }
 
 // ======================


### PR DESCRIPTION
## Summary

Users hit `TypeError: Cannot read properties of undefined (reading 'replace')` on pages that render entity types or item types (most visibly `/p/<slug>/edit/<id>`). Root cause: migration `044_icon_jsonb.sql` used `ALTER COLUMN TYPE` to convert `item_types.icon` and `entity_types.icon` from text to jsonb. That's a schema-level conversion and does **not** bump `updated_at` on the rows, so clients whose IndexedDB cache synced before the migration still hold legacy plain-string values (e.g. `"📍"`). Display code like `iconDisplayName` and `IconPicker` then tries `icon.name.replace(...)` on a string and crashes.

This PR makes every icon-consuming display path defensive:

- New `normalizeIcon(icon: IconValue | string | null | undefined): IconValue | null` in `src/lib/types.ts` — coerces legacy strings to `{ set: 'emoji', name: <string> }` and passes valid IconValue objects through unchanged.
- `iconDisplayName`, `IconRenderer`, `iconToHtml`, and `IconPicker` all route incoming icon values through the normalizer before using them.
- 8 new unit tests lock in legacy-string coercion, trimming, nullish handling, and IconValue pass-through.

Not bug-fixing this is not an option — it blocks the edit-item page entirely for any user whose cache predates the icon migration.

## Why the cache stayed stale
Client sync uses `updated_at > last_sync_cursor` to decide which rows to re-download. `ALTER COLUMN TYPE` rewrites the column representation without touching `updated_at`, so no rows look "new" to the client. A follow-up DB migration that does `UPDATE item_types SET updated_at = now()` (and same for `entity_types`) would force a full re-sync — worth doing, but a separate concern: the defensive normalizer fixes the crash regardless of cache state.

## Test plan

- [ ] `npm run type-check` — passes
- [ ] `npm run test` — 1186 tests pass (8 new)
- [ ] Load `/p/<slug>/edit/<some-item-id>` against a stale IndexedDB (or simulate by seeding an `item_types` row with a string `icon`) — page renders without crashing; legacy string icon shows as its emoji character

🤖 Generated with [Claude Code](https://claude.com/claude-code)