### PR TITLE
fix(offline): pass org_id/property_id explicitly when inserting photos

### DIFF
--- a/src/lib/offline/sync-engine.ts
+++ b/src/lib/offline/sync-engine.ts
@@ -66,11 +66,19 @@ async function executeMutation(
       return `Photo upload failed: ${uploadError.message}`;
     }
 
+    // Pass org_id + property_id explicitly rather than relying on the
+    // auto_populate_org_property trigger, which derives property_id from
+    // `orgs.default_property_id` — wrong whenever the item isn't on the
+    // user's default property, and silently causes the RLS check to fail
+    // against the wrong property. The mutation carries the correct scope
+    // (set when enqueued for the specific item).
     const { error: photoInsertError } = await supabase.from('photos').insert({
       item_id: photoBlob.item_id,
       update_id: photoBlob.update_id,
       storage_path: storagePath,
       is_primary: photoBlob.is_primary,
+      org_id: mutation.org_id,
+      property_id: mutation.property_id,
     });
 
     if (photoInsertError) {


### PR DESCRIPTION
## Summary

Photos added via the item edit form (and any caller that goes through `storePhotoBlob` + the offline mutation queue) were silently failing to persist — the blob uploaded to storage but the `photos` row never appeared on the item detail panel or the edit page.

## Root cause

The photo insert in `executeMutation` (`src/lib/offline/sync-engine.ts:69`) was calling:

```ts
supabase.from('photos').insert({
  item_id, update_id, storage_path, is_primary,
})
```

Relying on the `auto_populate_org_property` trigger (migration `009_properties_and_permissions.sql:290`) to fill `org_id` and `property_id`. But that trigger derives `property_id` from `orgs.default_property_id` — **the user's default property, not the item's property**:

```sql
IF TG_ARGV[0] = 'property_scoped' AND NEW.property_id IS NULL THEN
  NEW.property_id := (SELECT default_property_id FROM public.orgs WHERE id = NEW.org_id);
END IF;
```

Consequences:

- For items on the user's default property: the row ends up with the right `property_id` by coincidence. Works, but fragile.
- For items on any other property: the row lands with the wrong `property_id`, and the `photos_insert` RLS policy (`check_permission(auth.uid(), property_id, 'attachments', 'upload')`) checks the user's permission against the wrong property. If the user lacks `attachments.upload` on their default property, the insert is rejected. Blob sits in storage orphaned; no `photos` row is created. UI silently shows nothing.

## Fix

Pass `org_id` and `property_id` from the mutation (which was enqueued with the item's actual scope by `EditItemForm`) into the insert. The trigger's `IF NEW.property_id IS NULL` branch no longer fires, so the row lands with the correct scope regardless of what the org's default happens to be.

```ts
supabase.from('photos').insert({
  item_id, update_id, storage_path, is_primary,
  org_id: mutation.org_id,
  property_id: mutation.property_id,
})
```

## Out of scope

Authenticated photo uploads bypass image moderation entirely — tracked as #269. This PR is intentionally scoped to the insert-scope bug that was blocking the feature; the moderation gap is a separate architectural issue.

## Test plan

- [x] `npm run type-check`
- [x] `npx vitest run src/lib/offline/` — 38/38 pass
- [ ] Manual: on an item that is NOT on the org's default property, add a photo via the edit form, save, and confirm the photo appears on both the detail panel and the re-loaded edit page
- [ ] Manual: same flow on an item that IS on the default property — should continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)