### PR TITLE
fix(offline): mirror inserted photo into local cache after upload

### DIFF
--- a/src/lib/offline/sync-engine.ts
+++ b/src/lib/offline/sync-engine.ts
@@ -72,17 +72,31 @@ async function executeMutation(
     // user's default property, and silently causes the RLS check to fail
     // against the wrong property. The mutation carries the correct scope
     // (set when enqueued for the specific item).
-    const { error: photoInsertError } = await supabase.from('photos').insert({
-      item_id: photoBlob.item_id,
-      update_id: photoBlob.update_id,
-      storage_path: storagePath,
-      is_primary: photoBlob.is_primary,
-      org_id: mutation.org_id,
-      property_id: mutation.property_id,
-    });
+    const { data: insertedPhoto, error: photoInsertError } = await supabase
+      .from('photos')
+      .insert({
+        item_id: photoBlob.item_id,
+        update_id: photoBlob.update_id,
+        storage_path: storagePath,
+        is_primary: photoBlob.is_primary,
+        org_id: mutation.org_id,
+        property_id: mutation.property_id,
+      })
+      .select()
+      .single();
 
     if (photoInsertError) {
       return `Photo record insert failed: ${photoInsertError.message}`;
+    }
+
+    // Mirror the new row into IndexedDB so the item detail panel (which reads
+    // from the local cache via offlineStore.getPhotos) sees the photo as soon
+    // as the user navigates back — without waiting for the next inbound
+    // syncPropertyData tick. The OfflineProvider is mounted at the app root
+    // and its inbound-sync effect only re-runs on propertyId / isOnline
+    // change, so route navigation alone doesn't refresh the cache.
+    if (insertedPhoto) {
+      await db.photos.put({ ...insertedPhoto, _synced_at: new Date().toISOString() });
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #270. Photos still don't appear on the item detail panel after being added via the edit form, even though PR #270 fixed the server-side insert.

## Root cause

The sync engine's photo branch inserts into Supabase but never writes the row into local IndexedDB:

```ts
// BEFORE (on main)
const { error } = await supabase.from('photos').insert({...});
// no local write
```

`DetailPanel` reads from `offlineStore.getPhotos(itemId)` — which queries `db.photos` — so it never sees the new row. Inbound `syncPropertyData` is what would normally pull it back, but `OfflineProvider` mounts once at `src/app/layout.tsx:77` and its inbound-sync `useEffect` only re-runs on `propertyId` / `isOnline` change. Navigating from `/manage/edit/[id]` back to the map doesn't trigger either, so the cache stays stale until the 5-minute poll tick or a hard refresh.

The delete path already updates the local cache inline at `EditItemForm.tsx:263` (`await offlineStore.db.photos.delete(photoId)`). This PR closes the symmetric gap on the insert path.

## Fix

Capture the inserted row via `.select().single()` and `db.photos.put()` it with `_synced_at` set. The detail panel sees the photo immediately on the next read — no wait for background sync.

```ts
const { data: insertedPhoto, error: photoInsertError } = await supabase
  .from('photos')
  .insert({...})
  .select()
  .single();
...
if (insertedPhoto) {
  await db.photos.put({ ...insertedPhoto, _synced_at: new Date().toISOString() });
}
```

The `_synced_at` field matters: the reconciliation logic added in #268 only deletes rows that have `_synced_at` set (i.e., server-synced, not pending-local-insert). Setting it here keeps the new row safe from reconciliation AND marks it as server-confirmed for subsequent drift detection.

## Why this was missing from #270

I pushed this commit to the #270 branch 7 minutes after that PR was squash-merged, so it never made it into the merge. Creating as a fresh PR off current main.

## Test plan

- [x] `npm run type-check`
- [x] `npx vitest run src/lib/offline/` — 38/38 pass
- [ ] Manual: add a photo via edit form → save → navigate to item detail → photo appears immediately (no 5-min wait)
- [ ] Manual: repeat on an item on a non-default property (the case #270 unblocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)