### PR TITLE
fix(updates): replace /manage/update page with reliable server-side redirect

### DIFF
--- a/src/app/manage/update/page.tsx
+++ b/src/app/manage/update/page.tsx
@@ -1,23 +1,38 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { resolveTenant } from '@/lib/tenant/resolve';
+import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { headers } from 'next/headers';
 
-import { Suspense } from 'react';
-import UpdateForm from '@/components/manage/UpdateForm';
+interface AddUpdatePageProps {
+  searchParams: { item?: string };
+}
 
-export default function AddUpdatePage() {
-  return (
-    <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-      <h1 className="font-heading text-2xl font-semibold text-forest-dark mb-6">
-        Add Update
-      </h1>
-      <p className="text-sm text-sage mb-6">
-        Record an observation, maintenance visit, or sighting. You can
-        include photos taken in the field.
-      </p>
-      <div className="card">
-        <Suspense fallback={<div className="py-8 text-center text-sm text-sage">Loading…</div>}>
-          <UpdateForm />
-        </Suspense>
-      </div>
-    </div>
+export default async function AddUpdatePage({ searchParams }: AddUpdatePageProps) {
+  const hostname = headers().get('host') ?? 'localhost';
+  const tenantClient = createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
   );
+  const tenant = await resolveTenant(hostname, '/manage/update', tenantClient);
+
+  let slug = tenant?.propertySlug ?? null;
+  if (!slug && tenant?.orgId) {
+    const { data: property } = await tenantClient
+      .from('properties')
+      .select('slug')
+      .eq('org_id', tenant.orgId)
+      .eq('is_active', true)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    slug = property?.slug ?? null;
+  }
+
+  if (!slug) {
+    redirect('/');
+  }
+
+  const itemId = searchParams.item;
+  redirect(itemId ? `/p/${slug}/update/${itemId}` : `/p/${slug}`);
 }


### PR DESCRIPTION
## Summary

Fixes the failing `Add Update Flow @smoke` E2E test that has been red on `main` since PR #262 landed, despite PR #263's follow-up attempt.

### Root cause

PR #262 introduced a middleware rewrite (`src/lib/supabase/middleware.ts:354`) that redirects `/manage/update?item=X` to `/p/[slug]/update/X` (the new type picker route) and added an E2E smoke test that depends on that redirect firing. The redirect isn't reliable in the E2E environment — the test logs show the browser navigating to `http://localhost:3000/manage/update?item=<id>` and staying there until the `waitForURL(/\/p\/.+\/update\/.+/)` assertion times out after 15s.

### Fix

Convert `src/app/manage/update/page.tsx` from a client component that rendered the legacy `UpdateForm` into a Server Component that resolves the tenant's default property slug directly and issues a redirect. This removes the dependency on middleware timing — `/manage/update` becomes a deterministic server-side redirect endpoint.

The legacy `UpdateForm` render path at this route is now effectively dead code: PR #262 already removed all other entry points (nav tab, dashboard button) and wired `ActionButtonsBlock` + `DetailPanel` to the new picker path. This PR just aligns the page's behavior with that intent.

## Test Plan

- [x] `npm run type-check` — 0 errors
- [x] `npm run test` — 1249 / 1249 passing
- [x] `npm run build` — clean
- [ ] E2E `add-update-flow.spec.ts` goes green in CI (verification after merge)

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)