### PR TITLE
fix(offline): reconcile deletions in offline sync engine

### DIFF
--- a/src/lib/offline/sync-engine.ts
+++ b/src/lib/offline/sync-engine.ts
@@ -186,6 +186,42 @@ export async function syncPropertyData(
       await table.bulkPut(withSyncedAt);
     }
 
+    // Reconcile deletions: delta sync (keyed on created_at / updated_at) can
+    // never detect hard-deleted rows on the server — the local cache would
+    // keep the deleted row forever, causing UI drift (e.g., item detail shows
+    // a photo that the edit page no longer lists). Re-query the authoritative
+    // ID set for this table+scope and drop any local rows that are missing.
+    // Cheap: select id only, bounded by property/org scope.
+    const scopeColumn = propertyScoped.includes(tableName)
+      ? 'property_id'
+      : orgScoped.includes(tableName)
+      ? 'org_id'
+      : null;
+    if (scopeColumn) {
+      const { data: idRows, error: idError } = await supabase
+        .from(tableName)
+        .select('id')
+        .eq(scopeColumn, scopeColumn === 'property_id' ? propertyId : orgId);
+      if (!idError && idRows) {
+        const serverIds = new Set((idRows as Array<{ id: string }>).map((r) => r.id));
+        const scopeValue = scopeColumn === 'property_id' ? propertyId : orgId;
+        const localRows = (await db
+          .table(tableName)
+          .where(scopeColumn)
+          .equals(scopeValue)
+          .toArray()) as Array<{ id: string; _synced_at?: string }>;
+        // Only delete rows that have been synced from the server at some point.
+        // Rows with empty _synced_at are local pending inserts — the server
+        // doesn't have them yet, so their absence from the ID set is expected.
+        const toDelete = localRows
+          .filter((r) => !serverIds.has(r.id) && !!r._synced_at)
+          .map((r) => r.id);
+        if (toDelete.length > 0) {
+          await db.table(tableName).bulkDelete(toDelete);
+        }
+      }
+    }
+
     const totalCount = await db.table(tableName).count();
     await db.sync_metadata.put({
       id: metaId, property_id: propertyId, table_name: tableName,


### PR DESCRIPTION
## Summary

Offline sync uses delta sync keyed on `created_at >= lastSynced` (`src/lib/offline/sync-engine.ts:168-171`) — it pulls new or updated rows but **never sees hard deletions**. Server DELETEs leave the IndexedDB row behind, so the local cache drifts until the table is rebuilt.

Observed symptom: after removing a photo via the item edit form, the item detail panel (which reads from IndexedDB via `offlineStore.getPhotos`) keeps showing the deleted photo, while the edit page (which reads Supabase directly) correctly shows it gone.

## Fix

After the delta pull for each property/org-scoped table, fetch the authoritative ID set from the server (`select id where property_id=X` or `where org_id=X`) and `bulkDelete` any local rows missing from it.

Guarded by `_synced_at` so pending local inserts (the server hasn't processed them yet) aren't accidentally wiped during the brief window between local write and outbound mutation processing — `_synced_at` is `''` for those and set to a timestamp only once the row came from a server pull.

## Test plan

- [x] `npm run type-check`
- [x] `npx vitest run src/lib/offline/` — 38/38 pass
- [ ] Manual: upload two photos to an item, delete one via the edit form, confirm item detail panel matches edit page (1 photo)
- [ ] Manual: go offline, add a new photo, come back online — the pending local row should sync up, not be deleted by reconciliation mid-window

## Scope note

This covers all scope-synced tables (`items`, `item_updates`, `photos`, `entities`, `item_types`, etc.), not just photos — so the same class of drift in any of them is corrected on every sync tick. Cost is one `select id` query per table per sync, bounded by scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)