### PR TITLE
feat: species picker grid refactor (sheet + place-aware enrichment)

### DIFF
--- a/docs/adr/0003-species-picker-architecture.md
+++ b/docs/adr/0003-species-picker-architecture.md
@@ -1,0 +1,39 @@
+# ADR-0003: Species Picker Architecture
+
+Date: 2026-04-19
+
+## Status
+
+Accepted
+
+## Context
+
+The original `SpeciesPicker` was a compact inline dropdown: search input, blur-dismissed result list, synchronous per-tap Supabase upserts into `entities`, minimal iNat projection (`id`, `name`, `common_name`, `photo_url`, `rank`, `observations_count`, `wikipedia_url`).
+
+Conservation staff asked for a richer selection surface with a full-screen photo grid, per-place native/introduced badges, a cavity-nester filter, and a detail subview that shows the taxon's summary, IUCN status, taxonomy, and a nearby-observations callout. iNat's API gives us some of this (IUCN, Wikipedia summary, ancestry, per-place establishment_means when a `place_id` is supplied) and not others (cavity-nester is not a structured trait; size and diet are prose-only).
+
+FieldMapper is mobile-first and offline-tolerant. Writes everywhere else in the app flow through the offline mutation queue (`src/lib/offline/sync-engine.ts`); the old picker's direct-Supabase upsert diverged from that convention.
+
+## Decision
+
+1. **Bottom-sheet picker pattern.** Rich pickers open a `MultiSnapBottomSheet` at the `full` snap. Inside the sheet, a grid and a detail subview share the same local state; the detail subview is an internal view-switch, not a route change. This becomes the standard pattern for selection UIs with rich per-item metadata.
+
+2. **Selection gated behind the detail view.** Tapping a card pushes the detail subview; selection happens only via the detail's sticky CTA. Users see the enriched context before they commit. The grid still displays ring + check badge on already-staged cards for visual feedback.
+
+3. **Commit-on-Done (staged-selection model).** Sheet-internal state holds a `Map<taxonId, SpeciesResult>` of staged selections. The parent's `selectedIds` is untouched until the user presses Done, at which point `planCommit` returns a `{ newTaxa, keptEntityIds }` pair and the picker runs a single batched upsert. Pure reducer (`staged-selection.ts`) is unit-testable without React.
+
+4. **Place-aware enrichment via `/api/species/[id]`.** A new route proxies iNat `/v1/taxa/:id`, optionally passing a `place_id` resolved server-side from lat/lng via `/v1/places/nearby`. A module-scope LRU (max 500 entries, keyed by lat/lng rounded to 1 decimal place) sits in `src/lib/species/place-id-cache.ts`, with in-flight request dedup and a 5-second timeout. The route exports `revalidate = 86400`. The existing `/api/species/search` and `/api/species/nearby` routes also accept lat/lng and pipe `place_id` through for establishment-means projection. The list-tier projection lives in `src/lib/species/inat-projection.ts` so all three routes share one source of truth.
+
+5. **Curated trait data lives in `src/lib/species/*.ts`.** Traits iNat doesn't carry (currently: cavity-nester) are maintained as a typed `ReadonlySet<number>` of taxon ids with an `isCavityNester(id)` helper. The ADR records the pattern; the cavity-nester list itself is seeded with common North American species and maintained by conservation staff. Future traits follow the same file shape.
+
+6. **Offline writes go through the existing mutation queue.** When Done is pressed offline, each new entity is written locally (Dexie `entities.put`) and an `enqueueMutation({ table: 'entities', operation: 'insert', ... })` record is queued. Temporary ids flow through `onChange`; the sync engine reconciles on next sync. Online, the picker keeps the current direct-Supabase upsert for parity with existing tests.
+
+7. **Parent contract preserved.** `UpdateForm.tsx` is not modified. `SpeciesPicker` props remain `{entityTypeId, entityTypeName, orgId, selectedIds, onChange, lat, lng}`. This is an invariant for any future picker refactor in this component.
+
+## Consequences
+
+- Future rich pickers (e.g., location picker, custom-field dropdown with images) have a template to follow. The bottom-sheet + internal-detail-subview shape is now the house style.
+- The place-id cache is per-process. On serverless cold-start, the first request in a cell pays a `/v1/places/nearby` round-trip; 24h revalidate on the detail route amortizes. If serverless invocation density is low enough that this matters, the next iteration is a persistent cache (Redis or DB-backed), not a per-property column.
+- Curated trait data files are explicit maintenance surface area. The cavity-nester list is seeded with ~35 ids and requires an explicit PR to extend. Alternative traits (pollinator host, invasive watchlist) should follow the same shape; do not introduce a trait-tag config UI until there's a third consumer.
+- The commit-on-Done model means a user can stage many toggles and still hit Cancel to discard; the picker doesn't block on each tap. Tests that previously asserted on per-tap `insert` calls must be updated to assert on Done-time insertion.
+- Because UpdateForm writes `update_entities` through the mutation queue already, and the picker now writes `entities` through the queue when offline, the full commit path is mutation-queue-aware and works end-to-end in airplane mode.

--- a/src/app/api/species/[id]/route.ts
+++ b/src/app/api/species/[id]/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type {
+  SpeciesDetail,
+  SpeciesEstablishmentMeans,
+  SpeciesAncestor,
+} from '@/lib/types';
+import { resolvePlaceId } from '@/lib/species/place-id-cache';
+import {
+  iucnCodeOf,
+  toEstablishmentMeans,
+  type INatTaxonRaw,
+} from '@/lib/species/inat-projection';
+
+export const revalidate = 86400;
+
+interface INatTaxonDetailRaw extends INatTaxonRaw {
+  wikipedia_summary?: string | null;
+  ancestors?: Array<{ id: number; name: string; rank: string }>;
+}
+
+const ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'", '&nbsp;': ' ',
+};
+
+function stripHtml(input: string | null | undefined): string | null {
+  if (!input) return null;
+  const noTags = input.replace(/<[^>]+>/g, '');
+  const decoded = noTags.replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&nbsp;/g, (m) => ENTITY_MAP[m] ?? m);
+  const collapsed = decoded.replace(/\s+/g, ' ').trim();
+  return collapsed.length > 0 ? collapsed : null;
+}
+
+function toSpeciesDetail(raw: INatTaxonDetailRaw): SpeciesDetail {
+  const ancestry: SpeciesAncestor[] = (raw.ancestors ?? []).map((a) => ({
+    id: a.id,
+    name: a.name,
+    rank: a.rank,
+  }));
+  const family = ancestry.find((a) => a.rank === 'family')?.name ?? null;
+  const establishment: SpeciesEstablishmentMeans = toEstablishmentMeans(raw);
+
+  return {
+    id: raw.id,
+    name: raw.name,
+    common_name: raw.preferred_common_name || raw.name,
+    photo_square_url: raw.default_photo?.square_url ?? null,
+    photo_medium_url: raw.default_photo?.medium_url ?? null,
+    photo_large_url: raw.default_photo?.large_url ?? null,
+    rank: raw.rank ?? 'unknown',
+    observations_count: raw.observations_count ?? 0,
+    wikipedia_url: raw.wikipedia_url ?? null,
+    wikipedia_summary: stripHtml(raw.wikipedia_summary),
+    iucn_code: iucnCodeOf(raw),
+    establishment_means: establishment,
+    ancestry,
+    family,
+    nearby_count: null,
+  };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const taxonId = Number(id);
+  if (!Number.isFinite(taxonId) || taxonId <= 0) {
+    return NextResponse.json({ error: 'invalid id' }, { status: 400 });
+  }
+
+  const latRaw = request.nextUrl.searchParams.get('lat');
+  const lngRaw = request.nextUrl.searchParams.get('lng');
+
+  let placeId: number | null = null;
+  if (latRaw !== null && lngRaw !== null) {
+    const lat = Number(latRaw);
+    const lng = Number(lngRaw);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+      placeId = await resolvePlaceId(lat, lng);
+    }
+  }
+
+  const upstream = new URL(`https://api.inaturalist.org/v1/taxa/${taxonId}`);
+  if (placeId !== null) upstream.searchParams.set('place_id', String(placeId));
+
+  try {
+    const res = await fetch(upstream.toString(), { headers: { Accept: 'application/json' } });
+    if (!res.ok) {
+      return NextResponse.json({ error: 'unavailable' }, { status: 200 });
+    }
+    const json = (await res.json()) as { results?: INatTaxonDetailRaw[] };
+    const raw = json.results?.[0];
+    if (!raw) {
+      return NextResponse.json({ error: 'unavailable' }, { status: 200 });
+    }
+    return NextResponse.json(toSpeciesDetail(raw), { status: 200 });
+  } catch {
+    return NextResponse.json({ error: 'unavailable' }, { status: 200 });
+  }
+}

--- a/src/app/api/species/__tests__/nearby.test.ts
+++ b/src/app/api/species/__tests__/nearby.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { __resetPlaceIdCacheForTests } from '@/lib/species/place-id-cache';
 
 const originalFetch = globalThis.fetch;
+
+// The nearby route calls resolvePlaceId before the species_counts upstream,
+// so most tests need a place-id fetch mock queued first. Returning an empty
+// results payload yields a null place_id (no state-level match).
+function placeIdEmptyResponse() {
+  return new Response(
+    JSON.stringify({ results: { standard: [], community: [] } }),
+    { status: 200 }
+  );
+}
 
 describe('GET /api/species/nearby', () => {
   beforeEach(() => {
     globalThis.fetch = originalFetch;
+    __resetPlaceIdCacheForTests();
   });
 
   it('rejects requests without lat', async () => {
@@ -30,27 +42,30 @@ describe('GET /api/species/nearby', () => {
   });
 
   it('returns trimmed SpeciesResult array from species_counts response', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          results: [
-            {
-              count: 99,
-              taxon: {
-                id: 7086,
-                name: 'Sialia sialis',
-                preferred_common_name: 'Eastern Bluebird',
-                default_photo: { medium_url: 'https://example.com/bluebird.jpg' },
-                rank: 'species',
-                observations_count: 42000,
-                wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(placeIdEmptyResponse())
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                count: 99,
+                taxon: {
+                  id: 7086,
+                  name: 'Sialia sialis',
+                  preferred_common_name: 'Eastern Bluebird',
+                  default_photo: { medium_url: 'https://example.com/bluebird.jpg' },
+                  rank: 'species',
+                  observations_count: 42000,
+                  wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
+                },
               },
-            },
-          ],
-        }),
-        { status: 200 }
-      )
-    );
+            ],
+          }),
+          { status: 200 }
+        )
+      );
     globalThis.fetch = fetchMock;
 
     const { GET } = await import('../nearby/route');
@@ -63,17 +78,25 @@ describe('GET /api/species/nearby', () => {
     expect(body).toHaveLength(1);
     expect(body[0].id).toBe(7086);
     expect(body[0].common_name).toBe('Eastern Bluebird');
+    expect(body[0].nearby_count).toBe(99);
+    expect(body[0].photo_square_url).toBe(null);
+    expect(body[0].establishment_means).toBe(null);
+    expect(body[0].iucn_code).toBe(null);
 
-    const callUrl = new URL((fetchMock.mock.calls[0] as [string])[0]);
+    // calls[0] is the place-id lookup; calls[1] is the species_counts upstream.
+    const callUrl = new URL((fetchMock.mock.calls[1] as [string])[0]);
     expect(callUrl.searchParams.get('lat')).toBe('42.5');
     expect(callUrl.searchParams.get('lng')).toBe('-73.5');
     expect(callUrl.searchParams.get('radius')).toBe('10');
   });
 
   it('caps radius at 50km', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(
-      new Response(JSON.stringify({ results: [] }), { status: 200 })
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(placeIdEmptyResponse())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ results: [] }), { status: 200 })
+      );
     globalThis.fetch = fetchMock;
 
     const { GET } = await import('../nearby/route');
@@ -82,13 +105,15 @@ describe('GET /api/species/nearby', () => {
     );
     await GET(request);
 
-    const callUrl = new URL((fetchMock.mock.calls[0] as [string])[0]);
+    // calls[0] is the place-id lookup; calls[1] is the species_counts upstream.
+    const callUrl = new URL((fetchMock.mock.calls[1] as [string])[0]);
     expect(callUrl.searchParams.get('radius')).toBe('50');
   });
 
   it('returns empty array on upstream error', async () => {
     globalThis.fetch = vi
       .fn()
+      .mockResolvedValueOnce(placeIdEmptyResponse())
       .mockResolvedValueOnce(new Response('boom', { status: 502 }));
     const { GET } = await import('../nearby/route');
     const request = new NextRequest(

--- a/src/app/api/species/__tests__/search.test.ts
+++ b/src/app/api/species/__tests__/search.test.ts
@@ -48,9 +48,12 @@ describe('GET /api/species/search', () => {
         name: 'Sialia sialis',
         common_name: 'Eastern Bluebird',
         photo_url: 'https://example.com/bluebird.jpg',
+        photo_square_url: null,
         rank: 'species',
         observations_count: 42000,
         wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
+        establishment_means: null,
+        iucn_code: null,
       },
     ]);
   });

