### PR TITLE
fix(offline): defer triggerSync so photo blobs attach before outbound processes the mutation

### DIFF
--- a/src/lib/offline/provider.tsx
+++ b/src/lib/offline/provider.tsx
@@ -138,24 +138,33 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
     getPhotos: (itemId) => store.getPhotos(db, itemId),
     getEntities: (orgId) => store.getEntities(db, orgId),
     getEntityTypes: (orgId) => store.getEntityTypes(db, orgId),
+    // triggerSync must be scheduled as a macrotask (setTimeout 0), not a
+    // microtask. Callers routinely do more awaited work after this mutation
+    // resolves — e.g. EditItemForm stores photo blobs keyed by the returned
+    // mutationId. If triggerSync ran as a microtask, processOutboundQueue
+    // could pick up the mutation and call getPhotoBlobs() BEFORE the blob
+    // has been written, silently dropping the photos (the mutation completes
+    // without uploading them and removePhotoBlobsByMutation then deletes
+    // any blobs that arrived too late). Deferring via setTimeout lets the
+    // caller's microtask chain finish first.
     insertItem: (params) => {
       const result = store.insertItem(db, params);
-      result.then(() => { refreshPendingCount(); triggerSync(); });
+      result.then(() => { refreshPendingCount(); setTimeout(triggerSync, 0); });
       return result;
     },
     updateItem: (itemId, changes, orgId, propertyId) => {
       const result = store.updateItem(db, itemId, changes, orgId, propertyId);
-      result.then(() => { refreshPendingCount(); triggerSync(); });
+      result.then(() => { refreshPendingCount(); setTimeout(triggerSync, 0); });
       return result;
     },
     deleteItem: (itemId, orgId, propertyId) => {
       const result = store.deleteItem(db, itemId, orgId, propertyId);
-      result.then(() => { refreshPendingCount(); triggerSync(); });
+      result.then(() => { refreshPendingCount(); setTimeout(triggerSync, 0); });
       return result;
     },
     insertItemUpdate: (params) => {
       const result = store.insertItemUpdate(db, params);
-      result.then(() => { refreshPendingCount(); triggerSync(); });
+      result.then(() => { refreshPendingCount(); setTimeout(triggerSync, 0); });
       return result;
     },
     syncProperty,


### PR DESCRIPTION
## Summary

Photos added via the edit form still aren't appearing on item detail even after #270 and #271. Root cause is a JS event-loop race between the mutation queue sync trigger and the photo blob writes.

## Root cause

The `OfflineProvider` wrappers around `insertItem` / `updateItem` / `deleteItem` / `insertItemUpdate` fire `triggerSync()` from a `.then()` callback (`src/lib/offline/provider.tsx:141-160`). `.then` runs as a **microtask**, which means it executes immediately after the mutation resolves — and **before** the caller's `await` continuation.

The EditItemForm sequence:

```ts
const { mutationId } = await offlineStore.updateItem(...)  // mutation enqueued
// ... more awaited enqueueMutation calls for item_entities, photo deletes ...
for (...) {
  await storePhotoBlob(db, { mutation_id: mutationId, ... })  // <-- blobs written
}
```

Because microtasks run in registration order, the provider's `.then()` is already queued by the time `await offlineStore.updateItem(...)` returns. So the actual execution order is:

1. Mutation enqueued, promise resolves.
2. Provider's `.then()` fires → `triggerSync()` starts.
3. `triggerSync` awaits `supabase.auth.getUser()` → yields.
4. EditItemForm's continuation runs → starts storing photo blobs.
5. Each `storePhotoBlob` is an await → yields.
6. Auth returns → `processOutboundQueue` runs → picks up the items-update mutation → calls `getPhotoBlobs(mutation.id)` → **returns `[]`** because the blobs aren't all written yet.
7. The for-loop body doesn't execute. No photo uploads. Mutation operation (items update) runs and succeeds.
8. `markCompleted` → `removePhotoBlobsByMutation(mutation.id)` → any blobs that did land in the meantime get **deleted**.
9. EditItemForm finishes storing remaining blobs → they sit orphaned (or were already deleted in step 8).

Net result: the photo row never makes it to the server, and both the edit page and the detail panel show nothing. This explains why the user kept seeing the bug despite #270 (scope fix) and #271 (cache mirror) — neither of those paths ever ran because `getPhotoBlobs` returned empty.

## Fix

Defer `triggerSync` to the **macrotask** queue via `setTimeout(fn, 0)`. Macrotasks run after ALL queued microtasks drain, so the caller's entire microtask chain — including every `storePhotoBlob` — completes before sync picks up the mutation.

```ts
// Before:
result.then(() => { refreshPendingCount(); triggerSync(); });

// After:
result.then(() => { refreshPendingCount(); setTimeout(triggerSync, 0); });
```

Applied to all four wrappers for consistency; the same race applies to any form that enqueues a mutation and attaches photo blobs (update forms, create forms, etc.).

## Test plan

- [x] `npm run type-check`
- [x] `npx vitest run src/lib/offline/` — 38/38 pass
- [ ] Manual: add a photo via edit form → save → check detail panel shows the photo (the whole point)
- [ ] Manual: verify existing flows still sync (edit form without photos, item create, update create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)