### PR TITLE
docs: offline cache schema-change checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,10 @@
 - [ ] Type check passes (`npm run type-check`)
 - [ ] E2E tests pass (if applicable)
 
+## Cache safety
+
+- [ ] This PR does not add a SQL migration, OR the migration follows `docs/playbooks/offline-cache-schema-changes.md`.
+
 ## Memory & Decision Tracking
 
 - [ ] Does this change introduce a lasting technical decision? If yes, create or update an ADR in `docs/adr/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ These are non-negotiable. Do not deviate without an ADR (see below).
 | Server mutations | Server actions (`'use server'`) returning `{ success: true }` or `{ error: string }` |
 | Server Supabase | `createClient()` from `@/lib/supabase/server` (synchronous) |
 | Client Supabase | `createClient()` from `@/lib/supabase/client` (synchronous) |
+| Offline cache safety | Any SQL migration that touches a table in `SYNC_TABLES` (see `src/lib/offline/sync-engine.ts`) must follow `docs/playbooks/offline-cache-schema-changes.md`. When in doubt, `update <table> set updated_at = now();` in the same migration. |
 
 ## Coding and Change Discipline
 

--- a/docs/adr/0002-offline-cache-drift-prevention.md
+++ b/docs/adr/0002-offline-cache-drift-prevention.md
@@ -1,0 +1,98 @@
+# ADR-0002: Offline Cache Drift Prevention
+
+**Status:** Accepted
+
+**Date:** 2026-04-17
+
+**Owners:** @patjackson52
+
+## Context
+
+FieldMapper is an offline-first PWA. The client keeps a local IndexedDB copy of every synced row (items, item_types, entities, entity_types, and so on — see `SYNC_TABLES` in `src/lib/offline/sync-engine.ts`). Delta sync refreshes that copy with a per-table cursor: "give me every row where `updated_at` (or `created_at` for some tables) is newer than my last sync."
+
+Schema-level changes like `ALTER COLUMN TYPE`, adding a column with a server-side default, or removing a column do NOT bump row-level timestamps. The delta cursor sees nothing new, the cache keeps the old row representation, and code compiled against the new TypeScript shape crashes on the stale data.
+
+Real incident: migration `044_icon_jsonb.sql` converted `item_types.icon` and `entity_types.icon` from `text` to `jsonb` via `ALTER COLUMN TYPE`. Clients whose caches synced before the migration kept plain-string icons (`"📍"`). The new display code assumed `{set, name}` objects and crashed with `Cannot read properties of undefined (reading 'replace')` on the `/p/<slug>/edit/<id>` page. The runtime hotfix (PR #260, `normalizeIcon`) masks the symptom but leaves the class of bug latent for every future schema change.
+
+The sync engine actually uses three strategies and the right remedy for a schema change depends on which class the affected table is in:
+
+- **Class A** (8 tables, `TABLES_WITH_UPDATED_AT`): `updated_at` delta sync, trigger-backed.
+- **Class B** (3 tables): `created_at` delta sync, no `updated_at`.
+- **Class C** (3 tables, `TABLES_WITHOUT_TIMESTAMPS`): full sync every time.
+
+This asymmetry is easy to miss and was itself a factor in the icon bug: any single uniform prescription ("always bump updated_at") is wrong for Class B and irrelevant for Class C.
+
+## Decision
+
+Ship a **process-only defense** as the first layer:
+
+1. A canonical playbook at `docs/playbooks/offline-cache-schema-changes.md` that explains the failure mode, documents the Class A/B/C taxonomy, and prescribes class-aware remedies for five change types (column type change, added column with default, rename/remove, new synced table, enum narrowing).
+2. A new row in the Architectural Invariants table in `AGENTS.md` that points migration authors at the playbook. Agents read AGENTS.md at session start, so this catches agent-written migrations.
+3. A `## Cache safety` checkbox in `.github/pull_request_template.md` that surfaces the check at review time, catching human-written migrations.
+
+No code changes. No runtime cost. One extra line per schema-changing migration (`update <table> set updated_at = now();` for Class A tables; alternate remedies for B and C).
+
+Runtime validators and schema fingerprints — the more robust but more expensive defenses — are deferred unless the process layer proves insufficient. Revisit if two or more migrations ship without the checklist being applied.
+
+## Alternatives Considered
+
+- **Runtime validators at the IndexedDB read boundary** (Zod or handwritten schemas for each of the ~17 cached tables, validating rows on every read). Catches drift after it ships; gives a hook to trigger cursor invalidation or telemetry. Rejected for now: ~4–8 hours of setup, ~200–400 lines of validator code, redundant with TypeScript interfaces unless we generate the types from the validators (a bigger rewrite), ~5–50 ms per 1000-row read synchronously, ~15 kB bundle for Zod (or ~3 kB for Valibot, or 0 kB for handwritten). Addresses the same bug class the playbook addresses — just at a different layer — and does not prevent cursor-stuck bugs without also being paired with cursor invalidation.
+
+- **Schema fingerprint in `sync_metadata`** (each table row tagged with a schema version; mismatch invalidates the cursor and forces a full re-fetch). More direct at the root cause than validators — automatic recovery with no per-row cost at read time. Rejected for now: requires server-side cooperation to expose a per-table schema version, adds a new column to `sync_metadata`, forces a full table refetch on every schema change (bandwidth cost). Higher leverage than validators but also higher setup cost and coordination burden.
+
+- **A one-time migration to bump `updated_at` on every currently-affected synced table.** Would force all existing stale caches to repair themselves on the next sync, which is tempting. Rejected for now: the `normalizeIcon` hotfix (PR #260) already masks the only known stale-shape case, and running a blanket `UPDATE` across all rows on all eight Class A tables is a non-trivial production write. Tracked as a potential follow-up if another stale-shape case surfaces before this playbook catches on.
+
+## Decision Drivers
+
+- **Cost tolerance.** The team is small. The playbook ships in an afternoon; validators or fingerprints are weeks. Start with the cheapest layer that could work.
+- **Bug frequency.** Only one production incident of this class has been observed (the icon crash). The frequency doesn't yet justify a heavy runtime defense.
+- **Discoverability at the right moment.** The failure mode is trapped in migration-authoring, not at runtime — which is exactly where AGENTS.md and the PR template are read.
+- **Observability over silence.** If the process layer fails, we will see it as another runtime crash. That's a clear signal to escalate to a runtime defense.
+
+## Consequences
+
+**Positive:**
+- Zero runtime cost, zero bundle size impact, zero new dependencies.
+- One canonical place (`docs/playbooks/offline-cache-schema-changes.md`) to look up what to do, plus two entry points (AGENTS.md invariant row, PR template checkbox) at the moments authoring and reviewing actually happen.
+- Class A/B/C taxonomy forces authors to consult `src/lib/offline/sync-engine.ts` and understand their table's sync mode, reducing silent assumptions.
+
+**Negative:**
+- Relies on discipline. An author who ignores the AGENTS.md row and unchecks the PR template checkbox without actually reading the playbook can still ship a broken migration.
+- Does not auto-recover from past drift. Users whose caches predate migration 044 will still hit the stale-string icon path until `normalizeIcon` is there to catch it.
+- Not enforceable by CI in this iteration. A migration author can bypass the check and the PR will still merge.
+
+**Neutral:**
+- Authors working on non-synced tables (e.g., `invites`, `communications_*`) now have one more checkbox to tick, though the playbook's "None of the above?" section makes the trivial case explicit.
+- The playbook duplicates the `SYNC_TABLES` list in prose. The source of truth is the code constant; the playbook is a mirror that can drift if the constant changes. Mitigated by a note in the playbook directing readers back to the source file.
+
+## Escalation criteria
+
+Revisit this decision if any of the following occur:
+
+1. Two or more SQL migrations ship that should have followed the playbook but didn't.
+2. A second production incident in the same bug class (schema drift → cache crash) happens after this playbook lands.
+3. Schema-change velocity grows to the point where the checklist is consulted multiple times per week.
+
+Likely next step if escalated: a GitHub Action that greps migration diffs for `ALTER COLUMN` without a matching `UPDATE ... set updated_at` (the cheapest form of enforcement). If that's still not enough, move on to runtime validators or schema fingerprints.
+
+## Related Files
+
+- `docs/playbooks/offline-cache-schema-changes.md`
+- `AGENTS.md` (Architectural Invariants table)
+- `.github/pull_request_template.md`
+- `src/lib/offline/sync-engine.ts` (`SYNC_TABLES`, `TABLES_WITH_UPDATED_AT`, `TABLES_WITHOUT_TIMESTAMPS`)
+- `src/lib/offline/db.ts` (Dexie schema versions)
+- `supabase/migrations/044_icon_jsonb.sql` (motivating incident)
+- `src/lib/types.ts` (`normalizeIcon`, the runtime masking of the 044 incident)
+- `docs/superpowers/specs/2026-04-17-offline-cache-schema-checklist-design.md`
+- `docs/superpowers/plans/2026-04-17-offline-cache-schema-checklist.md`
+
+## Related Issues / PRs
+
+- #259 — Species picker iNaturalist integration (merged; unrelated but surfaced the 044 bug when the user interacted with the edit-item page).
+- #260 — `normalizeIcon` runtime hotfix for the 044 stale-cache icon crash (merged).
+- #261 — This PR, introducing the playbook, AGENTS.md row, and PR template checkbox.
+
+## Tags
+
+`offline`, `indexeddb`, `sync`, `migrations`, `process`

--- a/docs/playbooks/offline-cache-schema-changes.md
+++ b/docs/playbooks/offline-cache-schema-changes.md
@@ -12,6 +12,8 @@ The client keeps a local IndexedDB copy of every synced row. Delta sync refreshe
 
 Real example: migration `044_icon_jsonb.sql` converted `item_types.icon` and `entity_types.icon` from `text` to `jsonb` via `ALTER COLUMN TYPE`. Clients whose caches synced before the migration kept plain-string icons (`"📍"`). Display code assumed the new `{set, name}` object shape and crashed with `Cannot read properties of undefined (reading 'replace')` on the edit-item page.
 
+What migration 044 should have done additionally: `update item_types set updated_at = now();` and `update entity_types set updated_at = now();` in the same migration. Rule 1 below codifies this.
+
 ## 2. When this applies
 
 Synced tables (as of this writing — re-check `SYNC_TABLES` in `src/lib/offline/sync-engine.ts` for the authoritative list):
@@ -23,6 +25,18 @@ properties, orgs, roles, org_memberships
 ```
 
 Changes to tables NOT in that list cannot drift client caches because they are never cached. Examples out of scope: `invites`, `communications_*`, `location_history`, `mutation_queue` internals.
+
+### Sync mode per table
+
+The sync engine uses three strategies, and the right remedy depends on which class your table is in. Consult `TABLES_WITH_UPDATED_AT` and `TABLES_WITHOUT_TIMESTAMPS` in `src/lib/offline/sync-engine.ts` for the authoritative split.
+
+| Class | Sync strategy | Tables (as of this writing) | Matters for this playbook? |
+|---|---|---|---|
+| **A** | Delta sync on `updated_at` (trigger-backed) | `items`, `item_types`, `entities`, `entity_types`, `properties`, `orgs`, `roles`, `org_memberships` | Yes — the main audience of the checklist. |
+| **B** | Delta sync on `created_at` (append-mostly tables) | `item_updates`, `photos`, `geo_layers` | Sometimes — see Rule 1's Class B caveat. |
+| **C** | Full sync every time (no timestamp column) | `update_types`, `update_type_fields`, `custom_fields` | No — cache drift self-corrects on the next sync. Skip the checklist. |
+
+If your migration touches a Class C table, you're done. If it touches a Class B table, read Rule 1's Class B caveat before choosing a remedy. Class A is the primary case the rules below describe.
 
 ## 3. The checklist
 
@@ -39,6 +53,8 @@ update <table> set updated_at = now();
 ```
 
 This forces every row to be re-synced so clients download the new representation. Cost: one-time extra bandwidth the next time each client syncs.
+
+**Caveat for Class B tables** (`item_updates`, `photos`, `geo_layers`): the delta-sync cursor is on `created_at`, not `updated_at`, so bumping `updated_at` has no effect on sync. Either (a) bump the Dexie schema version in `src/lib/offline/db.ts` to force a full rebuild of the store on next app load, or (b) extend the sync engine to also watch `updated_at` on the affected table (larger change — coordinate with the offline-sync owner). Do NOT do `update <table> set created_at = now();` — that corrupts sort order.
 
 ### Rule 2 — You added a column with a server-side default
 
@@ -74,11 +90,17 @@ Remedy — in the same migration, repair any rows carrying the now-invalid value
 update <table> set <column> = '<valid-value>' where <column> = '<removed-value>';
 ```
 
-This update itself bumps `updated_at` on synced tables (they have an `updated_at` trigger from migration 013 onward), so clients re-sync the repaired rows automatically. No separate timestamp bump is needed unless the table lacks the trigger — verify by grepping `supabase/migrations/` for `<table>_updated_at`.
+What happens next depends on the table's sync class:
+
+- **Class A** (has `updated_at` trigger): the repair `UPDATE` bumps `updated_at` automatically, and the delta-sync cursor picks up the repaired rows on the next sync. No extra step needed.
+- **Class B** (delta on `created_at`): the repair fixes the server but stale caches won't re-sync. Pair with the Class B remedy from Rule 1.
+- **Class C** (full sync): the repair shows up on the next full sync. No extra step needed.
 
 ### None of the above?
 
-The migration is cache-safe. Examples that need no action:
+If the migration targets a Class A or B table with a change that doesn't match Rules 1–5, ask: "does this change the client-visible shape of the row?" If yes, bump `updated_at` as in Rule 1 out of caution. If no, the migration is cache-safe.
+
+Cache-safe examples that need no action:
 
 - Creating a brand-new table that is not in `SYNC_TABLES`.
 - Adding an index or unique constraint (no row-shape change).
@@ -96,4 +118,4 @@ Ask: will stale caches still work?
 
 ## 5. Rule of thumb
 
-When in doubt, add `update <table> set updated_at = now();` to the migration. It forces one extra round-trip of sync per client but eliminates the entire class of cache-drift bugs.
+When in doubt on a Class A table, add `update <table> set updated_at = now();` to the migration. For Class B tables, bump the Dexie schema version. For Class C tables, no action is needed — drift self-corrects on the next sync. This class-aware default eliminates the entire cache-drift bug class with one line per migration.

--- a/docs/playbooks/offline-cache-schema-changes.md
+++ b/docs/playbooks/offline-cache-schema-changes.md
@@ -1,0 +1,99 @@
+# Playbook: Offline Cache Schema Changes
+
+**Purpose:** Prevent SQL migrations from silently breaking the client's IndexedDB offline cache. Every migration that touches a synced table must follow this checklist.
+
+**When to use:** Any SQL migration under `supabase/migrations/` that adds, removes, renames, or changes the type of a column on a synced table. Also applies when you add a new synced table, narrow an enum, or change a check constraint.
+
+---
+
+## 1. Why this exists
+
+The client keeps a local IndexedDB copy of every synced row. Delta sync refreshes that copy with a cursor: "give me every row where `updated_at` is newer than my last sync." Schema-level changes like `ALTER COLUMN TYPE`, adding a column with a server-side default, or changing a default value do NOT bump `updated_at`. The cursor sees nothing new, the cache keeps the old representation, and code that assumes the new shape crashes.
+
+Real example: migration `044_icon_jsonb.sql` converted `item_types.icon` and `entity_types.icon` from `text` to `jsonb` via `ALTER COLUMN TYPE`. Clients whose caches synced before the migration kept plain-string icons (`"📍"`). Display code assumed the new `{set, name}` object shape and crashed with `Cannot read properties of undefined (reading 'replace')` on the edit-item page.
+
+## 2. When this applies
+
+Synced tables (as of this writing — re-check `SYNC_TABLES` in `src/lib/offline/sync-engine.ts` for the authoritative list):
+
+```
+items, item_types, custom_fields, item_updates, update_types,
+update_type_fields, photos, entities, entity_types, geo_layers,
+properties, orgs, roles, org_memberships
+```
+
+Changes to tables NOT in that list cannot drift client caches because they are never cached. Examples out of scope: `invites`, `communications_*`, `location_history`, `mutation_queue` internals.
+
+## 3. The checklist
+
+Read top to bottom. Stop at the first rule that matches your migration, apply the remedy, and move on.
+
+### Rule 1 — You changed the TYPE of an existing column
+
+Examples: `text` → `jsonb`, `int` → `bigint`, `varchar(n)` → `text`.
+
+Remedy — add to the same migration:
+
+```sql
+update <table> set updated_at = now();
+```
+
+This forces every row to be re-synced so clients download the new representation. Cost: one-time extra bandwidth the next time each client syncs.
+
+### Rule 2 — You added a column with a server-side default
+
+Example: `alter table items add column priority text default 'normal';`.
+
+Remedy — decide which is true for your migration:
+
+- **Client code depends on this field being present** → bump `updated_at` as in Rule 1.
+- **Client code tolerates the field being absent** → no bump needed, but the TypeScript interface in `src/lib/types.ts` should mark the field as optional (`field?: T`) or nullable (`field: T | null`).
+
+### Rule 3 — You renamed or removed a column
+
+Remedy — do both, in the same migration cycle:
+
+1. Add `update <table> set updated_at = now();` to the SQL migration. When clients re-sync, Dexie's `bulkPut` will replace the cached row with one that no longer carries the old column.
+2. Bump the Dexie schema version in `src/lib/offline/db.ts`. Add a new `this.version(N + 1).stores({...})` block. If the removed/renamed column was an indexed field in Dexie, update the index list in the new version. Do not mutate the previous version block.
+
+### Rule 4 — You added a new synced table
+
+Remedy — all three:
+
+1. Add the table name to `SYNC_TABLES` in `src/lib/offline/sync-engine.ts`.
+2. Add the table to the appropriate scope filter in the same file (`propertyScoped` or `orgScoped`) so the sync engine queries the right foreign key.
+3. Add a Dexie store definition in `src/lib/offline/db.ts` in a new version block.
+
+### Rule 5 — You narrowed an enum or check constraint
+
+Example: removing `'beta'` from a status check constraint that used to allow it.
+
+Remedy — in the same migration, repair any rows carrying the now-invalid value:
+
+```sql
+update <table> set <column> = '<valid-value>' where <column> = '<removed-value>';
+```
+
+This update itself bumps `updated_at` on synced tables (they have an `updated_at` trigger from migration 013 onward), so clients re-sync the repaired rows automatically. No separate timestamp bump is needed unless the table lacks the trigger — verify by grepping `supabase/migrations/` for `<table>_updated_at`.
+
+### None of the above?
+
+The migration is cache-safe. Examples that need no action:
+
+- Creating a brand-new table that is not in `SYNC_TABLES`.
+- Adding an index or unique constraint (no row-shape change).
+- Changing an RLS policy (no row-shape change).
+- Adding a nullable column with no default that client code doesn't reference yet.
+
+## 4. Secondary reminder — TypeScript interface changes
+
+When a code PR adds or changes a field on a TypeScript interface for a synced row (`Item`, `ItemType`, `Entity`, `EntityType`, `UpdateType`, `UpdateTypeField`, `CustomField`, `Property`, `Org`, `Role`, `OrgMembership`, `Photo`, `ItemUpdate`) *without* a corresponding SQL migration:
+
+Ask: will stale caches still work?
+
+- Usually **yes** if you make the new field optional (`field?: T` or `field: T | null`) and handle `undefined` gracefully at the call site.
+- If the code needs the field to be present at runtime, the change needs an accompanying SQL migration — at which point Rule 2 above applies.
+
+## 5. Rule of thumb
+
+When in doubt, add `update <table> set updated_at = now();` to the migration. It forces one extra round-trip of sync per client but eliminates the entire class of cache-drift bugs.

--- a/docs/playbooks/offline-cache-schema-changes.md
+++ b/docs/playbooks/offline-cache-schema-changes.md
@@ -69,12 +69,18 @@ Remedy — decide which is true for your migration:
 
 Remedy — do both, in the same migration cycle:
 
-1. Add `update <table> set updated_at = now();` to the SQL migration. When clients re-sync, Dexie's `bulkPut` will replace the cached row with one that no longer carries the old column.
+1. For **Class A** tables, add `update <table> set updated_at = now();` to the SQL migration so clients re-sync. Dexie's `bulkPut` replaces the cached row with one that no longer carries the old column. For **Class B** tables, fall back to Rule 1's Class B remedy (bump Dexie schema version or extend sync to watch `updated_at`) — the `update <table> set updated_at = now();` trick does not apply because these tables have no `updated_at` column. For **Class C** tables, cache drift self-corrects on the next full sync; no extra SQL needed.
 2. Bump the Dexie schema version in `src/lib/offline/db.ts`. Add a new `this.version(N + 1).stores({...})` block. If the removed/renamed column was an indexed field in Dexie, update the index list in the new version. Do not mutate the previous version block.
 
 ### Rule 4 — You added a new synced table
 
-Remedy — all three:
+Before the three steps below, decide which sync class the new table belongs in. The choice determines which timestamp columns you add.
+
+- **Class A** (rows mutate, need low-latency delta sync): add `created_at` and `updated_at` columns with an `updated_at` trigger (follow migration 013's `entities_updated_at` / `entity_types_updated_at` pattern). Add the table name to `TABLES_WITH_UPDATED_AT` in `src/lib/offline/sync-engine.ts`.
+- **Class B** (append-mostly, rarely mutated): add `created_at` only. The sync engine will pick up new rows via `created_at`; mutations on existing rows won't propagate until a Dexie schema bump or a sync-engine change, so only pick this class if mutations are truly rare.
+- **Class C** (tiny reference data, always full-sync): skip timestamps entirely. Add the table name to `TABLES_WITHOUT_TIMESTAMPS` in `src/lib/offline/sync-engine.ts`.
+
+Then:
 
 1. Add the table name to `SYNC_TABLES` in `src/lib/offline/sync-engine.ts`.
 2. Add the table to the appropriate scope filter in the same file (`propertyScoped` or `orgScoped`) so the sync engine queries the right foreign key.
@@ -98,7 +104,7 @@ What happens next depends on the table's sync class:
 
 ### None of the above?
 
-If the migration targets a Class A or B table with a change that doesn't match Rules 1–5, ask: "does this change the client-visible shape of the row?" If yes, bump `updated_at` as in Rule 1 out of caution. If no, the migration is cache-safe.
+If the migration targets a Class A or B table with a change that doesn't match Rules 1–5, ask: "does this change the client-visible shape of the row?" If yes, apply Rule 1's remedy for that class (updated_at bump for Class A; Dexie schema version bump or sync-engine widening for Class B). If no, the migration is cache-safe.
 
 Cache-safe examples that need no action:
 

--- a/docs/playbooks/offline-cache-schema-changes.md
+++ b/docs/playbooks/offline-cache-schema-changes.md
@@ -4,6 +4,8 @@
 
 **When to use:** Any SQL migration under `supabase/migrations/` that adds, removes, renames, or changes the type of a column on a synced table. Also applies when you add a new synced table, narrow an enum, or change a check constraint.
 
+**Decision record:** See [ADR-0002: Offline Cache Drift Prevention](../adr/0002-offline-cache-drift-prevention.md) for the alternatives considered (runtime validators, schema fingerprint) and why this process-only defense was chosen.
+
 ---
 
 ## 1. Why this exists

--- a/docs/superpowers/plans/2026-04-17-offline-cache-schema-checklist.md
+++ b/docs/superpowers/plans/2026-04-17-offline-cache-schema-checklist.md
@@ -1,0 +1,298 @@
+# Offline Cache Schema-Change Checklist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a process-only defense against the offline-cache schema-drift bug class by adding one new playbook, one invariants-table row in `AGENTS.md`, and one checkbox in the PR template.
+
+**Architecture:** Three small file touches. No runtime code, no tests, no migrations. The playbook is the canonical content; the other two touches make it discoverable at authoring and review time. Spec reference: `docs/superpowers/specs/2026-04-17-offline-cache-schema-checklist-design.md`.
+
+**Tech Stack:** Markdown, git.
+
+---
+
+## File Structure
+
+**New files:**
+- `docs/playbooks/offline-cache-schema-changes.md` — the canonical checklist, four sections (trigger, mental model, decision-tree checklist, secondary reminder for TS interface changes)
+
+**Modified files:**
+- `AGENTS.md` — one new row in the Architectural Invariants table (after the existing rows, before the Coding and Change Discipline section)
+- `.github/pull_request_template.md` — one new `## Cache safety` section between the Testing section and the Memory & Decision Tracking section
+
+**Not touched:**
+- `src/lib/offline/sync-engine.ts` — referenced by the playbook but not modified (the playbook points to the `SYNC_TABLES` list as the source of truth; no code change)
+- `src/lib/offline/db.ts` — same
+- `CLAUDE.md` — deliberately not touched. The Playbooks section there currently lists only one playbook; if we start linking every playbook from CLAUDE.md it becomes a second source of truth. AGENTS.md is the canonical operating manual. Revisit only if the new playbook is repeatedly missed by agents.
+
+---
+
+## Task 1: Create the playbook
+
+**Files:**
+- Create: `docs/playbooks/offline-cache-schema-changes.md`
+
+- [ ] **Step 1: Confirm the file does not yet exist**
+
+Run: `ls docs/playbooks/offline-cache-schema-changes.md`
+Expected: `No such file or directory`
+
+- [ ] **Step 2: Confirm the current `SYNC_TABLES` list in the codebase**
+
+Run: `grep -A5 "^const SYNC_TABLES" src/lib/offline/sync-engine.ts`
+Expected output (the list the playbook will reference):
+```
+const SYNC_TABLES = [
+  'items', 'item_types', 'custom_fields', 'item_updates', 'update_types',
+  'update_type_fields', 'photos', 'entities', 'entity_types', 'geo_layers',
+  'properties', 'orgs', 'roles', 'org_memberships',
+] as const;
+```
+
+If the list has drifted since the spec was written, update the playbook's Section 1 to match what's actually in the source file. The source file is the source of truth.
+
+- [ ] **Step 3: Create the playbook**
+
+Create `docs/playbooks/offline-cache-schema-changes.md` with this exact content:
+
+````markdown
+# Playbook: Offline Cache Schema Changes
+
+**Purpose:** Prevent SQL migrations from silently breaking the client's IndexedDB offline cache. Every migration that touches a synced table must follow this checklist.
+
+**When to use:** Any SQL migration under `supabase/migrations/` that adds, removes, renames, or changes the type of a column on a synced table. Also applies when you add a new synced table, narrow an enum, or change a check constraint.
+
+---
+
+## 1. Why this exists
+
+The client keeps a local IndexedDB copy of every synced row. Delta sync refreshes that copy with a cursor: "give me every row where `updated_at` is newer than my last sync." Schema-level changes like `ALTER COLUMN TYPE`, adding a column with a server-side default, or changing a default value do NOT bump `updated_at`. The cursor sees nothing new, the cache keeps the old representation, and code that assumes the new shape crashes.
+
+Real example: migration `044_icon_jsonb.sql` converted `item_types.icon` and `entity_types.icon` from `text` to `jsonb` via `ALTER COLUMN TYPE`. Clients whose caches synced before the migration kept plain-string icons (`"📍"`). Display code assumed the new `{set, name}` object shape and crashed with `Cannot read properties of undefined (reading 'replace')` on the edit-item page.
+
+## 2. When this applies
+
+Synced tables (as of this writing — re-check `SYNC_TABLES` in `src/lib/offline/sync-engine.ts` for the authoritative list):
+
+```
+items, item_types, custom_fields, item_updates, update_types,
+update_type_fields, photos, entities, entity_types, geo_layers,
+properties, orgs, roles, org_memberships
+```
+
+Changes to tables NOT in that list cannot drift client caches because they are never cached. Examples out of scope: `invites`, `communications_*`, `location_history`, `mutation_queue` internals.
+
+## 3. The checklist
+
+Read top to bottom. Stop at the first rule that matches your migration, apply the remedy, and move on.
+
+### Rule 1 — You changed the TYPE of an existing column
+
+Examples: `text` → `jsonb`, `int` → `bigint`, `varchar(n)` → `text`.
+
+Remedy — add to the same migration:
+
+```sql
+update <table> set updated_at = now();
+```
+
+This forces every row to be re-synced so clients download the new representation. Cost: one-time extra bandwidth the next time each client syncs.
+
+### Rule 2 — You added a column with a server-side default
+
+Example: `alter table items add column priority text default 'normal';`.
+
+Remedy — decide which is true for your migration:
+
+- **Client code depends on this field being present** → bump `updated_at` as in Rule 1.
+- **Client code tolerates the field being absent** → no bump needed, but the TypeScript interface in `src/lib/types.ts` should mark the field as optional (`field?: T`) or nullable (`field: T | null`).
+
+### Rule 3 — You renamed or removed a column
+
+Remedy — do both, in the same migration cycle:
+
+1. Add `update <table> set updated_at = now();` to the SQL migration. When clients re-sync, Dexie's `bulkPut` will replace the cached row with one that no longer carries the old column.
+2. Bump the Dexie schema version in `src/lib/offline/db.ts`. Add a new `this.version(N + 1).stores({...})` block. If the removed/renamed column was an indexed field in Dexie, update the index list in the new version. Do not mutate the previous version block.
+
+### Rule 4 — You added a new synced table
+
+Remedy — all three:
+
+1. Add the table name to `SYNC_TABLES` in `src/lib/offline/sync-engine.ts`.
+2. Add the table to the appropriate scope filter in the same file (`propertyScoped` or `orgScoped`) so the sync engine queries the right foreign key.
+3. Add a Dexie store definition in `src/lib/offline/db.ts` in a new version block.
+
+### Rule 5 — You narrowed an enum or check constraint
+
+Example: removing `'beta'` from a status check constraint that used to allow it.
+
+Remedy — in the same migration, repair any rows carrying the now-invalid value:
+
+```sql
+update <table> set <column> = '<valid-value>' where <column> = '<removed-value>';
+```
+
+This update itself bumps `updated_at` on synced tables (they have an `updated_at` trigger from migration 013 onward), so clients re-sync the repaired rows automatically. No separate timestamp bump is needed unless the table lacks the trigger — verify by grepping `supabase/migrations/` for `<table>_updated_at`.
+
+### None of the above?
+
+The migration is cache-safe. Examples that need no action:
+
+- Creating a brand-new table that is not in `SYNC_TABLES`.
+- Adding an index or unique constraint (no row-shape change).
+- Changing an RLS policy (no row-shape change).
+- Adding a nullable column with no default that client code doesn't reference yet.
+
+## 4. Secondary reminder — TypeScript interface changes
+
+When a code PR adds or changes a field on a TypeScript interface for a synced row (`Item`, `ItemType`, `Entity`, `EntityType`, `UpdateType`, `UpdateTypeField`, `CustomField`, `Property`, `Org`, `Role`, `OrgMembership`, `Photo`, `ItemUpdate`) *without* a corresponding SQL migration:
+
+Ask: will stale caches still work?
+
+- Usually **yes** if you make the new field optional (`field?: T` or `field: T | null`) and handle `undefined` gracefully at the call site.
+- If the code needs the field to be present at runtime, the change needs an accompanying SQL migration — at which point Rule 2 above applies.
+
+## 5. Rule of thumb
+
+When in doubt, add `update <table> set updated_at = now();` to the migration. It forces one extra round-trip of sync per client but eliminates the entire class of cache-drift bugs.
+````
+
+- [ ] **Step 4: Verify the file renders cleanly**
+
+Run: `head -20 docs/playbooks/offline-cache-schema-changes.md`
+Expected: the file starts with `# Playbook: Offline Cache Schema Changes` and the first paragraph of the Purpose line.
+
+Run: `wc -l docs/playbooks/offline-cache-schema-changes.md`
+Expected: roughly 90–110 lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/playbooks/offline-cache-schema-changes.md
+git commit -m "docs(playbook): offline cache schema-change checklist"
+```
+
+---
+
+## Task 2: Add the `AGENTS.md` invariants row
+
+**Files:**
+- Modify: `AGENTS.md` — the Architectural Invariants table, currently at lines 22–34
+
+- [ ] **Step 1: Inspect the current table**
+
+Run: `grep -n "^|" AGENTS.md | head -20`
+
+Expected: you see the table headers on lines 22–23 (`| Invariant | Detail |` and `|---|---|`), the existing rows on 24–34, and no Offline-cache row yet. If an Offline-cache row already exists, STOP — the playbook is already linked, and this task is already done.
+
+- [ ] **Step 2: Add the new row**
+
+Edit `AGENTS.md`. Find the existing row `| Client Supabase | \`createClient()\` from \`@/lib/supabase/client\` (synchronous) |` and add a new row immediately after it:
+
+```markdown
+| Offline cache safety | Any SQL migration that touches a table in `SYNC_TABLES` (see `src/lib/offline/sync-engine.ts`) must follow `docs/playbooks/offline-cache-schema-changes.md`. When in doubt, `update <table> set updated_at = now();` in the same migration. |
+```
+
+- [ ] **Step 3: Verify the row renders as valid markdown**
+
+Run: `grep -A1 "Offline cache safety" AGENTS.md`
+Expected: exactly one match, followed immediately by the next existing row of the file (whatever it is) — confirms the row was inserted cleanly with no stray blank lines or broken table syntax.
+
+Run: `awk '/^## Architectural Invariants/,/^## Coding and Change Discipline/' AGENTS.md | head -40`
+Expected: the entire Invariants table renders with headers, separator, existing rows, and the new `Offline cache safety` row as the final data row.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(agents): add offline cache safety invariant"
+```
+
+---
+
+## Task 3: Update the PR template
+
+**Files:**
+- Modify: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Inspect the current template**
+
+Run: `cat .github/pull_request_template.md`
+
+Expected sections: `Summary`, `Type of Change`, `Testing`, `Memory & Decision Tracking`, `Screenshots`.
+
+Confirm there is no existing `Cache safety` section. If there is, STOP — already done.
+
+- [ ] **Step 2: Add the Cache safety section**
+
+Edit `.github/pull_request_template.md`. Insert a new section between the existing `## Testing` section and the existing `## Memory & Decision Tracking` section:
+
+```markdown
+## Cache safety
+
+- [ ] This PR does not add a SQL migration, OR the migration follows `docs/playbooks/offline-cache-schema-changes.md`.
+```
+
+The placement intentionally sits after Testing (so the author thinks about correctness first) and before Memory tracking (so the cache check is not buried under unrelated bookkeeping).
+
+- [ ] **Step 3: Verify the template parses as valid markdown**
+
+Run: `grep -n "^## " .github/pull_request_template.md`
+Expected: the section headings in order — `## Summary`, `## Type of Change`, `## Testing`, `## Cache safety`, `## Memory & Decision Tracking`, `## Screenshots`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/pull_request_template.md
+git commit -m "docs(pr): add cache-safety checkbox to PR template"
+```
+
+---
+
+## Task 4: Final internal-consistency check
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 1: Confirm all three files exist and point at each other correctly**
+
+Run: `grep -l "offline-cache-schema-changes" docs/playbooks/offline-cache-schema-changes.md AGENTS.md .github/pull_request_template.md`
+Expected: all three paths printed. Each file should mention the playbook either as itself or as a link.
+
+- [ ] **Step 2: Confirm the playbook's `SYNC_TABLES` list still matches the source of truth**
+
+Run: `grep -A5 "^const SYNC_TABLES" src/lib/offline/sync-engine.ts`
+
+Compare its output against Section 2 of the playbook (`cat docs/playbooks/offline-cache-schema-changes.md | grep -A3 "items, item_types"`). The table names should match exactly. If `SYNC_TABLES` has added a table since the playbook was drafted, update Section 2 of the playbook in a small follow-up commit. (This is a one-time check; ongoing drift is managed by the same playbook it's verifying.)
+
+- [ ] **Step 3: Confirm the AGENTS.md Invariants table is still valid markdown**
+
+Run: `awk '/^## Architectural Invariants/,/^## /' AGENTS.md | head -30`
+Expected: a clean table with headers, separator row, and all invariant rows including the new `Offline cache safety` row, followed by the next top-level heading.
+
+- [ ] **Step 4: Confirm the PR template still renders**
+
+Use the GitHub CLI to dry-render the template for a PR on a test branch (optional but reassuring if it's your first time editing the template):
+
+```bash
+gh pr create --dry-run --title "test" --body-file .github/pull_request_template.md 2>&1 | head -30
+```
+
+If you don't have `--dry-run` access or don't want to exercise `gh`, just verify the file is syntactically a valid markdown checklist by visually scanning `cat .github/pull_request_template.md`.
+
+No new commit for Task 4 unless Step 2 found drift requiring a playbook update.
+
+---
+
+## Done criteria
+
+- `docs/playbooks/offline-cache-schema-changes.md` exists and contains all four sections (Why, When, Checklist, Secondary reminder).
+- `AGENTS.md` has an `Offline cache safety` row in its Architectural Invariants table that links to the playbook.
+- `.github/pull_request_template.md` has a `## Cache safety` section with one checkbox linking to the playbook.
+- The `SYNC_TABLES` list in the playbook matches `src/lib/offline/sync-engine.ts` at merge time.
+- No code files changed. `npm run test` and `npm run type-check` were not required to run (unchanged by this PR) but verifying they still pass with `npm run test && npm run type-check` is a sanity check against accidental file corruption.
+
+## Deferred follow-ups (intentionally not in this plan)
+
+- Linking the new playbook from `CLAUDE.md`'s Playbooks section. Skipped because AGENTS.md is the canonical location.
+- A GitHub Action that greps migration diffs for `ALTER COLUMN` without a matching `UPDATE ... set updated_at`. Revisit if two or more migrations ship without the playbook being applied.
+- A one-time migration that bumps `updated_at` across all affected tables so existing stale caches repair themselves without relying on defensive normalizers. Tracked separately.
+- Runtime read-boundary validators (option 2 in brainstorming) and schema fingerprinting (option 5). Both deferred until process discipline is shown insufficient.

--- a/docs/superpowers/specs/2026-04-17-offline-cache-schema-checklist-design.md
+++ b/docs/superpowers/specs/2026-04-17-offline-cache-schema-checklist-design.md
@@ -1,0 +1,211 @@
+# Offline Cache Schema-Change Checklist — Design
+
+## Overview
+
+Prevent the class of bug where a SQL migration silently invalidates the client's IndexedDB offline cache, causing runtime crashes or stale reads in production. Root example: migration `044_icon_jsonb.sql` used `ALTER COLUMN TYPE` to convert `item_types.icon` and `entity_types.icon` from text to jsonb, but `ALTER COLUMN TYPE` does not bump `updated_at` on rows. The sync engine's delta cursor (`updated_at >= last_synced_at`) therefore skipped every affected row, so clients whose caches synced before the migration kept serving plain-string icons. Display code assumed the new IconValue object shape and crashed with `Cannot read properties of undefined (reading 'replace')` on the edit-item page.
+
+This spec introduces a lightweight, process-only defense: a playbook every schema-changing migration must follow, plus two pointers (AGENTS.md and the PR template) that make the playbook discoverable at the moment of authoring and reviewing a migration.
+
+Scope intentionally excludes runtime validators at the read boundary (Option 2 in brainstorming) and schema fingerprinting / cursor invalidation (Option 5). Those remain on the table if process discipline proves insufficient — tracked as follow-ups at the end of this spec.
+
+## Goals
+
+- Make the checklist impossible to miss when authoring a SQL migration that touches a synced table.
+- Codify the "always bump `updated_at` when changing row shape" rule so agents and humans apply it without having to rediscover the cursor-skipped-my-rows trap.
+- Keep setup cost under an hour. No CI automation, no runtime cost, no new dependencies.
+- Give authors one canonical place to look when they're unsure whether a change needs a cache bust.
+
+## Non-Goals
+
+- Runtime validation of rows read from IndexedDB. Deferred.
+- Automated linting of migration files in CI. Deferred; revisit if the checklist is not followed after a few migrations.
+- A Dexie upgrade-hook framework for automatic client-side data normalization. Deferred.
+- Changes to how the sync engine resolves cursors or detects drift.
+- A one-time migration to bump `updated_at` across all existing synced tables. Current stale caches are already handled by the `normalizeIcon` hotfix (PR #260) — this spec is forward-looking.
+
+## Architecture
+
+Three coordinated touch points, all documentation:
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  docs/playbooks/offline-cache-schema-changes.md                    │
+│  (the canonical checklist — the actual content)                    │
+└────────────────────────────────────────────────────────────────────┘
+         ▲                                              ▲
+         │                                              │
+┌────────┴───────────────────────┐    ┌─────────────────┴─────────┐
+│  AGENTS.md                     │    │ .github/PULL_REQUEST_     │
+│  — adds a one-line rule under  │    │ TEMPLATE.md               │
+│    Architectural Invariants    │    │ — adds "Cache-safety      │
+│    linking to the playbook     │    │   check" item referencing │
+│                                │    │   the playbook            │
+└────────────────────────────────┘    └───────────────────────────┘
+```
+
+**Why three touch points?** Each catches a different moment:
+- `AGENTS.md` is loaded by every agent session — catches agents before they author the migration.
+- The PR template is surfaced when a human opens a PR — catches humans at review time.
+- The playbook is the single source of truth that the other two link to, so maintenance is one-place.
+
+## Component 1 — `docs/playbooks/offline-cache-schema-changes.md`
+
+The playbook has four sections, in this order:
+
+### Section 1: When this applies
+
+Trigger: any SQL migration that touches a table in the `SYNC_TABLES` list exported from `src/lib/offline/sync-engine.ts`. Current list (copied into the playbook for quick reference, with a note to re-check the source of truth):
+
+```
+items, item_types, custom_fields, item_updates, update_types,
+update_type_fields, photos, entities, entity_types, geo_layers,
+properties, orgs, roles, org_memberships
+```
+
+Non-synced tables (e.g., `invites`, `communications_*`, `location_history`) are out of scope — changes to them cannot drift client caches because they are never cached.
+
+### Section 2: The mental model
+
+A short paragraph explaining the failure mode in plain language:
+
+> The client keeps a local IndexedDB copy of every synced row. It refreshes that copy using a delta-sync cursor: "give me every row where `updated_at` is newer than the last time I synced." Schema-level changes like `ALTER COLUMN TYPE` or a new default value on an existing column do NOT bump `updated_at`. The cursor sees nothing new, the cache keeps the old representation, and code that assumes the new shape crashes.
+
+This section exists so a future author who has never seen the icon bug still understands *why* the checklist matters. Without it, the checklist looks arbitrary.
+
+### Section 3: The checklist
+
+Five rules, in decision-tree order. The author reads down until one matches, applies the prescribed remedy, and is done.
+
+**1. You changed the TYPE of an existing column** (e.g., `text` → `jsonb`, `int` → `bigint`, `varchar(n)` → `text`).
+
+Remedy: add to the same migration:
+```sql
+update <table> set updated_at = now();
+```
+This forces a re-sync of every row so clients download the new representation. Cost: one-time extra bandwidth the next time each client syncs.
+
+**2. You added a column with a server-side default** (e.g., `alter table x add column foo text default 'bar'`).
+
+Remedy: decide which is true:
+- "Client code depends on this field being present" → bump `updated_at` as in rule 1.
+- "Client code tolerates the field being absent (reads it as optional)" → no bump needed. TypeScript interface should mark the field as optional or nullable.
+
+**3. You renamed or removed a column.**
+
+Remedy: both actions in the same migration:
+- `update <table> set updated_at = now();` so clients drop rows carrying the old column on next sync (bulkPut replaces by id).
+- Bump the Dexie schema version in `src/lib/offline/db.ts`. If the removed/renamed column was indexed in Dexie, update the index definition in the new version.
+
+**4. You added a new synced table.**
+
+Remedy, all three:
+- Add the table name to `SYNC_TABLES` in `src/lib/offline/sync-engine.ts`.
+- Add the table to one of the scope arrays (`propertyScoped` or `orgScoped`) in the same file so the sync engine filters correctly.
+- Add a Dexie store definition in `src/lib/offline/db.ts` in a new version block (do not mutate the existing version).
+
+**5. You narrowed an enum or check constraint** (removed a previously-valid value).
+
+Remedy: in the same migration, update any rows carrying the now-invalid value:
+```sql
+update <table> set <column> = '<valid-value>' where <column> = '<removed-value>';
+```
+This update itself bumps `updated_at` on synced tables (they have an `updated_at` trigger from migration 013 onward), so clients re-sync the repaired rows automatically. No separate timestamp bump needed unless the table lacks the trigger — verify by grepping `_updated_at` triggers for the table in `supabase/migrations/`.
+
+**None of the above?** The migration is cache-safe. Examples that do NOT need anything:
+- Creating a brand-new table that is not in `SYNC_TABLES`.
+- Adding an index or unique constraint (no row-shape change).
+- Changing an RLS policy (no row-shape change).
+- Adding a nullable column with no default that client code doesn't reference yet.
+
+### Section 4: Secondary reminder for TS-interface changes
+
+When a code PR adds or changes a field on a TypeScript interface for a synced row (`Item`, `ItemType`, `Entity`, `EntityType`, `UpdateType`, `UpdateTypeField`, `CustomField`, `Property`, `Org`, `Role`, `OrgMembership`, `Photo`, `ItemUpdate`) *without* a corresponding SQL migration:
+
+> Ask: will stale caches still work? Usually yes if you make the new field optional (`field?: T` or `field: T | null`) and handle `undefined` gracefully. If the code needs the field to be present, the change needs an accompanying SQL migration (rule 2 above).
+
+This section is a reminder, not a hard rule — TypeScript-only changes to a cached type don't touch the cache itself, they just tighten what the code expects from it.
+
+## Component 2 — `AGENTS.md` addition
+
+Add a single line under **Architectural Invariants** (the table at the top of the file). New row:
+
+| Invariant | Detail |
+|---|---|
+| Offline cache safety | Any SQL migration that touches a table in `SYNC_TABLES` must follow `docs/playbooks/offline-cache-schema-changes.md`. When in doubt, `update <table> set updated_at = now();` in the same migration. |
+
+No other changes to AGENTS.md.
+
+## Component 3 — PR template addition
+
+Add one item to `.github/PULL_REQUEST_TEMPLATE.md` under a new "Cache-safety check" heading (or append to an existing testing/checklist section if one exists — to be confirmed during implementation):
+
+```markdown
+## Cache-safety check
+
+- [ ] This PR does not add a SQL migration, OR the migration follows `docs/playbooks/offline-cache-schema-changes.md`.
+```
+
+Single checkbox. If the PR has no migration, the author ticks it trivially. If it has a migration, the author confirms they followed the playbook.
+
+## Data Flow
+
+No runtime data flow changes — this is pure documentation.
+
+Authoring flow (what the playbook changes):
+
+```
+  Author plans a migration
+           │
+           ▼
+  AGENTS.md: "Offline cache safety — see playbook"
+           │
+           ▼
+  Playbook: read Section 3 checklist
+           │
+           ▼
+  Author applies remedy(ies) in migration SQL
+           │
+           ▼
+  PR opened, template shows cache-safety checkbox
+           │
+           ▼
+  Reviewer verifies migration follows playbook
+```
+
+## Error Handling
+
+Not applicable — documentation has no error states.
+
+What happens if the checklist is skipped anyway:
+- The bug manifests as a runtime crash on the first page that reads a drifted row.
+- Recovery is whatever we ship in PR #260 (the `normalizeIcon` pattern) or a hotfix specific to that row shape.
+- The checklist being ignored once does not cascade — each migration is independent.
+
+## Testing
+
+- **Spec completeness** — inline review below.
+- **Follow-up real-world test** — the next SQL migration after this spec lands should be author-tested against the checklist. If the author misses a step and a reviewer catches it, the playbook worked. If the author misses a step and it reaches main, the playbook needs sharper language.
+- **No unit tests required** — no code is changing.
+
+## Open Questions / Deferred
+
+- **CI automation** (deferred). A GitHub Action that greps migration diffs for `ALTER COLUMN` without a matching `UPDATE ... set updated_at = now()` would make the checklist enforcing rather than aspirational. Revisit if two or more migrations ship without the checklist being applied.
+- **Runtime read-boundary validators** (deferred, option 2 in brainstorming). Could catch drift the checklist misses, at the cost of ~15 kB bundle + per-read CPU. Revisit if process discipline is insufficient and we accumulate more normalizer patterns like `normalizeIcon`.
+- **Schema fingerprint in sync_metadata** (deferred, option 5 in brainstorming). Would give the sync engine a way to detect drift and auto-invalidate cursors. Higher leverage than validators but requires server-side cooperation (schema version exposed per table). Revisit if this becomes a recurring concern.
+- **A one-time migration to bump `updated_at` on all currently-affected tables** so existing stale caches repair themselves without needing the `normalizeIcon` patch long-term. Worth considering as a separate small PR after this lands; not part of this spec.
+
+## File Structure
+
+```
+docs/
+  playbooks/
+    offline-cache-schema-changes.md        # new — the canonical checklist
+AGENTS.md                                  # modified — one line added
+.github/
+  PULL_REQUEST_TEMPLATE.md                 # modified — one checkbox added
+                                           # (may be created if it does not
+                                           # already exist — verify during
+                                           # implementation)
+```
+
+No source code changes. No test changes. No migration. No dependency changes.


### PR DESCRIPTION
## Summary

Process-only defense against the offline-cache schema-drift bug class. Zero runtime cost, no migrations, no code changes — three coordinated docs touch points:

- **`docs/playbooks/offline-cache-schema-changes.md`** (new, ~130 lines) — the canonical checklist. Explains the failure mode (delta-sync cursor + `ALTER COLUMN TYPE` not bumping `updated_at`), lays out a Class A/B/C taxonomy for the 14 synced tables (matching `TABLES_WITH_UPDATED_AT` / `TABLES_WITHOUT_TIMESTAMPS` in `src/lib/offline/sync-engine.ts`), and prescribes class-aware remedies for five change types (column type change, added column with default, rename/remove, new synced table, enum narrowing).
- **`AGENTS.md`** — one new row in the Architectural Invariants table pointing authors at the playbook.
- **`.github/pull_request_template.md`** — new `## Cache safety` section with one checkbox referencing the playbook.

Motivating bug: migration `044_icon_jsonb.sql` used `ALTER COLUMN TYPE` without bumping `updated_at`, so client IndexedDB caches kept legacy string icons and the display code crashed. Fixed at runtime by PR #260 (`normalizeIcon`); this PR prevents future occurrences at authoring time.

## Why docs-only

Explored three layers in brainstorming — process (this PR), runtime validators, schema fingerprints. Started with the cheapest layer; revisit the other two only if the checklist is not followed in practice.

## Intentionally out of scope

- CI automation that greps migration diffs for missing `updated_at` bumps.
- Runtime Zod/Valibot validators at the IndexedDB read boundary.
- Schema fingerprint in `sync_metadata` that auto-invalidates drift.
- A one-time `UPDATE` migration to bump `updated_at` across currently-affected tables (the `normalizeIcon` hotfix already masks that).

All four tracked in the spec's "Deferred" section.

## Test plan

- [ ] Read the playbook at `docs/playbooks/offline-cache-schema-changes.md` top to bottom — does the Class A/B/C taxonomy match `src/lib/offline/sync-engine.ts`?
- [ ] Open a test PR with a no-op change. Confirm the new `## Cache safety` section shows up in the template and the linked playbook is reachable from the rendered PR.
- [ ] Confirm `AGENTS.md` Architectural Invariants table renders cleanly on GitHub (new row visible, no broken pipes).
- [ ] Next SQL migration on a synced table uses this playbook; author notices the checklist in AGENTS.md and/or the PR template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)