### PR TITLE
fix: UpdateForm loses item ID from useSearchParams hydration

### DIFF
--- a/src/components/manage/UpdateForm.tsx
+++ b/src/components/manage/UpdateForm.tsx
@@ -52,6 +52,13 @@ export default function UpdateForm({ initialTypeId, lockType = false }: UpdateFo
 
   // When locked, seed itemId immediately from URL param
   const [itemId, setItemId] = useState(preselectedItemId ?? '');
+
+  // Sync itemId when searchParams hydrate after initial render
+  useEffect(() => {
+    if (preselectedItemId) {
+      setItemId(preselectedItemId);
+    }
+  }, [preselectedItemId]);
   const [updateTypeId, setUpdateTypeId] = useState(initialTypeId ?? '');
   const [content, setContent] = useState('');
   const [updateDate, setUpdateDate] = useState(


### PR DESCRIPTION
## Summary

- **Root cause:** `useState(preselectedItemId ?? '')` only runs its initializer once. In Next.js 14, `useSearchParams()` inside a `Suspense` boundary returns empty during hydration, so `itemId` state initializes to `''` even when `?item=` is in the URL. The locked item card renders correctly (derived from `preselectedItemId` which updates), but `itemId` state stays empty, causing "Please select an item" on save.
- **Fix:** Add a `useEffect` to sync `itemId` state when `preselectedItemId` hydrates

## Test plan

- [ ] Navigate to an item detail → click "Add Update" → verify locked item card shows → click Save → should succeed (no "Please select an item" error)
- [ ] Navigate directly to `/manage/update` (no `?item=` param) → verify item dropdown shows → submit without selecting → should still show validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)