--- a/src/app/api/species/__tests__/species-id.test.ts
+++ b/src/app/api/species/__tests__/species-id.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '../[id]/route';
+import { NextRequest } from 'next/server';
+import { __resetPlaceIdCacheForTests } from '@/lib/species/place-id-cache';
+
+function buildRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost'));
+}
+
+function mockINatTaxonResponse(taxon: Record<string, unknown>) {
+  globalThis.fetch = vi.fn().mockImplementation(async (url: RequestInfo) => {
+    const u = typeof url === 'string' ? url : url.toString();
+    if (u.includes('/v1/places/nearby')) {
+      return new Response(
+        JSON.stringify({ results: { standard: [{ id: 54, admin_level: 20, name: 'Vermont' }], community: [] } }),
+        { status: 200 }
+      );
+    }
+    if (u.includes('/v1/taxa/')) {
+      return new Response(JSON.stringify({ results: [taxon] }), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  });
+}
+
+describe('GET /api/species/[id]', () => {
+  beforeEach(() => {
+    __resetPlaceIdCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a SpeciesDetail for a known taxon', async () => {
+    mockINatTaxonResponse({
+      id: 12727,
+      name: 'Sialia sialis',
+      preferred_common_name: 'Eastern Bluebird',
+      rank: 'species',
+      observations_count: 42000,
+      wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
+      wikipedia_summary: '<p>The <i>eastern bluebird</i> is a small thrush.</p>',
+      default_photo: {
+        square_url: 'https://example.com/sq.jpg',
+        medium_url: 'https://example.com/md.jpg',
+        large_url: 'https://example.com/lg.jpg',
+      },
+      conservation_status: { iucn: 10 },
+      ancestors: [
+        { id: 1, name: 'Animalia', rank: 'kingdom' },
+        { id: 2, name: 'Chordata', rank: 'phylum' },
+        { id: 3, name: 'Aves', rank: 'class' },
+        { id: 4, name: 'Passeriformes', rank: 'order' },
+        { id: 5, name: 'Turdidae', rank: 'family' },
+      ],
+    });
+
+    const req = buildRequest('http://localhost/api/species/12727?lat=43.5&lng=-72.6');
+    const res = await GET(req, { params: Promise.resolve({ id: '12727' }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(12727);
+    expect(body.common_name).toBe('Eastern Bluebird');
+    expect(body.photo_large_url).toBe('https://example.com/lg.jpg');
+    expect(body.photo_medium_url).toBe('https://example.com/md.jpg');
+    expect(body.photo_square_url).toBe('https://example.com/sq.jpg');
+    expect(body.iucn_code).toBe('LC');
+    expect(body.wikipedia_summary).toBe('The eastern bluebird is a small thrush.');
+    expect(body.family).toBe('Turdidae');
+    expect(body.ancestry).toEqual([
+      { id: 1, name: 'Animalia', rank: 'kingdom' },
+      { id: 2, name: 'Chordata', rank: 'phylum' },
+      { id: 3, name: 'Aves', rank: 'class' },
+      { id: 4, name: 'Passeriformes', rank: 'order' },
+      { id: 5, name: 'Turdidae', rank: 'family' },
+    ]);
+  });
+
+  it('returns 200 with { error: "unavailable" } when iNat fails', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    const req = buildRequest('http://localhost/api/species/12727');
+    const res = await GET(req, { params: Promise.resolve({ id: '12727' }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'unavailable' });
+  });
+
+  it('passes place_id to the iNat taxon call when lat/lng are given', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: RequestInfo) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/v1/places/nearby')) {
+        return new Response(
+          JSON.stringify({ results: { standard: [{ id: 54, admin_level: 20, name: 'Vermont' }], community: [] } }),
+          { status: 200 }
+        );
+      }
+      return new Response(
+        JSON.stringify({ results: [{ id: 1, name: 'X', rank: 'species' }] }),
+        { status: 200 }
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const req = buildRequest('http://localhost/api/species/1?lat=43.5&lng=-72.6');
+    await GET(req, { params: Promise.resolve({ id: '1' }) });
+
+    const taxonCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).includes('/v1/taxa/1')
+    );
+    expect(taxonCall).toBeDefined();
+    expect(String(taxonCall![0])).toContain('place_id=54');
+  });
+});

--- a/src/app/api/species/nearby/route.ts
+++ b/src/app/api/species/nearby/route.ts
@@ -1,26 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { SpeciesResult } from '@/lib/types';
+import { resolvePlaceId } from '@/lib/species/place-id-cache';
+import { toSpeciesResult, type INatTaxonRaw } from '@/lib/species/inat-projection';
 
-interface INatTaxonRaw {
-  id: number;
-  name: string;
-  preferred_common_name?: string | null;
-  default_photo?: { medium_url?: string | null } | null;
-  rank?: string;
-  observations_count?: number;
-  wikipedia_url?: string | null;
-}
-
-function toSpeciesResult(raw: INatTaxonRaw): SpeciesResult {
-  return {
-    id: raw.id,
-    name: raw.name,
-    common_name: raw.preferred_common_name || raw.name,
-    photo_url: raw.default_photo?.medium_url ?? null,
-    rank: raw.rank ?? 'unknown',
-    observations_count: raw.observations_count ?? 0,
-    wikipedia_url: raw.wikipedia_url ?? null,
-  };
+function toNearbyResult(raw: INatTaxonRaw, nearbyCount: number): SpeciesResult {
+  return { ...toSpeciesResult(raw), nearby_count: nearbyCount };
 }
 
 export async function GET(request: NextRequest) {
@@ -43,6 +27,8 @@ export async function GET(request: NextRequest) {
     ? Math.min(Math.max(requestedRadius, 1), 50)
     : 10;
 
+  const placeId = await resolvePlaceId(lat, lng);
+
   const upstream = new URL(
     'https://api.inaturalist.org/v1/observations/species_counts'
   );
@@ -50,6 +36,7 @@ export async function GET(request: NextRequest) {
   upstream.searchParams.set('lng', String(lng));
   upstream.searchParams.set('radius', String(radius));
   upstream.searchParams.set('per_page', '20');
+  if (placeId !== null) upstream.searchParams.set('place_id', String(placeId));
 
   try {
     const res = await fetch(upstream.toString(), {
@@ -64,12 +51,12 @@ export async function GET(request: NextRequest) {
     }
 
     const json = (await res.json()) as {
-      results?: Array<{ taxon: INatTaxonRaw }>;
+      results?: Array<{ taxon: INatTaxonRaw; count?: number }>;
     };
 
     const results = (json.results ?? [])
       .filter((r) => r.taxon)
-      .map((r) => toSpeciesResult(r.taxon));
+      .map((r) => toNearbyResult(r.taxon, r.count ?? 0));
 
     return NextResponse.json(results, {
       status: 200,

--- a/src/app/api/species/search/route.ts
+++ b/src/app/api/species/search/route.ts
@@ -1,31 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import type { SpeciesResult } from '@/lib/types';
-
-interface INatTaxonRaw {
-  id: number;
-  name: string;
-  preferred_common_name?: string | null;
-  default_photo?: { medium_url?: string | null } | null;
-  rank?: string;
-  observations_count?: number;
-  wikipedia_url?: string | null;
-}
-
-function toSpeciesResult(raw: INatTaxonRaw): SpeciesResult {
-  return {
-    id: raw.id,
-    name: raw.name,
-    common_name: raw.preferred_common_name || raw.name,
-    photo_url: raw.default_photo?.medium_url ?? null,
-    rank: raw.rank ?? 'unknown',
-    observations_count: raw.observations_count ?? 0,
-    wikipedia_url: raw.wikipedia_url ?? null,
-  };
-}
+import { resolvePlaceId } from '@/lib/species/place-id-cache';
+import { toSpeciesResult, type INatTaxonRaw } from '@/lib/species/inat-projection';
 
 export async function GET(request: NextRequest) {
   const q = request.nextUrl.searchParams.get('q');
   const taxonId = request.nextUrl.searchParams.get('taxon_id');
+  const latRaw = request.nextUrl.searchParams.get('lat');
+  const lngRaw = request.nextUrl.searchParams.get('lng');
 
   if (!q || q.trim().length === 0) {
     return NextResponse.json(
@@ -34,10 +15,20 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  let placeId: number | null = null;
+  if (latRaw !== null && lngRaw !== null) {
+    const lat = Number(latRaw);
+    const lng = Number(lngRaw);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+      placeId = await resolvePlaceId(lat, lng);
+    }
+  }
+
   const upstream = new URL('https://api.inaturalist.org/v1/taxa/autocomplete');
   upstream.searchParams.set('q', q);
   upstream.searchParams.set('per_page', '20');
   if (taxonId) upstream.searchParams.set('taxon_id', taxonId);
+  if (placeId !== null) upstream.searchParams.set('place_id', String(placeId));
 
   try {
     const res = await fetch(upstream.toString(), {

--- a/src/components/manage/SpeciesPicker.tsx
+++ b/src/components/manage/SpeciesPicker.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useNetworkStatus } from '@/lib/offline/network';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { createClient } from '@/lib/supabase/client';
+import { useNetworkStatus } from '@/lib/offline/network';
+import { getOfflineDb } from '@/lib/offline/db';
+import { enqueueMutation } from '@/lib/offline/mutations';
 import type { SpeciesResult } from '@/lib/types';
+import SpeciesPill from './species-picker/SpeciesPill';
+import SpeciesPickerSheet from './species-picker/SpeciesPickerSheet';
+import type { SelectedEntitySeed } from './species-picker/staged-selection';
 
 interface SpeciesPickerProps {
   entityTypeId: string;
@@ -15,10 +20,22 @@ interface SpeciesPickerProps {
   lng?: number;
 }
 
-interface SelectedEntity {
+interface SelectedEntityRow {
+  id: string;
+  name: string;
+  description: string | null;
+  external_id: string | null;
+  custom_field_values: Record<string, unknown> | null;
+}
+
+interface PillEntity {
   id: string;
   name: string;
   photo_url: string | null;
+  photo_square_url: string | null;
+  taxonId: number | null;
+  scientific: string | null;
+  wikipedia_url: string | null;
 }
 
 export default function SpeciesPicker({
@@ -31,63 +48,8 @@ export default function SpeciesPicker({
   lng,
 }: SpeciesPickerProps) {
   const { isOnline } = useNetworkStatus();
-  const [query, setQuery] = useState('');
-  const [isFocused, setIsFocused] = useState(false);
-  const [nearby, setNearby] = useState<SpeciesResult[]>([]);
-  const [nearbyLoading, setNearbyLoading] = useState(false);
-  const [results, setResults] = useState<SpeciesResult[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [selectedEntities, setSelectedEntities] = useState<SelectedEntity[]>([]);
-
-  useEffect(() => {
-    if (!isFocused) return;
-    if (lat === undefined || lng === undefined) return;
-    if (!isOnline) return;
-
-    let cancelled = false;
-    setNearbyLoading(true);
-    fetch(`/api/species/nearby?lat=${lat}&lng=${lng}`)
-      .then((r) => (r.ok ? r.json() : []))
-      .then((json: SpeciesResult[]) => {
-        if (!cancelled) setNearby(Array.isArray(json) ? json : []);
-      })
-      .catch(() => {
-        if (!cancelled) setNearby([]);
-      })
-      .finally(() => {
-        if (!cancelled) setNearbyLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isFocused, lat, lng, isOnline]);
-
-  useEffect(() => {
-    const trimmed = query.trim();
-    if (trimmed.length === 0) {
-      setResults([]);
-      return;
-    }
-    if (!isOnline) return;
-
-    const handle = setTimeout(async () => {
-      setSearchLoading(true);
-      try {
-        const res = await fetch(
-          `/api/species/search?q=${encodeURIComponent(trimmed)}`
-        );
-        const json = res.ok ? await res.json() : [];
-        setResults(Array.isArray(json) ? json : []);
-      } catch {
-        setResults([]);
-      } finally {
-        setSearchLoading(false);
-      }
-    }, 300);
-
-    return () => clearTimeout(handle);
-  }, [query, isOnline]);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [selectedEntities, setSelectedEntities] = useState<PillEntity[]>([]);
 
   useEffect(() => {
     if (selectedIds.length === 0) {
@@ -96,195 +58,204 @@ export default function SpeciesPicker({
     }
 
     let cancelled = false;
-    const fetchEntities = async () => {
+    const run = async () => {
       const supabase = createClient();
       const { data } = await supabase
         .from('entities')
-        .select('id, name, custom_field_values')
+        .select('id, name, description, external_id, custom_field_values')
         .in('id', selectedIds);
 
       if (cancelled) return;
-      const rows = (data ?? []) as Array<{
-        id: string;
-        name: string;
-        custom_field_values: Record<string, unknown>;
-      }>;
-      const mapped: SelectedEntity[] = selectedIds.map((sid) => {
+      const rows = (data ?? []) as SelectedEntityRow[];
+      const mapped: PillEntity[] = selectedIds.map((sid) => {
         const row = rows.find((r) => r.id === sid);
-        const photo =
-          row && typeof row.custom_field_values?.photo_url === 'string'
-            ? (row.custom_field_values.photo_url as string)
+        const cfv = row?.custom_field_values ?? {};
+        const photoUrl =
+          typeof cfv.photo_url === 'string' ? (cfv.photo_url as string) : null;
+        const photoSquare =
+          typeof cfv.photo_square_url === 'string'
+            ? (cfv.photo_square_url as string)
             : null;
+        const taxonId = row?.external_id ? Number(row.external_id) : null;
+        const scientific =
+          typeof cfv.scientific_name === 'string'
+            ? (cfv.scientific_name as string)
+            : row?.description ?? null;
+        const wikipedia_url =
+          typeof cfv.wikipedia_url === 'string' ? (cfv.wikipedia_url as string) : null;
         return {
           id: sid,
           name: row?.name ?? 'Unknown',
-          photo_url: photo,
+          photo_url: photoUrl,
+          photo_square_url: photoSquare,
+          taxonId: taxonId !== null && Number.isFinite(taxonId) ? taxonId : null,
+          scientific,
+          wikipedia_url,
         };
       });
       setSelectedEntities(mapped);
     };
 
-    fetchEntities();
-
+    void run();
     return () => {
       cancelled = true;
     };
   }, [selectedIds]);
 
-  function removeSelected(id: string) {
-    onChange(selectedIds.filter((sid) => sid !== id));
-  }
+  const seeds: SelectedEntitySeed[] = useMemo(() => {
+    return selectedEntities
+      .filter((e): e is PillEntity & { taxonId: number } => e.taxonId !== null)
+      .map((e) => ({
+        entityId: e.id,
+        taxonId: e.taxonId,
+        card: {
+          id: e.taxonId,
+          name: e.scientific ?? e.name,
+          common_name: e.name,
+          photo_url: e.photo_url,
+          photo_square_url: e.photo_square_url,
+          rank: 'species',
+          observations_count: 0,
+          wikipedia_url: e.wikipedia_url,
+        } satisfies SpeciesResult,
+      }));
+  }, [selectedEntities]);
 
-  const showNearby = isFocused && query.trim().length === 0 && nearby.length > 0;
-  const showEmptyState =
-    isFocused && query.trim().length === 0 && nearby.length === 0 && !nearbyLoading;
+  const handleRemove = useCallback(
+    (entityId: string) => {
+      onChange(selectedIds.filter((id) => id !== entityId));
+    },
+    [onChange, selectedIds]
+  );
 
-  async function handleSelect(species: SpeciesResult) {
-    const supabase = createClient();
-    const externalId = String(species.id);
+  const handleCommit = useCallback(
+    async (plan: { newTaxa: SpeciesResult[]; keptEntityIds: string[] }) => {
+      const newEntityIds: string[] = [];
 
-    const { data: existing } = await supabase
-      .from('entities')
-      .select('id')
-      .eq('entity_type_id', entityTypeId)
-      .eq('external_id', externalId)
-      .maybeSingle();
+      if (plan.newTaxa.length === 0) {
+        onChange(plan.keptEntityIds);
+        return;
+      }
 
-    let entityId: string | null = existing?.id ?? null;
+      if (isOnline) {
+        const supabase = createClient();
+        for (const card of plan.newTaxa) {
+          const externalId = String(card.id);
+          const { data: existing } = await supabase
+            .from('entities')
+            .select('id')
+            .eq('entity_type_id', entityTypeId)
+            .eq('external_id', externalId)
+            .maybeSingle();
 
-    if (!entityId) {
-      const { data: inserted, error } = await supabase
-        .from('entities')
-        .insert({
-          entity_type_id: entityTypeId,
-          org_id: orgId,
-          name: species.common_name,
-          description: species.name,
-          external_id: externalId,
-          photo_path: null,
-          custom_field_values: {
-            scientific_name: species.name,
-            photo_url: species.photo_url,
-            wikipedia_url: species.wikipedia_url,
-            observations_count: species.observations_count,
-          },
-        })
-        .select('id')
-        .single();
+          let entityId: string | null = existing?.id ?? null;
+          if (!entityId) {
+            const { data: inserted, error } = await supabase
+              .from('entities')
+              .insert({
+                entity_type_id: entityTypeId,
+                org_id: orgId,
+                name: card.common_name,
+                description: card.name,
+                external_id: externalId,
+                photo_path: null,
+                custom_field_values: {
+                  scientific_name: card.name,
+                  photo_url: card.photo_url,
+                  photo_square_url: card.photo_square_url,
+                  wikipedia_url: card.wikipedia_url,
+                  observations_count: card.observations_count,
+                },
+              })
+              .select('id')
+              .single();
+            if (error || !inserted) continue;
+            entityId = inserted.id;
+          }
+          if (entityId) newEntityIds.push(entityId);
+        }
+      } else {
+        // Offline: local write + enqueue mutation.
+        const db = getOfflineDb();
+        for (const card of plan.newTaxa) {
+          const id = crypto.randomUUID();
+          const externalId = String(card.id);
+          const payload = {
+            id,
+            entity_type_id: entityTypeId,
+            org_id: orgId,
+            name: card.common_name,
+            description: card.name,
+            external_id: externalId,
+            photo_path: null,
+            custom_field_values: {
+              scientific_name: card.name,
+              photo_url: card.photo_url,
+              photo_square_url: card.photo_square_url,
+              wikipedia_url: card.wikipedia_url,
+              observations_count: card.observations_count,
+            },
+          };
+          const nowIso = new Date().toISOString();
+          await db.entities.put({
+            ...payload,
+            external_link: null,
+            sort_order: 0,
+            created_at: nowIso,
+            updated_at: nowIso,
+            _synced_at: '',
+          });
+          await enqueueMutation(db, {
+            table: 'entities',
+            operation: 'insert',
+            record_id: id,
+            payload,
+            org_id: orgId,
+            property_id: '',
+          });
+          newEntityIds.push(id);
+        }
+      }
 
-      if (error || !inserted) return;
-      entityId = inserted.id;
-    }
-
-    if (entityId && !selectedIds.includes(entityId)) {
-      onChange([...selectedIds, entityId]);
-    }
-    setQuery('');
-    setIsFocused(false);
-  }
+      onChange([...plan.keptEntityIds, ...newEntityIds]);
+    },
+    [entityTypeId, orgId, isOnline, onChange]
+  );
 
   return (
     <div>
       {selectedEntities.length > 0 && (
-        <div className="flex flex-wrap gap-1 mb-2">
-          {selectedEntities.map((se) => (
-            <span
-              key={se.id}
-              className="inline-flex items-center gap-1.5 bg-forest/10 text-forest-dark text-xs px-2 py-1 rounded-full"
-            >
-              {se.photo_url && (
-                <img
-                  src={se.photo_url}
-                  alt=""
-                  className="w-5 h-5 rounded-full object-cover"
-                />
-              )}
-              {se.name}
-              <button
-                type="button"
-                aria-label={`Remove ${se.name}`}
-                onClick={() => removeSelected(se.id)}
-                className="hover:text-red-600"
-              >
-                &times;
-              </button>
-            </span>
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {selectedEntities.map((e) => (
+            <SpeciesPill
+              key={e.id}
+              name={e.name}
+              photoUrl={e.photo_square_url ?? e.photo_url}
+              onRemove={() => handleRemove(e.id)}
+            />
           ))}
         </div>
       )}
 
-      <div className="relative">
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setTimeout(() => setIsFocused(false), 150)}
-          placeholder={`Search ${entityTypeName.toLowerCase()}...`}
-          className="input-field"
-          disabled={!isOnline}
-        />
+      <button
+        type="button"
+        onClick={() => setSheetOpen(true)}
+        className="btn-secondary w-full justify-center"
+      >
+        Add {entityTypeName.toLowerCase()}
+      </button>
 
-        {!isOnline && (
-          <p className="text-xs text-sage mt-1">
-            Search requires internet connection.
-          </p>
-        )}
-
-        {isFocused && query.trim().length > 0 && (
-          <div className="absolute z-10 mt-1 w-full max-h-72 overflow-y-auto bg-white border border-sage-light rounded-lg shadow-lg">
-            {searchLoading && (
-              <div className="px-3 py-2 text-xs text-sage">Searching...</div>
-            )}
-            {!searchLoading && results.length === 0 && (
-              <div className="px-3 py-2 text-xs text-sage">No matches.</div>
-            )}
-            {results.map((s) => (
-              <button
-                type="button"
-                key={s.id}
-                onClick={() => void handleSelect(s)}
-                className="w-full text-left px-3 py-2 text-sm text-forest-dark hover:bg-sage-light"
-              >
-                <div className="font-medium">{s.common_name}</div>
-                <div className="text-xs italic text-sage">
-                  {s.name}
-                  {s.observations_count > 0 && (
-                    <span className="not-italic ml-2 text-[10px]">
-                      ({s.observations_count.toLocaleString()} observations)
-                    </span>
-                  )}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
-
-        {showNearby && (
-          <div className="absolute z-10 mt-1 w-full max-h-72 overflow-y-auto bg-white border border-sage-light rounded-lg shadow-lg">
-            <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-sage border-b border-sage-light">
-              Recently seen nearby
-            </div>
-            {nearby.map((s) => (
-              <button
-                type="button"
-                key={s.id}
-                onClick={() => void handleSelect(s)}
-                className="w-full text-left px-3 py-2 text-sm text-forest-dark hover:bg-sage-light"
-              >
-                <div className="font-medium">{s.common_name}</div>
-                <div className="text-xs italic text-sage">{s.name}</div>
-              </button>
-            ))}
-          </div>
-        )}
-
-        {showEmptyState && (
-          <div className="absolute z-10 mt-1 w-full bg-white border border-sage-light rounded-lg shadow-lg px-3 py-2 text-xs text-sage">
-            Type to search species...
-          </div>
-        )}
-      </div>
+      <SpeciesPickerSheet
+        isOpen={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        orgId={orgId}
+        entityTypeId={entityTypeId}
+        entityTypeName={entityTypeName}
+        lat={lat}
+        lng={lng}
+        seeds={seeds}
+        onCommit={handleCommit}
+      />
     </div>
   );
 }

--- a/src/components/manage/__tests__/SpeciesPicker.test.tsx
+++ b/src/components/manage/__tests__/SpeciesPicker.test.tsx
@@ -1,336 +1,419 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SpeciesPicker from '@/components/manage/SpeciesPicker';
+
+let mockIsOnline = true;
+
+// Framer-motion stub so sheet content renders immediately in JSDOM.
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, style, animate, initial, exit, transition, ...props }: any) => (
+      <div
+        {...props}
+        style={{
+          ...style,
+          ...(animate && typeof animate === 'object' ? animate : {}),
+        }}
+      >
+        {children}
+      </div>
+    ),
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}));
+
+// JSDOM lacks ResizeObserver; MultiSnapBottomSheet requires it.
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
 
 vi.mock('@/lib/offline/network', () => ({
   useNetworkStatus: () => ({ isOnline: mockIsOnline }),
 }));
 
-vi.mock('@/lib/supabase/client', () => ({
-  createClient: () => ({
-    from: vi.fn(),
-    storage: { from: vi.fn() },
+vi.mock('@/lib/location/provider', () => ({
+  useUserLocation: () => ({
+    position: null,
+    accuracy: null,
+    heading: null,
+    error: null,
+    isTracking: false,
+    startTracking: () => {},
   }),
 }));
 
-let mockIsOnline = true;
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => supabaseMock,
+}));
+
+vi.mock('@/lib/offline/db', () => ({
+  getOfflineDb: () => (getOfflineDbMock as (...args: unknown[]) => unknown)(),
+}));
+
+vi.mock('@/lib/offline/mutations', () => ({
+  enqueueMutation: (...args: unknown[]) =>
+    (enqueueMutationMock as (...args: unknown[]) => unknown)(...args),
+}));
+
+let supabaseMock: {
+  from: ReturnType<typeof vi.fn>;
+  storage: { from: ReturnType<typeof vi.fn> };
+};
+let getOfflineDbMock: ReturnType<typeof vi.fn>;
+let enqueueMutationMock: ReturnType<typeof vi.fn>;
 
 const baseProps = {
   entityTypeId: 'et-species',
   entityTypeName: 'Species',
   orgId: 'org-1',
-  selectedIds: [],
+  selectedIds: [] as string[],
   onChange: vi.fn(),
 };
 
-describe('SpeciesPicker (skeleton)', () => {
+function speciesJson(species: unknown[]) {
+  return new Response(JSON.stringify(species), { status: 200 });
+}
+
+function detailJson(detail: Record<string, unknown>) {
+  return new Response(JSON.stringify(detail), { status: 200 });
+}
+
+// Supabase mock that handles both the pill loader (.select().in()) and
+// the recent-species loader (.select().eq().eq().order().limit()), plus
+// the picker's dedup check (.select().eq().eq().maybeSingle()) and inserts.
+function makeFlexibleSupabase(opts: {
+  pills?: unknown[];
+  recent?: unknown[];
+  existingById?: { id: string } | null;
+  insertResult?: { id: string };
+}) {
+  const pillIn = vi.fn().mockResolvedValue({ data: opts.pills ?? [], error: null });
+  const recentLimit = vi.fn().mockResolvedValue({ data: opts.recent ?? [], error: null });
+  const recentOrder = vi.fn().mockReturnValue({ limit: recentLimit });
+  const maybeSingle = vi
+    .fn()
+    .mockResolvedValue({ data: opts.existingById ?? null, error: null });
+  const insertSingle = vi
+    .fn()
+    .mockResolvedValue({ data: opts.insertResult ?? null, error: null });
+  const insertSelect = vi.fn().mockReturnValue({ single: insertSingle });
+  const insert = vi.fn().mockReturnValue({ select: insertSelect });
+
+  const selectChain = () => ({
+    in: pillIn,
+    eq: (..._a: unknown[]) => ({
+      eq: (..._b: unknown[]) => ({
+        maybeSingle,
+        order: recentOrder,
+      }),
+    }),
+  });
+
+  const from = vi.fn().mockImplementation(() => ({
+    select: (..._a: unknown[]) => selectChain(),
+    insert,
+  }));
+
+  supabaseMock = {
+    from,
+    storage: { from: vi.fn() },
+  };
+
+  return { pillIn, recentLimit, maybeSingle, insert, insertSingle };
+}
+
+describe('SpeciesPicker (trigger + sheet)', () => {
   beforeEach(() => {
     mockIsOnline = true;
     vi.clearAllMocks();
-    globalThis.fetch = vi.fn();
+    globalThis.fetch = vi.fn().mockResolvedValue(speciesJson([]));
+    makeFlexibleSupabase({});
+    getOfflineDbMock = vi.fn();
+    enqueueMutationMock = vi.fn();
   });
 
-  it('shows the search input', () => {
-    render(<SpeciesPicker {...baseProps} />);
-    expect(screen.getByPlaceholderText(/search species/i)).toBeInTheDocument();
-  });
-
-  it('shows offline notice when navigator is offline', () => {
-    mockIsOnline = false;
+  it('renders the trigger button with the entity type name', () => {
     render(<SpeciesPicker {...baseProps} />);
     expect(
-      screen.getByText(/search requires internet connection/i)
+      screen.getByRole('button', { name: /add species/i })
     ).toBeInTheDocument();
   });
 
-  it('fetches nearby species when focused with coordinates', async () => {
-    const nearbyMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          {
-            id: 1,
-            name: 'Sialia sialis',
-            common_name: 'Eastern Bluebird',
-            photo_url: null,
-            rank: 'species',
-            observations_count: 1,
-            wikipedia_url: null,
-          },
-        ]),
-        { status: 200 }
-      )
-    );
-    globalThis.fetch = nearbyMock;
-
-    const user = userEvent.setup();
-    render(<SpeciesPicker {...baseProps} lat={42.5} lng={-73.5} />);
-
-    await user.click(screen.getByPlaceholderText(/search species/i));
-
-    await waitFor(() =>
-      expect(screen.getByText(/recently seen nearby/i)).toBeInTheDocument()
-    );
-    expect(screen.getByText('Eastern Bluebird')).toBeInTheDocument();
-
-    const called = new URL((nearbyMock.mock.calls[0] as [string])[0], 'http://localhost');
-    expect(called.pathname).toBe('/api/species/nearby');
-    expect(called.searchParams.get('lat')).toBe('42.5');
-    expect(called.searchParams.get('lng')).toBe('-73.5');
-  });
-
-  it('does not fetch nearby when coordinates are missing', async () => {
-    const fetchMock = vi.fn();
-    globalThis.fetch = fetchMock;
-
+  it('opens the sheet when the trigger is clicked', async () => {
     const user = userEvent.setup();
     render(<SpeciesPicker {...baseProps} />);
-    await user.click(screen.getByPlaceholderText(/search species/i));
+    await user.click(screen.getByRole('button', { name: /add species/i }));
+    expect(screen.getByRole('tab', { name: /recent/i })).toBeInTheDocument();
+  });
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(screen.getByText(/type to search species/i)).toBeInTheDocument();
+  it('shows offline banner inside the sheet when offline', async () => {
+    mockIsOnline = false;
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
+    expect(
+      screen.getByText(/search requires internet connection/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /all/i })).toBeDisabled();
+  });
+
+  it('disables the search input when offline', async () => {
+    mockIsOnline = false;
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
+    expect(screen.getByPlaceholderText(/search species/i)).toBeDisabled();
   });
 });
 
-describe('SpeciesPicker (search)', () => {
+describe('SpeciesPicker (grid + detail flow)', () => {
   beforeEach(() => {
     mockIsOnline = true;
     vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+    makeFlexibleSupabase({});
+    getOfflineDbMock = vi.fn();
+    enqueueMutationMock = vi.fn();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+  const bluebirdCard = {
+    id: 12727,
+    name: 'Sialia sialis',
+    common_name: 'Eastern Bluebird',
+    photo_url: 'https://example.com/md.jpg',
+    photo_square_url: 'https://example.com/sq.jpg',
+    rank: 'species',
+    observations_count: 42000,
+    wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
+    nearby_count: 17,
+    establishment_means: 'native',
+    iucn_code: 'LC',
+  };
 
-  function searchResponse(items: unknown[]) {
-    return new Response(JSON.stringify(items), { status: 200 });
-  }
+  const starlingCard = {
+    id: 13858,
+    name: 'Sturnus vulgaris',
+    common_name: 'European Starling',
+    photo_url: 'https://example.com/st.jpg',
+    photo_square_url: null,
+    rank: 'species',
+    observations_count: 1,
+    wikipedia_url: null,
+    nearby_count: 3,
+    establishment_means: 'introduced',
+    iucn_code: 'LC',
+  };
 
-  it('debounces search by 300ms before calling /api/species/search', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(searchResponse([
-        {
-          id: 7086,
-          name: 'Sialia sialis',
-          common_name: 'Eastern Bluebird',
-          photo_url: null,
-          rank: 'species',
-          observations_count: 42000,
-          wikipedia_url: null,
-        },
-      ]));
+  it('uses lat/lng to fetch nearby and renders cards with introduced pill', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: RequestInfo) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/api/species/nearby')) {
+        return speciesJson([bluebirdCard, starlingCard]);
+      }
+      return speciesJson([]);
+    });
     globalThis.fetch = fetchMock;
 
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<SpeciesPicker {...baseProps} />);
-
-    const input = screen.getByPlaceholderText(/search species/i);
-    await user.type(input, 'blue');
-
-    // Before 300ms, no search call fired
-    expect(
-      fetchMock.mock.calls.filter((c) =>
-        String(c[0]).includes('/api/species/search')
-      )
-    ).toHaveLength(0);
-
-    vi.advanceTimersByTime(320);
-
-    await waitFor(() => {
-      const searchCalls = fetchMock.mock.calls.filter((c) =>
-        String(c[0]).includes('/api/species/search')
-      );
-      expect(searchCalls).toHaveLength(1);
-      expect(String(searchCalls[0][0])).toContain('q=blue');
-    });
-  });
-
-  it('renders search results replacing nearby list', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      searchResponse([
-        {
-          id: 1,
-          name: 'Sialia sialis',
-          common_name: 'Eastern Bluebird',
-          photo_url: 'https://example.com/bluebird.jpg',
-          rank: 'species',
-          observations_count: 99,
-          wikipedia_url: null,
-        },
-      ])
-    );
-
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<SpeciesPicker {...baseProps} />);
-
-    const input = screen.getByPlaceholderText(/search species/i);
-    await user.type(input, 'bluebird');
-    vi.advanceTimersByTime(320);
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} lat={43.5} lng={-72.6} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
 
     await waitFor(() =>
       expect(screen.getByText('Eastern Bluebird')).toBeInTheDocument()
     );
-    expect(screen.getByText('Sialia sialis')).toBeInTheDocument();
-    expect(screen.queryByText(/recently seen nearby/i)).not.toBeInTheDocument();
-  });
-});
-
-describe('SpeciesPicker (selection)', () => {
-  beforeEach(() => {
-    mockIsOnline = true;
-    vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+    expect(screen.getByText('European Starling')).toBeInTheDocument();
+    expect(screen.getAllByTestId('introduced-pill')).toHaveLength(1);
+    const nearbyCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).includes('/api/species/nearby')
+    );
+    expect(String(nearbyCall![0])).toContain('lat=43.5');
+    expect(String(nearbyCall![0])).toContain('lng=-72.6');
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  it('Native filter hides introduced cards and keeps unknown-status cards visible', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: RequestInfo) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/api/species/nearby')) {
+        return speciesJson([
+          bluebirdCard,
+          starlingCard,
+          { ...bluebirdCard, id: 99999, common_name: 'Unknown Status', establishment_means: null },
+        ]);
+      }
+      return speciesJson([]);
+    });
+
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} lat={43.5} lng={-72.6} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
+    await waitFor(() =>
+      expect(screen.getByText('European Starling')).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /^native$/i }));
+    expect(screen.queryByText('European Starling')).not.toBeInTheDocument();
+    expect(screen.getByText('Eastern Bluebird')).toBeInTheDocument();
+    expect(screen.getByText('Unknown Status')).toBeInTheDocument();
   });
 
-  const speciesRow = {
-    id: 7086,
-    name: 'Sialia sialis',
-    common_name: 'Eastern Bluebird',
-    photo_url: 'https://example.com/bluebird.jpg',
-    rank: 'species',
-    observations_count: 42000,
-    wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
-  };
+  it('tapping a card opens detail and CTA toggles staged', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: RequestInfo) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/api/species/nearby')) return speciesJson([bluebirdCard]);
+      if (u.includes('/api/species/12727')) {
+        return detailJson({
+          id: 12727,
+          name: 'Sialia sialis',
+          common_name: 'Eastern Bluebird',
+          photo_square_url: 'https://example.com/sq.jpg',
+          photo_medium_url: 'https://example.com/md.jpg',
+          photo_large_url: 'https://example.com/lg.jpg',
+          rank: 'species',
+          observations_count: 42000,
+          wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
+          wikipedia_summary: 'A small thrush.',
+          iucn_code: 'LC',
+          establishment_means: 'native',
+          ancestry: [{ id: 1, name: 'Turdidae', rank: 'family' }],
+          family: 'Turdidae',
+          nearby_count: null,
+        });
+      }
+      return speciesJson([]);
+    });
 
-  function searchResponse(items: unknown[]) {
-    return new Response(JSON.stringify(items), { status: 200 });
-  }
-
-  it('links to existing entity when external_id matches', async () => {
-    globalThis.fetch = vi
-      .fn()
-      .mockResolvedValue(searchResponse([speciesRow]));
-
-    // supabase.from('entities').select(...).eq('entity_type_id', ...).eq('external_id', '7086')
-    //   .maybeSingle() → returns existing row
-    const existingRow = { id: 'existing-entity-id' };
-    const maybeSingle = vi.fn().mockResolvedValue({ data: existingRow, error: null });
-    const eq2 = vi.fn().mockReturnValue({ maybeSingle });
-    const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
-    const select = vi.fn().mockReturnValue({ eq: eq1 });
-    const insert = vi.fn();
-    const from = vi.fn().mockReturnValue({ select, insert });
-
-    const supabaseModule = await import('@/lib/supabase/client');
-    vi.spyOn(supabaseModule, 'createClient').mockReturnValue({
-      from,
-      storage: { from: vi.fn() },
-    } as unknown as ReturnType<typeof supabaseModule.createClient>);
-
-    const onChange = vi.fn();
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<SpeciesPicker {...baseProps} onChange={onChange} />);
-
-    await user.type(screen.getByPlaceholderText(/search species/i), 'blue');
-    vi.advanceTimersByTime(320);
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} lat={43.5} lng={-72.6} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
     await waitFor(() => screen.getByText('Eastern Bluebird'));
 
-    await user.click(screen.getByText('Eastern Bluebird'));
+    await user.click(screen.getByRole('button', { name: /view details for eastern bluebird/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/a small thrush/i)).toBeInTheDocument()
+    );
 
-    expect(insert).not.toHaveBeenCalled();
-    expect(onChange).toHaveBeenCalledWith(['existing-entity-id']);
+    const addButton = screen.getByRole('button', { name: /add to this update/i });
+    await user.click(addButton);
+    expect(
+      screen.getByRole('button', { name: /remove from this update/i })
+    ).toBeInTheDocument();
   });
 
-  it('inserts a new entity when external_id does not exist', async () => {
-    globalThis.fetch = vi
-      .fn()
-      .mockResolvedValue(searchResponse([speciesRow]));
+  it('pressing Done after adding a new taxon inserts one entity and calls onChange once', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: RequestInfo) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/api/species/nearby')) return speciesJson([bluebirdCard]);
+      if (u.includes('/api/species/12727')) {
+        return detailJson({
+          id: 12727,
+          name: 'Sialia sialis',
+          common_name: 'Eastern Bluebird',
+          photo_square_url: null,
+          photo_medium_url: null,
+          photo_large_url: null,
+          rank: 'species',
+          observations_count: 0,
+          wikipedia_url: null,
+          wikipedia_summary: null,
+          iucn_code: null,
+          establishment_means: 'native',
+          ancestry: [],
+          family: null,
+          nearby_count: null,
+        });
+      }
+      return speciesJson([]);
+    });
 
-    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
-    const eq2 = vi.fn().mockReturnValue({ maybeSingle });
-    const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
-    const select = vi.fn().mockReturnValue({ eq: eq1 });
-
-    const insertSingle = vi
-      .fn()
-      .mockResolvedValue({ data: { id: 'new-entity-id' }, error: null });
-    const insertSelect = vi.fn().mockReturnValue({ single: insertSingle });
-    const insert = vi.fn().mockReturnValue({ select: insertSelect });
-
-    const from = vi.fn().mockReturnValue({ select, insert });
-
-    const supabaseModule = await import('@/lib/supabase/client');
-    vi.spyOn(supabaseModule, 'createClient').mockReturnValue({
-      from,
-      storage: { from: vi.fn() },
-    } as unknown as ReturnType<typeof supabaseModule.createClient>);
+    const { insert } = makeFlexibleSupabase({
+      existingById: null,
+      insertResult: { id: 'new-entity-id' },
+    });
 
     const onChange = vi.fn();
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<SpeciesPicker {...baseProps} onChange={onChange} />);
-
-    await user.type(screen.getByPlaceholderText(/search species/i), 'blue');
-    vi.advanceTimersByTime(320);
+    const user = userEvent.setup();
+    render(
+      <SpeciesPicker {...baseProps} onChange={onChange} lat={43.5} lng={-72.6} />
+    );
+    await user.click(screen.getByRole('button', { name: /add species/i }));
     await waitFor(() => screen.getByText('Eastern Bluebird'));
 
-    await user.click(screen.getByText('Eastern Bluebird'));
+    await user.click(screen.getByRole('button', { name: /view details for eastern bluebird/i }));
+    await waitFor(() => screen.getByRole('button', { name: /add to this update/i }));
+    await user.click(screen.getByRole('button', { name: /add to this update/i }));
+    await user.click(screen.getByRole('button', { name: /^done$/i }));
 
     await waitFor(() => expect(insert).toHaveBeenCalledTimes(1));
-    const insertedRow = insert.mock.calls[0][0];
-    expect(insertedRow).toMatchObject({
+    const inserted = insert.mock.calls[0][0];
+    expect(inserted).toMatchObject({
       entity_type_id: 'et-species',
       org_id: 'org-1',
       name: 'Eastern Bluebird',
       description: 'Sialia sialis',
-      external_id: '7086',
+      external_id: '12727',
     });
-    expect(insertedRow.custom_field_values).toMatchObject({
-      scientific_name: 'Sialia sialis',
-      photo_url: 'https://example.com/bluebird.jpg',
-      wikipedia_url: 'https://en.wikipedia.org/wiki/Eastern_bluebird',
-      observations_count: 42000,
-    });
+    expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(['new-entity-id']);
+  });
+
+  it('pressing Done offline with no staged changes calls onChange once with empty kept ids', async () => {
+    mockIsOnline = false;
+    globalThis.fetch = vi.fn().mockResolvedValue(speciesJson([]));
+
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
+    await user.click(screen.getByRole('button', { name: /^done$/i }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('canceling the sheet (close button) does not call onChange', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<SpeciesPicker {...baseProps} onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /add species/i }));
+    await user.click(screen.getByRole('button', { name: /close species picker/i }));
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 
-describe('SpeciesPicker (chips)', () => {
+describe('SpeciesPicker (pills)', () => {
   beforeEach(() => {
     mockIsOnline = true;
     vi.clearAllMocks();
+    getOfflineDbMock = vi.fn();
+    enqueueMutationMock = vi.fn();
   });
 
-  it('renders chip for each selected entity with name and remove button', async () => {
-    const inFn = vi.fn().mockResolvedValue({
-      data: [
+  it('renders a pill for each selected entity and allows × removal', async () => {
+    makeFlexibleSupabase({
+      pills: [
         {
           id: 'e1',
           name: 'Eastern Bluebird',
           description: 'Sialia sialis',
+          external_id: '12727',
           custom_field_values: { photo_url: 'https://example.com/b.jpg' },
         },
       ],
-      error: null,
     });
-    const select = vi.fn().mockReturnValue({ in: inFn });
-    const from = vi.fn().mockReturnValue({ select });
-
-    const supabaseModule = await import('@/lib/supabase/client');
-    vi.spyOn(supabaseModule, 'createClient').mockReturnValue({
-      from,
-      storage: { from: vi.fn() },
-    } as unknown as ReturnType<typeof supabaseModule.createClient>);
 
     const onChange = vi.fn();
     render(
-      <SpeciesPicker
-        {...baseProps}
-        selectedIds={['e1']}
-        onChange={onChange}
-      />
+      <SpeciesPicker {...baseProps} selectedIds={['e1']} onChange={onChange} />
     );
-
     await waitFor(() =>
       expect(screen.getByText('Eastern Bluebird')).toBeInTheDocument()
     );
-
-    const removeBtn = screen.getByRole('button', { name: /remove eastern bluebird/i });
+    const removeBtn = screen.getByRole('button', {
+      name: /remove eastern bluebird/i,
+    });
     const user = userEvent.setup();
     await user.click(removeBtn);
     expect(onChange).toHaveBeenCalledWith([]);

--- a/src/components/manage/species-picker/SpeciesCard.tsx
+++ b/src/components/manage/species-picker/SpeciesCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import type { SpeciesResult } from '@/lib/types';
+import { isCavityNester } from '@/lib/species/cavity-nesters';
+
+interface SpeciesCardProps {
+  card: SpeciesResult;
+  selected: boolean;
+  onTap: () => void;
+}
+
+export default function SpeciesCard({ card, selected, onTap }: SpeciesCardProps): ReactElement {
+  const showIntroduced = card.establishment_means === 'introduced';
+  const showCavityBadge = isCavityNester(card.id);
+
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      aria-pressed={selected}
+      aria-label={`View details for ${card.common_name}`}
+      className={[
+        'relative block w-full overflow-hidden rounded-xl bg-white text-left transition-shadow',
+        selected
+          ? 'ring-[3px] ring-[var(--color-primary)] shadow-md'
+          : 'ring-1 ring-sage-light shadow-sm hover:shadow-md',
+      ].join(' ')}
+    >
+      <div className="relative aspect-[16/10] bg-sage-light">
+        {card.photo_url ? (
+          <img
+            src={card.photo_url}
+            alt=""
+            className="h-full w-full object-cover"
+          />
+        ) : null}
+        {showIntroduced && (
+          <span
+            className="absolute left-2 top-2 rounded-full bg-[var(--color-accent)] px-2 py-0.5 text-[10px] font-medium text-forest-dark"
+            data-testid="introduced-pill"
+          >
+            Introduced
+          </span>
+        )}
+        {selected && (
+          <span
+            aria-hidden
+            className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-[var(--color-primary)] text-xs font-bold text-white"
+            data-testid="selected-check"
+          >
+            ✓
+          </span>
+        )}
+      </div>
+      <div className="p-3">
+        <div className="font-heading text-sm font-semibold text-forest-dark">
+          {card.common_name}
+        </div>
+        <div className="italic text-xs text-sage">{card.name}</div>
+        {typeof card.nearby_count === 'number' && card.nearby_count > 0 && (
+          <div className="mt-1 text-[11px] text-forest">
+            {card.nearby_count.toLocaleString()} nearby
+          </div>
+        )}
+        {showCavityBadge && (
+          <div className="mt-1 text-[10px] uppercase tracking-wide text-sage">
+            Cavity nester
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/components/manage/species-picker/SpeciesPickerDetail.tsx
+++ b/src/components/manage/species-picker/SpeciesPickerDetail.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import type { SpeciesDetail, SpeciesResult } from '@/lib/types';
+import { isCavityNester } from '@/lib/species/cavity-nesters';
+import { useSpeciesDetail } from './useSpeciesDetail';
+
+interface SpeciesPickerDetailProps {
+  card: SpeciesResult;
+  detailCache: Map<number, SpeciesDetail>;
+  lat?: number;
+  lng?: number;
+  isOnline: boolean;
+  isStaged: boolean;
+  onBack: () => void;
+  onToggle: () => void;
+}
+
+export default function SpeciesPickerDetail({
+  card,
+  detailCache,
+  lat,
+  lng,
+  isOnline,
+  isStaged,
+  onBack,
+  onToggle,
+}: SpeciesPickerDetailProps): ReactElement {
+  const { detail, loading, error } = useSpeciesDetail(
+    card.id,
+    lat,
+    lng,
+    detailCache,
+    isOnline
+  );
+
+  const heroUrl =
+    detail?.photo_large_url ?? detail?.photo_medium_url ?? card.photo_url ?? null;
+  const commonName = detail?.common_name ?? card.common_name;
+  const scientificName = detail?.name ?? card.name;
+  const establishment = detail?.establishment_means ?? card.establishment_means ?? null;
+  const iucn = detail?.iucn_code ?? card.iucn_code ?? null;
+  const showCavityBadge = isCavityNester(card.id);
+  const nearbyCount = card.nearby_count ?? null;
+  const family = detail?.family ?? null;
+  const summary = detail?.wikipedia_summary ?? null;
+  const wikipediaUrl = detail?.wikipedia_url ?? card.wikipedia_url ?? null;
+  const observations = detail?.observations_count ?? card.observations_count ?? 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <button
+        type="button"
+        onClick={onBack}
+        className="self-start text-sm text-forest-dark hover:underline"
+        aria-label="Back to species grid"
+      >
+        &larr; Back
+      </button>
+
+      <div className="overflow-hidden rounded-xl bg-sage-light" style={{ height: 260 }}>
+        {heroUrl && (
+          <img src={heroUrl} alt="" className="h-full w-full object-cover" />
+        )}
+      </div>
+
+      <div>
+        <h2 className="font-heading text-xl font-semibold text-forest-dark">
+          {commonName}
+        </h2>
+        <p className="italic text-sm text-sage">{scientificName}</p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {establishment === 'native' && (
+          <span className="rounded-full bg-forest/10 px-2.5 py-1 text-xs text-forest-dark">
+            Native
+          </span>
+        )}
+        {establishment === 'introduced' && (
+          <span className="rounded-full bg-[var(--color-accent)] px-2.5 py-1 text-xs text-forest-dark">
+            Introduced
+          </span>
+        )}
+        {showCavityBadge && (
+          <span className="rounded-full bg-sage-light px-2.5 py-1 text-xs text-forest-dark">
+            Cavity nester
+          </span>
+        )}
+        {iucn && (
+          <span className="rounded-full bg-sage-light px-2.5 py-1 text-xs text-forest-dark">
+            IUCN {iucn}
+          </span>
+        )}
+      </div>
+
+      {loading && <p className="text-xs text-sage">Loading details...</p>}
+      {error && <p className="text-xs text-sage">Details unavailable right now.</p>}
+
+      {summary && (
+        <p className="text-sm leading-relaxed text-forest-dark">{summary}</p>
+      )}
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg bg-sage-light px-3 py-2">
+          <div className="text-[10px] uppercase tracking-wide text-sage">IUCN</div>
+          <div className="font-heading text-sm text-forest-dark">{iucn ?? '—'}</div>
+        </div>
+        <div className="rounded-lg bg-sage-light px-3 py-2">
+          <div className="text-[10px] uppercase tracking-wide text-sage">Observations</div>
+          <div className="font-heading text-sm text-forest-dark">
+            {observations.toLocaleString()}
+          </div>
+        </div>
+        <div className="rounded-lg bg-sage-light px-3 py-2">
+          <div className="text-[10px] uppercase tracking-wide text-sage">Family</div>
+          <div className="font-heading text-sm text-forest-dark">{family ?? '—'}</div>
+        </div>
+        <div className="rounded-lg bg-sage-light px-3 py-2">
+          <div className="text-[10px] uppercase tracking-wide text-sage">Nearby</div>
+          <div className="font-heading text-sm text-forest-dark">
+            {nearbyCount !== null ? nearbyCount.toLocaleString() : '—'}
+          </div>
+        </div>
+      </div>
+
+      {detail?.ancestry && detail.ancestry.length > 0 && (
+        <p className="font-mono text-[11px] text-sage">
+          {detail.ancestry.map((a) => a.name).join(' › ')}
+        </p>
+      )}
+
+      {nearbyCount !== null && nearbyCount > 0 && (
+        <p className="text-xs text-forest">
+          {nearbyCount.toLocaleString()} nearby observations.
+        </p>
+      )}
+
+      {wikipediaUrl && (
+        <a
+          href={wikipediaUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-sm text-forest-dark underline"
+        >
+          Read on Wikipedia
+        </a>
+      )}
+
+      <div className="sticky bottom-0 -mx-4 bg-white px-4 pb-2 pt-3">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="btn-primary w-full"
+          aria-pressed={isStaged}
+        >
+          {isStaged ? 'Remove from this update' : 'Add to this update'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/manage/species-picker/SpeciesPickerGrid.tsx
+++ b/src/components/manage/species-picker/SpeciesPickerGrid.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useEffect, useState, type ReactElement } from 'react';
+import type { SpeciesResult } from '@/lib/types';
+import { isCavityNester } from '@/lib/species/cavity-nesters';
+import SpeciesCard from './SpeciesCard';
+import { useRecentSpecies, type RecentSpeciesEntry } from './useRecentSpecies';
+
+type Tab = 'nearby' | 'recent' | 'all';
+
+interface Filters {
+  native: boolean;
+  cavityNester: boolean;
+}
+
+interface SpeciesPickerGridProps {
+  orgId: string;
+  entityTypeId: string;
+  lat?: number;
+  lng?: number;
+  isOnline: boolean;
+  isStaged: (taxonId: number) => boolean;
+  onOpenDetail: (card: SpeciesResult) => void;
+  onRecentLoaded: (entries: RecentSpeciesEntry[]) => void;
+}
+
+export default function SpeciesPickerGrid({
+  orgId,
+  entityTypeId,
+  lat,
+  lng,
+  isOnline,
+  isStaged,
+  onOpenDetail,
+  onRecentLoaded,
+}: SpeciesPickerGridProps): ReactElement {
+  const hasCoords = typeof lat === 'number' && typeof lng === 'number';
+
+  const initialTab: Tab = !isOnline
+    ? 'recent'
+    : hasCoords
+    ? 'nearby'
+    : 'recent';
+
+  const [tab, setTab] = useState<Tab>(initialTab);
+  const [filters, setFilters] = useState<Filters>({ native: false, cavityNester: false });
+  const [query, setQuery] = useState('');
+
+  const [nearby, setNearby] = useState<SpeciesResult[]>([]);
+  const [nearbyLoading, setNearbyLoading] = useState(false);
+  const [searchResults, setSearchResults] = useState<SpeciesResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  const recent = useRecentSpecies(orgId, entityTypeId, true);
+
+  useEffect(() => {
+    onRecentLoaded(recent.entries);
+  }, [recent.entries, onRecentLoaded]);
+
+  useEffect(() => {
+    if (tab !== 'nearby' || !hasCoords || !isOnline) return;
+
+    let cancelled = false;
+    setNearbyLoading(true);
+    fetch(`/api/species/nearby?lat=${lat}&lng=${lng}`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((json: SpeciesResult[]) => {
+        if (!cancelled) setNearby(Array.isArray(json) ? json : []);
+      })
+      .catch(() => {
+        if (!cancelled) setNearby([]);
+      })
+      .finally(() => {
+        if (!cancelled) setNearbyLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, hasCoords, isOnline, lat, lng]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (tab !== 'all' || !isOnline || trimmed.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const url = new URL('/api/species/search', 'http://localhost');
+        url.searchParams.set('q', trimmed);
+        if (hasCoords) {
+          url.searchParams.set('lat', String(lat));
+          url.searchParams.set('lng', String(lng));
+        }
+        const res = await fetch(url.pathname + url.search);
+        const json = res.ok ? await res.json() : [];
+        setSearchResults(Array.isArray(json) ? json : []);
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [query, tab, isOnline, hasCoords, lat, lng]);
+
+  function applyFilters(list: SpeciesResult[]): SpeciesResult[] {
+    return list.filter((s) => {
+      if (filters.native && s.establishment_means === 'introduced') return false;
+      if (filters.cavityNester && !isCavityNester(s.id)) return false;
+      return true;
+    });
+  }
+
+  let cards: SpeciesResult[] = [];
+  if (tab === 'nearby') cards = applyFilters(nearby);
+  else if (tab === 'recent') cards = applyFilters(recent.entries.map((e) => e.card));
+  else cards = applyFilters(searchResults);
+
+  const allTabDisabled = !isOnline;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {!isOnline && (
+        <div
+          role="status"
+          className="rounded-lg bg-sage-light px-3 py-2 text-xs text-forest-dark"
+        >
+          Search requires internet connection.
+        </div>
+      )}
+
+      <input
+        type="search"
+        className="input-field"
+        placeholder="Search species..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => setTab('all')}
+        disabled={!isOnline}
+      />
+
+      <div role="tablist" className="flex gap-2">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'nearby'}
+          onClick={() => setTab('nearby')}
+          className={tab === 'nearby' ? 'btn-primary' : 'btn-secondary'}
+        >
+          Nearby
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'recent'}
+          onClick={() => setTab('recent')}
+          className={tab === 'recent' ? 'btn-primary' : 'btn-secondary'}
+        >
+          Recent
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'all'}
+          onClick={() => !allTabDisabled && setTab('all')}
+          disabled={allTabDisabled}
+          className={tab === 'all' ? 'btn-primary' : 'btn-secondary'}
+        >
+          All
+        </button>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          aria-pressed={filters.native}
+          onClick={() => setFilters((f) => ({ ...f, native: !f.native }))}
+          className={[
+            'rounded-full border px-3 py-1 text-xs',
+            filters.native
+              ? 'border-[var(--color-primary)] bg-[var(--color-primary)] text-white'
+              : 'border-sage-light text-forest-dark',
+          ].join(' ')}
+        >
+          Native
+        </button>
+        <button
+          type="button"
+          aria-pressed={filters.cavityNester}
+          onClick={() => setFilters((f) => ({ ...f, cavityNester: !f.cavityNester }))}
+          className={[
+            'rounded-full border px-3 py-1 text-xs',
+            filters.cavityNester
+              ? 'border-[var(--color-primary)] bg-[var(--color-primary)] text-white'
+              : 'border-sage-light text-forest-dark',
+          ].join(' ')}
+        >
+          Cavity nester
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        {cards.map((card) => (
+          <SpeciesCard
+            key={card.id}
+            card={card}
+            selected={isStaged(card.id)}
+            onTap={() => onOpenDetail(card)}
+          />
+        ))}
+      </div>
+
+      {tab === 'nearby' && !hasCoords && (
+        <p className="px-1 text-xs text-sage">
+          Nearby species require location. Open the map to share your location, or switch to Recent.
+        </p>
+      )}
+      {tab === 'nearby' && hasCoords && !isOnline && (
+        <p className="px-1 text-xs text-sage">Nearby species require a connection.</p>
+      )}
+      {tab === 'nearby' && hasCoords && isOnline && !nearbyLoading && cards.length === 0 && (
+        <p className="px-1 text-xs text-sage">No species in this area.</p>
+      )}
+      {tab === 'all' && query.trim().length < 2 && (
+        <p className="px-1 text-xs text-sage">Search for a species above.</p>
+      )}
+      {tab === 'all' && searchLoading && (
+        <p className="px-1 text-xs text-sage">Searching...</p>
+      )}
+      {tab === 'recent' && !recent.loading && cards.length === 0 && (
+        <p className="px-1 text-xs text-sage">No recent selections yet.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/manage/species-picker/SpeciesPickerSheet.tsx
+++ b/src/components/manage/species-picker/SpeciesPickerSheet.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import MultiSnapBottomSheet from '@/components/ui/MultiSnapBottomSheet';
+import type { SpeciesDetail, SpeciesResult } from '@/lib/types';
+import { useNetworkStatus } from '@/lib/offline/network';
+import { useUserLocation } from '@/lib/location/provider';
+import {
+  initStaged,
+  toggleStaged,
+  planCommit,
+  type SelectedEntitySeed,
+  type StagedState,
+} from './staged-selection';
+import SpeciesPickerGrid from './SpeciesPickerGrid';
+import SpeciesPickerDetail from './SpeciesPickerDetail';
+import type { RecentSpeciesEntry } from './useRecentSpecies';
+
+interface SpeciesPickerSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  orgId: string;
+  entityTypeId: string;
+  entityTypeName: string;
+  lat?: number;
+  lng?: number;
+  seeds: SelectedEntitySeed[];
+  onCommit: (plan: {
+    newTaxa: SpeciesResult[];
+    keptEntityIds: string[];
+  }) => Promise<void>;
+}
+
+export default function SpeciesPickerSheet({
+  isOpen,
+  onClose,
+  orgId,
+  entityTypeId,
+  entityTypeName,
+  lat,
+  lng,
+  seeds,
+  onCommit,
+}: SpeciesPickerSheetProps): ReactElement {
+  const { isOnline } = useNetworkStatus();
+  const userLocation = useUserLocation();
+
+  // Resolve coords: user's device position (if map already started tracking) takes priority
+  // over the property/update coords passed in. The picker never calls startTracking().
+  const resolvedLat = userLocation.position?.lat ?? lat;
+  const resolvedLng = userLocation.position?.lng ?? lng;
+
+  const [state, setState] = useState<StagedState>(() => initStaged(seeds));
+  const [detailCard, setDetailCard] = useState<SpeciesResult | null>(null);
+  const detailCacheRef = useRef<Map<number, SpeciesDetail>>(new Map());
+  const [committing, setCommitting] = useState(false);
+
+  // Reseed whenever the sheet transitions from closed to open.
+  useEffect(() => {
+    if (isOpen) {
+      setState(initStaged(seeds));
+      setDetailCard(null);
+    }
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isStaged = useCallback(
+    (taxonId: number) => state.staged.has(taxonId),
+    [state]
+  );
+
+  const handleOpenDetail = useCallback((card: SpeciesResult) => {
+    setDetailCard(card);
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setDetailCard(null);
+  }, []);
+
+  const handleToggle = useCallback(
+    (card: SpeciesResult) => {
+      setState((prev) => toggleStaged(prev, card.id, card));
+    },
+    []
+  );
+
+  const handleDone = useCallback(async () => {
+    setCommitting(true);
+    try {
+      const plan = planCommit(state);
+      await onCommit(plan);
+      onClose();
+    } finally {
+      setCommitting(false);
+    }
+  }, [state, onCommit, onClose]);
+
+  const handleRecentLoaded = useCallback((_entries: RecentSpeciesEntry[]) => {
+    // Reserved for future reconciliation — no-op for now.
+  }, []);
+
+  const header = useMemo(
+    () => (
+      <div className="sticky top-0 z-10 flex items-center justify-between bg-white pb-3 pt-1">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close species picker"
+          className="text-lg text-sage hover:text-red-600"
+        >
+          &times;
+        </button>
+        <h2 className="font-heading text-base text-forest-dark">
+          {detailCard ? 'Species detail' : `Choose ${entityTypeName.toLowerCase()}`}
+        </h2>
+        <button
+          type="button"
+          onClick={handleDone}
+          disabled={committing}
+          className="text-sm font-semibold text-[var(--color-primary)] disabled:opacity-50"
+        >
+          Done
+        </button>
+      </div>
+    ),
+    [onClose, detailCard, entityTypeName, handleDone, committing]
+  );
+
+  return (
+    <MultiSnapBottomSheet isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col">
+        {header}
+        {detailCard ? (
+          <SpeciesPickerDetail
+            card={detailCard}
+            detailCache={detailCacheRef.current}
+            lat={resolvedLat}
+            lng={resolvedLng}
+            isOnline={isOnline}
+            isStaged={isStaged(detailCard.id)}
+            onBack={handleBack}
+            onToggle={() => handleToggle(detailCard)}
+          />
+        ) : (
+          <SpeciesPickerGrid
+            orgId={orgId}
+            entityTypeId={entityTypeId}
+            lat={resolvedLat}
+            lng={resolvedLng}
+            isOnline={isOnline}
+            isStaged={isStaged}
+            onOpenDetail={handleOpenDetail}
+            onRecentLoaded={handleRecentLoaded}
+          />
+        )}
+      </div>
+    </MultiSnapBottomSheet>
+  );
+}

--- a/src/components/manage/species-picker/SpeciesPill.tsx
+++ b/src/components/manage/species-picker/SpeciesPill.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+interface SpeciesPillProps {
+  name: string;
+  photoUrl: string | null;
+  onRemove: () => void;
+}
+
+export default function SpeciesPill({ name, photoUrl, onRemove }: SpeciesPillProps): ReactElement {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full bg-forest/10 px-2.5 py-1 text-xs text-forest-dark">
+      {photoUrl ? (
+        <img
+          src={photoUrl}
+          alt=""
+          className="h-[26px] w-[26px] rounded-full object-cover"
+        />
+      ) : (
+        <span className="h-[26px] w-[26px] rounded-full bg-sage-light" aria-hidden />
+      )}
+      <span className="font-medium">{name}</span>
+      <button
+        type="button"
+        aria-label={`Remove ${name}`}
+        onClick={onRemove}
+        className="ml-0.5 text-sage hover:text-red-600"
+      >
+        &times;
+      </button>
+    </span>
+  );
+}

--- a/src/components/manage/species-picker/__tests__/staged-selection.test.ts
+++ b/src/components/manage/species-picker/__tests__/staged-selection.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  initStaged,
+  toggleStaged,
+  planCommit,
+  type StagedState,
+  type SelectedEntitySeed,
+} from '../staged-selection';
+import type { SpeciesResult } from '@/lib/types';
+
+function sp(id: number, extras: Partial<SpeciesResult> = {}): SpeciesResult {
+  return {
+    id,
+    name: `Sp ${id}`,
+    common_name: `Common ${id}`,
+    photo_url: null,
+    photo_square_url: null,
+    rank: 'species',
+    observations_count: 0,
+    wikipedia_url: null,
+    ...extras,
+  };
+}
+
+describe('staged-selection', () => {
+  it('initStaged with no selections returns empty maps', () => {
+    const state = initStaged([]);
+    expect(state.staged.size).toBe(0);
+    expect(state.stagedExistingEntityIds.size).toBe(0);
+  });
+
+  it('initStaged seeds both maps from existing entities', () => {
+    const seeds: SelectedEntitySeed[] = [
+      { entityId: 'e1', taxonId: 12727, card: sp(12727) },
+      { entityId: 'e2', taxonId: 18472, card: sp(18472) },
+    ];
+    const state = initStaged(seeds);
+    expect(state.staged.size).toBe(2);
+    expect(state.stagedExistingEntityIds.get(12727)).toBe('e1');
+    expect(state.stagedExistingEntityIds.get(18472)).toBe('e2');
+    expect(state.staged.get(12727)).toMatchObject({ id: 12727 });
+  });
+
+  it('toggleStaged adds a new taxon', () => {
+    const state: StagedState = initStaged([]);
+    const next = toggleStaged(state, 12727, sp(12727));
+    expect(next.staged.has(12727)).toBe(true);
+  });
+
+  it('toggleStaged removes a taxon that is currently in staged', () => {
+    const state = toggleStaged(initStaged([]), 12727, sp(12727));
+    const next = toggleStaged(state, 12727, sp(12727));
+    expect(next.staged.has(12727)).toBe(false);
+  });
+
+  it('toggleStaged does not drop stagedExistingEntityIds when removing an existing taxon', () => {
+    const seed: SelectedEntitySeed = { entityId: 'e1', taxonId: 12727, card: sp(12727) };
+    let state = initStaged([seed]);
+    state = toggleStaged(state, 12727, sp(12727)); // now removed from staged
+    expect(state.staged.has(12727)).toBe(false);
+    expect(state.stagedExistingEntityIds.get(12727)).toBe('e1'); // still recorded
+  });
+
+  it('planCommit separates new taxa from kept entity ids', () => {
+    const seeds: SelectedEntitySeed[] = [
+      { entityId: 'e1', taxonId: 12727, card: sp(12727) },
+      { entityId: 'e2', taxonId: 18472, card: sp(18472) },
+    ];
+    let state = initStaged(seeds);
+    state = toggleStaged(state, 18472, sp(18472)); // remove existing
+    state = toggleStaged(state, 14836, sp(14836)); // add new
+
+    const plan = planCommit(state);
+    expect(plan.keptEntityIds).toEqual(['e1']);
+    expect(plan.newTaxa).toHaveLength(1);
+    expect(plan.newTaxa[0].id).toBe(14836);
+  });
+
+  it('planCommit with no changes returns only kept entity ids', () => {
+    const seeds: SelectedEntitySeed[] = [
+      { entityId: 'e1', taxonId: 12727, card: sp(12727) },
+    ];
+    const state = initStaged(seeds);
+    const plan = planCommit(state);
+    expect(plan.keptEntityIds).toEqual(['e1']);
+    expect(plan.newTaxa).toEqual([]);
+  });
+});

--- a/src/components/manage/species-picker/staged-selection.ts
+++ b/src/components/manage/species-picker/staged-selection.ts
@@ -1,0 +1,61 @@
+import type { SpeciesResult } from '@/lib/types';
+
+export interface SelectedEntitySeed {
+  entityId: string;
+  taxonId: number;
+  card: SpeciesResult;
+}
+
+export interface StagedState {
+  staged: Map<number, SpeciesResult>;
+  stagedExistingEntityIds: Map<number, string>;
+}
+
+export function initStaged(seeds: SelectedEntitySeed[]): StagedState {
+  const staged = new Map<number, SpeciesResult>();
+  const stagedExistingEntityIds = new Map<number, string>();
+  for (const seed of seeds) {
+    staged.set(seed.taxonId, seed.card);
+    stagedExistingEntityIds.set(seed.taxonId, seed.entityId);
+  }
+  return { staged, stagedExistingEntityIds };
+}
+
+export function toggleStaged(
+  state: StagedState,
+  taxonId: number,
+  card: SpeciesResult
+): StagedState {
+  const staged = new Map(state.staged);
+  if (staged.has(taxonId)) {
+    staged.delete(taxonId);
+  } else {
+    staged.set(taxonId, card);
+  }
+  return { staged, stagedExistingEntityIds: state.stagedExistingEntityIds };
+}
+
+export function isStaged(state: StagedState, taxonId: number): boolean {
+  return state.staged.has(taxonId);
+}
+
+export interface CommitPlan {
+  newTaxa: SpeciesResult[];
+  keptEntityIds: string[];
+}
+
+export function planCommit(state: StagedState): CommitPlan {
+  const newTaxa: SpeciesResult[] = [];
+  const keptEntityIds: string[] = [];
+
+  for (const [taxonId, card] of Array.from(state.staged.entries())) {
+    const existingEntityId = state.stagedExistingEntityIds.get(taxonId);
+    if (existingEntityId !== undefined) {
+      keptEntityIds.push(existingEntityId);
+    } else {
+      newTaxa.push(card);
+    }
+  }
+
+  return { newTaxa, keptEntityIds };
+}

--- a/src/components/manage/species-picker/useRecentSpecies.ts
+++ b/src/components/manage/species-picker/useRecentSpecies.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { SpeciesResult } from '@/lib/types';
+
+interface EntityRow {
+  id: string;
+  name: string;
+  description: string | null;
+  external_id: string | null;
+  custom_field_values: Record<string, unknown> | null;
+  updated_at: string;
+}
+
+const RECENT_LIMIT = 30;
+
+export interface RecentSpeciesEntry {
+  entityId: string;
+  card: SpeciesResult;
+}
+
+export function useRecentSpecies(
+  orgId: string,
+  entityTypeId: string,
+  enabled: boolean
+): { entries: RecentSpeciesEntry[]; loading: boolean } {
+  const [entries, setEntries] = useState<RecentSpeciesEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setEntries([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    const run = async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from('entities')
+        .select('id, name, description, external_id, custom_field_values, updated_at')
+        .eq('org_id', orgId)
+        .eq('entity_type_id', entityTypeId)
+        .order('updated_at', { ascending: false })
+        .limit(RECENT_LIMIT);
+
+      if (cancelled) return;
+
+      const rows = (data ?? []) as EntityRow[];
+      const mapped: RecentSpeciesEntry[] = rows
+        .filter((r) => r.external_id !== null)
+        .map((r) => {
+          const taxonId = Number(r.external_id);
+          const cfv = r.custom_field_values ?? {};
+          const photoUrl = typeof cfv.photo_url === 'string' ? (cfv.photo_url as string) : null;
+          const photoSquare =
+            typeof cfv.photo_square_url === 'string' ? (cfv.photo_square_url as string) : null;
+          const scientific = typeof cfv.scientific_name === 'string'
+            ? (cfv.scientific_name as string)
+            : (r.description ?? '');
+          const card: SpeciesResult = {
+            id: taxonId,
+            name: scientific,
+            common_name: r.name,
+            photo_url: photoUrl,
+            photo_square_url: photoSquare,
+            rank: 'species',
+            observations_count: 0,
+            wikipedia_url:
+              typeof cfv.wikipedia_url === 'string' ? (cfv.wikipedia_url as string) : null,
+          };
+          return { entityId: r.id, card };
+        });
+
+      setEntries(mapped);
+      setLoading(false);
+    };
+
+    void run().catch(() => {
+      if (!cancelled) {
+        setEntries([]);
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, entityTypeId, enabled]);
+
+  return { entries, loading };
+}

--- a/src/components/manage/species-picker/useSpeciesDetail.ts
+++ b/src/components/manage/species-picker/useSpeciesDetail.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { SpeciesDetail } from '@/lib/types';
+
+export function useSpeciesDetail(
+  taxonId: number | null,
+  lat: number | undefined,
+  lng: number | undefined,
+  cache: Map<number, SpeciesDetail>,
+  enabled: boolean
+): { detail: SpeciesDetail | null; loading: boolean; error: boolean } {
+  const [detail, setDetail] = useState<SpeciesDetail | null>(() =>
+    taxonId !== null ? cache.get(taxonId) ?? null : null
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (taxonId === null) {
+      setDetail(null);
+      setLoading(false);
+      setError(false);
+      return;
+    }
+
+    const cached = cache.get(taxonId);
+    if (cached) {
+      setDetail(cached);
+      setLoading(false);
+      setError(false);
+      return;
+    }
+
+    if (!enabled) {
+      setDetail(null);
+      setLoading(false);
+      setError(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+
+    const url = new URL(`/api/species/${taxonId}`, 'http://localhost');
+    if (typeof lat === 'number' && typeof lng === 'number') {
+      url.searchParams.set('lat', String(lat));
+      url.searchParams.set('lng', String(lng));
+    }
+
+    fetch(url.pathname + url.search)
+      .then(async (r) => (r.ok ? r.json() : { error: 'unavailable' }))
+      .then((body: SpeciesDetail | { error: string }) => {
+        if (cancelled) return;
+        if ('error' in body) {
+          setDetail(null);
+          setError(true);
+        } else {
+          cache.set(taxonId, body);
+          setDetail(body);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [taxonId, lat, lng, enabled, cache]);
+
+  return { detail, loading, error };
+}

--- a/src/lib/species/__tests__/cavity-nesters.test.ts
+++ b/src/lib/species/__tests__/cavity-nesters.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { CAVITY_NESTER_TAXON_IDS, isCavityNester } from '../cavity-nesters';
+
+describe('cavity-nesters', () => {
+  it('exposes a non-empty Set of iNat taxon ids', () => {
+    expect(CAVITY_NESTER_TAXON_IDS.size).toBeGreaterThan(0);
+    Array.from(CAVITY_NESTER_TAXON_IDS).forEach((id) => {
+      expect(Number.isInteger(id)).toBe(true);
+      expect(id).toBeGreaterThan(0);
+    });
+  });
+
+  it('isCavityNester returns true for ids in the set', () => {
+    const [first] = Array.from(CAVITY_NESTER_TAXON_IDS);
+    expect(isCavityNester(first)).toBe(true);
+  });
+
+  it('isCavityNester returns false for ids not in the set', () => {
+    expect(isCavityNester(-1)).toBe(false);
+    expect(isCavityNester(0)).toBe(false);
+  });
+});

--- a/src/lib/species/__tests__/inat-projection.test.ts
+++ b/src/lib/species/__tests__/inat-projection.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toEstablishmentMeans,
+  toSpeciesResult,
+  iucnCodeOf,
+  type INatTaxonRaw,
+} from '../inat-projection';
+
+const base: INatTaxonRaw = {
+  id: 12727,
+  name: 'Sialia sialis',
+  preferred_common_name: 'Eastern Bluebird',
+  rank: 'species',
+  observations_count: 42,
+  wikipedia_url: null,
+};
+
+describe('toEstablishmentMeans', () => {
+  it('returns "native" for iNat "native" string', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'native' } })).toBe('native');
+  });
+  it('returns "native" for iNat "endemic" string', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'endemic' } })).toBe('native');
+  });
+  it('returns "introduced" for iNat "introduced" string', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'introduced' } })).toBe('introduced');
+  });
+  it('returns "introduced" for iNat "invasive" string', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'invasive' } })).toBe('introduced');
+  });
+  it('returns "introduced" for British spelling "naturalised"', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'naturalised' } })).toBe('introduced');
+  });
+  it('returns "introduced" for American spelling "naturalized"', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'naturalized' } })).toBe('introduced');
+  });
+  it('returns null for unknown string', () => {
+    expect(toEstablishmentMeans({ ...base, establishment_means: { establishment_means: 'something-weird' } })).toBe(null);
+  });
+  it('falls back to listed_taxa[0] when establishment_means is absent', () => {
+    expect(toEstablishmentMeans({ ...base, listed_taxa: [{ establishment_means: 'native' }] })).toBe('native');
+  });
+  it('returns null when both sources are missing', () => {
+    expect(toEstablishmentMeans(base)).toBe(null);
+  });
+});
+
+describe('iucnCodeOf', () => {
+  it('maps 10 → LC', () => {
+    expect(iucnCodeOf({ ...base, conservation_status: { iucn: 10 } })).toBe('LC');
+  });
+  it('maps 40 → EN', () => {
+    expect(iucnCodeOf({ ...base, conservation_status: { iucn: 40 } })).toBe('EN');
+  });
+  it('maps 0 → NE (Not Evaluated)', () => {
+    expect(iucnCodeOf({ ...base, conservation_status: { iucn: 0 } })).toBe('NE');
+  });
+  it('maps 5 → DD (Data Deficient)', () => {
+    expect(iucnCodeOf({ ...base, conservation_status: { iucn: 5 } })).toBe('DD');
+  });
+  it('returns null for an unknown numeric code', () => {
+    expect(iucnCodeOf({ ...base, conservation_status: { iucn: 999 } })).toBe(null);
+  });
+  it('returns null when conservation_status is absent', () => {
+    expect(iucnCodeOf(base)).toBe(null);
+  });
+});
+
+describe('toSpeciesResult', () => {
+  it('projects a full SpeciesResult with all enrichment fields', () => {
+    const raw: INatTaxonRaw = {
+      ...base,
+      default_photo: { square_url: 'sq.jpg', medium_url: 'md.jpg' },
+      conservation_status: { iucn: 40 },
+      establishment_means: { establishment_means: 'endemic' },
+    };
+    const projected = toSpeciesResult(raw);
+    expect(projected).toMatchObject({
+      id: 12727,
+      name: 'Sialia sialis',
+      common_name: 'Eastern Bluebird',
+      photo_url: 'md.jpg',
+      photo_square_url: 'sq.jpg',
+      rank: 'species',
+      observations_count: 42,
+      wikipedia_url: null,
+      establishment_means: 'native',
+      iucn_code: 'EN',
+    });
+  });
+
+  it('falls back on missing optional fields', () => {
+    const projected = toSpeciesResult({ id: 1, name: 'X' });
+    expect(projected).toMatchObject({
+      id: 1,
+      name: 'X',
+      common_name: 'X',
+      photo_url: null,
+      photo_square_url: null,
+      rank: 'unknown',
+      observations_count: 0,
+      wikipedia_url: null,
+      establishment_means: null,
+      iucn_code: null,
+    });
+  });
+});

--- a/src/lib/species/__tests__/place-id-cache.test.ts
+++ b/src/lib/species/__tests__/place-id-cache.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  resolvePlaceId,
+  __resetPlaceIdCacheForTests,
+  __getPlaceIdCacheSizeForTests,
+} from '../place-id-cache';
+
+function mockINatResponse(places: Array<{ id: number; admin_level: number; name: string }>) {
+  const response = new Response(
+    JSON.stringify({ results: { standard: places, community: [] } }),
+    { status: 200 }
+  );
+  globalThis.fetch = vi.fn().mockResolvedValue(response);
+  return globalThis.fetch as ReturnType<typeof vi.fn>;
+}
+
+describe('resolvePlaceId', () => {
+  beforeEach(() => {
+    __resetPlaceIdCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('resolves the smallest state-level place (admin_level 20)', async () => {
+    mockINatResponse([
+      { id: 97394, admin_level: 10, name: 'United States' },
+      { id: 54, admin_level: 20, name: 'Vermont' },
+      { id: 54321, admin_level: 30, name: 'Windham County' },
+    ]);
+
+    const placeId = await resolvePlaceId(43.5, -72.6);
+    expect(placeId).toBe(54);
+  });
+
+  it('returns null when iNat returns no state-level place', async () => {
+    mockINatResponse([
+      { id: 97394, admin_level: 10, name: 'United States' },
+    ]);
+    const placeId = await resolvePlaceId(43.5, -72.6);
+    expect(placeId).toBeNull();
+  });
+
+  it('caches resolved place ids by rounded lat/lng (1 decimal)', async () => {
+    const fetchMock = mockINatResponse([
+      { id: 54, admin_level: 20, name: 'Vermont' },
+    ]);
+    await resolvePlaceId(43.51, -72.61); // rounds to 43.5,-72.6
+    await resolvePlaceId(43.54, -72.58); // rounds to 43.5,-72.6 — cache hit
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches null as a valid value (no re-fetch for known-unresolvable cells)', async () => {
+    const fetchMock = mockINatResponse([
+      { id: 97394, admin_level: 10, name: 'United States' },
+    ]);
+    await resolvePlaceId(0, 0);
+    await resolvePlaceId(0, 0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null on iNat fetch error', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    const placeId = await resolvePlaceId(43.5, -72.6);
+    expect(placeId).toBeNull();
+  });
+
+  it('deduplicates concurrent in-flight requests for the same rounded key', async () => {
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve(
+                new Response(
+                  JSON.stringify({
+                    results: { standard: [{ id: 54, admin_level: 20, name: 'Vermont' }], community: [] },
+                  }),
+                  { status: 200 }
+                )
+              ),
+            0
+          )
+        )
+    );
+    globalThis.fetch = fetchMock;
+
+    const [a, b] = await Promise.all([resolvePlaceId(43.5, -72.6), resolvePlaceId(43.5, -72.6)]);
+    expect(a).toBe(54);
+    expect(b).toBe(54);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('LRU-evicts past max cache size (500)', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({ results: { standard: [{ id: 1, admin_level: 20, name: 'X' }], community: [] } }),
+        { status: 200 }
+      );
+    });
+    for (let i = 0; i < 501; i++) {
+      const lat = Math.floor(i / 10) * 0.1;
+      const lng = (i % 10) * 0.1;
+      await resolvePlaceId(lat, lng);
+    }
+    expect(__getPlaceIdCacheSizeForTests()).toBeLessThanOrEqual(500);
+  });
+});

--- a/src/lib/species/cavity-nesters.ts
+++ b/src/lib/species/cavity-nesters.ts
@@ -1,0 +1,64 @@
+// Curated list of iNat taxon ids for North American cavity-nesting birds.
+// This is the authoritative source for the "Cavity nester" filter in the
+// species picker — iNat does not carry this trait as structured data.
+// Add new ids by appending to the array; the Set is built once at module load.
+//
+// Ownership: conservation staff. When adding, include the common name in the
+// trailing comment for reviewability.
+
+const IDS: readonly number[] = [
+  // Woodpeckers (Picidae)
+  18472,  // Northern Flicker (Colaptes auratus)
+  18422,  // Downy Woodpecker (Dryobates pubescens)
+  18436,  // Hairy Woodpecker (Dryobates villosus)
+  18434,  // Red-bellied Woodpecker (Melanerpes carolinus)
+  18416,  // Pileated Woodpecker (Dryocopus pileatus)
+  18408,  // Red-headed Woodpecker (Melanerpes erythrocephalus)
+  18410,  // Lewis's Woodpecker (Melanerpes lewis)
+  // Chickadees and titmice (Paridae)
+  14836,  // Black-capped Chickadee (Poecile atricapillus)
+  14850,  // Carolina Chickadee (Poecile carolinensis)
+  14854,  // Mountain Chickadee (Poecile gambeli)
+  14864,  // Tufted Titmouse (Baeolophus bicolor)
+  // Bluebirds and thrushes (Turdidae)
+  12727,  // Eastern Bluebird (Sialia sialis)
+  12728,  // Western Bluebird (Sialia mexicana)
+  12729,  // Mountain Bluebird (Sialia currucoides)
+  // Swallows (Hirundinidae)
+  10237,  // Tree Swallow (Tachycineta bicolor)
+  10236,  // Violet-green Swallow (Tachycineta thalassina)
+  10251,  // Purple Martin (Progne subis)
+  // Wrens (Troglodytidae)
+  14118,  // House Wren (Troglodytes aedon)
+  14138,  // Carolina Wren (Thryothorus ludovicianus)
+  14123,  // Bewick's Wren (Thryomanes bewickii)
+  // Nuthatches (Sittidae)
+  14887,  // White-breasted Nuthatch (Sitta carolinensis)
+  14889,  // Red-breasted Nuthatch (Sitta canadensis)
+  // Owls (Strigidae)
+  19346,  // Eastern Screech-Owl (Megascops asio)
+  19345,  // Western Screech-Owl (Megascops kennicottii)
+  19354,  // Northern Saw-whet Owl (Aegolius acadicus)
+  // Ducks (Anatidae — cavity-nesting species only)
+  6912,   // Wood Duck (Aix sponsa)
+  6920,   // Bufflehead (Bucephala albeola)
+  6928,   // Common Goldeneye (Bucephala clangula)
+  6924,   // Hooded Merganser (Lophodytes cucullatus)
+  // Kestrels (Falconidae)
+  5287,   // American Kestrel (Falco sparverius)
+  // Swifts (Apodidae)
+  16846,  // Chimney Swift (Chaetura pelagica)
+  // Flycatchers (Tyrannidae)
+  17105,  // Great Crested Flycatcher (Myiarchus crinitus)
+  17106,  // Ash-throated Flycatcher (Myiarchus cinerascens)
+  // Starlings (Sturnidae — non-native but cavity-nesting)
+  13858,  // European Starling (Sturnus vulgaris)
+  // Sparrows (Passeridae)
+  13851,  // House Sparrow (Passer domesticus)
+];
+
+export const CAVITY_NESTER_TAXON_IDS: ReadonlySet<number> = new Set(IDS);
+
+export function isCavityNester(taxonId: number): boolean {
+  return CAVITY_NESTER_TAXON_IDS.has(taxonId);
+}

--- a/src/lib/species/inat-projection.ts
+++ b/src/lib/species/inat-projection.ts
@@ -1,0 +1,56 @@
+import type { SpeciesResult, SpeciesEstablishmentMeans } from '@/lib/types';
+
+export interface INatTaxonRaw {
+  id: number;
+  name: string;
+  preferred_common_name?: string | null;
+  default_photo?: {
+    square_url?: string | null;
+    medium_url?: string | null;
+    large_url?: string | null;
+  } | null;
+  rank?: string;
+  observations_count?: number;
+  wikipedia_url?: string | null;
+  conservation_status?: { iucn?: number | null } | null;
+  // When place_id is supplied, iNat returns the place-scoped listing first.
+  establishment_means?: { establishment_means?: string | null } | null;
+  listed_taxa?: Array<{ establishment_means?: string | null }>;
+}
+
+// iNat numeric IUCN scale. 0 and 5 are "Not Evaluated" and "Data Deficient"
+// respectively; 10-70 are the threatened-category rungs.
+export const IUCN_CODE: Record<number, string> = {
+  0: 'NE', 5: 'DD',
+  10: 'LC', 20: 'NT', 30: 'VU', 40: 'EN', 50: 'CR', 60: 'EW', 70: 'EX',
+};
+
+export function iucnCodeOf(raw: INatTaxonRaw): string | null {
+  const iucnRaw = raw.conservation_status?.iucn ?? null;
+  return iucnRaw != null ? IUCN_CODE[iucnRaw] ?? null : null;
+}
+
+export function toEstablishmentMeans(raw: INatTaxonRaw): SpeciesEstablishmentMeans {
+  const em =
+    raw.establishment_means?.establishment_means ??
+    raw.listed_taxa?.[0]?.establishment_means ??
+    null;
+  if (em === 'native' || em === 'endemic') return 'native';
+  if (em === 'introduced' || em === 'invasive' || em === 'naturalised' || em === 'naturalized') return 'introduced';
+  return null;
+}
+
+export function toSpeciesResult(raw: INatTaxonRaw): SpeciesResult {
+  return {
+    id: raw.id,
+    name: raw.name,
+    common_name: raw.preferred_common_name || raw.name,
+    photo_url: raw.default_photo?.medium_url ?? null,
+    photo_square_url: raw.default_photo?.square_url ?? null,
+    rank: raw.rank ?? 'unknown',
+    observations_count: raw.observations_count ?? 0,
+    wikipedia_url: raw.wikipedia_url ?? null,
+    establishment_means: toEstablishmentMeans(raw),
+    iucn_code: iucnCodeOf(raw),
+  };
+}

--- a/src/lib/species/place-id-cache.ts
+++ b/src/lib/species/place-id-cache.ts
@@ -1,0 +1,88 @@
+// Server-side only. Resolves an iNat place_id from lat/lng using an in-memory
+// LRU keyed by lat/lng rounded to 1 decimal place (~11 km cell).
+// Null is a legitimate cached value meaning "no state-level place exists here."
+
+const MAX_ENTRIES = 500;
+const STATE_ADMIN_LEVEL = 20; // iNat convention: 10=country, 20=state/province, 30=county
+const FETCH_TIMEOUT_MS = 5000;
+
+interface INatPlace {
+  id: number;
+  admin_level: number;
+  name?: string;
+}
+
+// Map preserves insertion order; we re-insert on read to implement LRU.
+const cache = new Map<string, number | null>();
+
+// Dedups concurrent in-flight requests keyed by the rounded lat/lng cell.
+const inflight = new Map<string, Promise<number | null>>();
+
+function keyFor(lat: number, lng: number): string {
+  return `${lat.toFixed(1)},${lng.toFixed(1)}`;
+}
+
+function touch(key: string, value: number | null): void {
+  cache.delete(key);
+  cache.set(key, value);
+  if (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+export async function resolvePlaceId(lat: number, lng: number): Promise<number | null> {
+  const key = keyFor(lat, lng);
+  if (cache.has(key)) {
+    const cached = cache.get(key) ?? null;
+    touch(key, cached);
+    return cached;
+  }
+
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const bbox = 0.05; // degrees
+  const upstream = new URL('https://api.inaturalist.org/v1/places/nearby');
+  upstream.searchParams.set('nelat', String(lat + bbox));
+  upstream.searchParams.set('nelng', String(lng + bbox));
+  upstream.searchParams.set('swlat', String(lat - bbox));
+  upstream.searchParams.set('swlng', String(lng - bbox));
+  upstream.searchParams.set('per_page', '30');
+
+  const promise = (async (): Promise<number | null> => {
+    try {
+      const res = await fetch(upstream.toString(), {
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        touch(key, null);
+        return null;
+      }
+      const json = (await res.json()) as { results?: { standard?: INatPlace[]; community?: INatPlace[] } };
+      const allPlaces = [...(json.results?.standard ?? []), ...(json.results?.community ?? [])];
+      const statePlace = allPlaces.find((p) => p.admin_level === STATE_ADMIN_LEVEL);
+      const value = statePlace?.id ?? null;
+      touch(key, value);
+      return value;
+    } catch {
+      touch(key, null);
+      return null;
+    }
+  })().finally(() => {
+    inflight.delete(key);
+  });
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+// Test-only helpers. Not re-exported from a barrel; consumers should not import these.
+export function __resetPlaceIdCacheForTests(): void {
+  cache.clear();
+}
+
+export function __getPlaceIdCacheSizeForTests(): number {
+  return cache.size;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -270,14 +270,44 @@ export type EntityLinkTarget = 'items' | 'updates';
 
 export type EntityApiSource = 'inaturalist';
 
+export type SpeciesEstablishmentMeans = 'native' | 'introduced' | null;
+
 export interface SpeciesResult {
   id: number;
   name: string;
   common_name: string;
   photo_url: string | null;
+  photo_square_url: string | null;
   rank: string;
   observations_count: number;
   wikipedia_url: string | null;
+  nearby_count?: number;
+  establishment_means?: SpeciesEstablishmentMeans;
+  iucn_code?: string | null;
+}
+
+export interface SpeciesAncestor {
+  id: number;
+  name: string;
+  rank: string;
+}
+
+export interface SpeciesDetail {
+  id: number;
+  name: string;
+  common_name: string;
+  photo_square_url: string | null;
+  photo_medium_url: string | null;
+  photo_large_url: string | null;
+  rank: string;
+  observations_count: number;
+  wikipedia_url: string | null;
+  wikipedia_summary: string | null;
+  iucn_code: string | null;
+  establishment_means: SpeciesEstablishmentMeans;
+  ancestry: SpeciesAncestor[];
+  family: string | null;
+  nearby_count: number | null;
 }
 
 export interface EntityType {


### PR DESCRIPTION
## Summary

- Refactors `SpeciesPicker` into a full-screen `MultiSnapBottomSheet` photo grid with tabs (Nearby / Recent / All), filter chips (Native, Cavity nester), and a detail subview. Selection gated behind the detail view's CTA; commit is batched on Done (online: direct Supabase upsert; offline: enqueued via the existing mutation queue with temporary ids).
- Adds place-aware iNat enrichment: new `/api/species/[id]` route + shared `inat-projection.ts` helper + module-scope `place-id-cache.ts` LRU (max 500, in-flight dedup, 5s timeout). `/api/species/search` and `/api/species/nearby` now accept optional `lat`/`lng` and project `establishment_means`, `iucn_code`, `nearby_count`, `photo_square_url` through.
- Curated `CAVITY_NESTER_TAXON_IDS` (35 seed ids) at `src/lib/species/cavity-nesters.ts` — the pattern for fields iNat doesn't structure. Documented in ADR-0003.

## Commits

- `ec1f5d6` feat(species): extend types, add place-aware detail route, curated cavity-nesters
- `a0c6d2e` feat(species-picker): full-screen bottom-sheet grid with staged commit
- `4e0eeeb` docs(adr): 0003 species picker architecture

## Invariants preserved

- `UpdateForm.tsx` **not** modified. `SpeciesPicker` props contract unchanged: `{entityTypeId, entityTypeName, orgId, selectedIds, onChange, lat, lng}`.
- `MultiSnapBottomSheet.tsx` **not** modified — current auto-full behavior is sufficient.
- `useUserLocation` is consumed passively (read `position` only); never calls `startTracking()` from inside the picker, matching the existing "no unsolicited permission prompts on non-map pages" invariant.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-19-species-picker-grid-design.md` (on `docs/adr-catchup-20260417`).
- Plan: `docs/superpowers/plans/2026-04-19-species-picker-grid.md` (same branch).
- ADR: `docs/adr/0003-species-picker-architecture.md` (this PR).

## Test plan

- [x] `npm run type-check` — only pre-existing unrelated errors (`@turf/union`, `leaflet-draw`, `resend`); zero new errors.
- [x] `npm test` — 1288/1288 pass in the real tree. 59 species-scope tests across 8 files.
- [ ] Smoke-test in `npm run dev`: open picker on an update form, toggle Nearby/Recent/All tabs, use Native and Cavity nester filter chips.
- [ ] Tap a card → detail subview → sticky "Add to this update" CTA toggles selection.
- [ ] Multi-select (3+ taxa) → Done → verify single onChange fires with all entity ids, `entities` insertions happen once each.
- [ ] External_id dedup: pick a taxon that already has an entity row → verify no duplicate insert.
- [ ] Offline flow: airplane mode → open picker → Recent tab loads from offline-cached `entities` → add a new taxon → Done → verify `entities.put` + `enqueueMutation` fire; re-connect and verify sync engine reconciles the temporary id.
- [ ] Pill `×` removal calls onChange immediately (no sheet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)