### PR TITLE
fix(offline): photo storage path must start with org_id (vault-public RLS)

### DIFF
--- a/src/lib/offline/sync-engine.ts
+++ b/src/lib/offline/sync-engine.ts
@@ -57,7 +57,14 @@ async function executeMutation(
   // Handle photo uploads first if this mutation has associated blobs
   const photoBlobs = await getPhotoBlobs(db, mutation.id);
   for (const photoBlob of photoBlobs) {
-    const storagePath = `${photoBlob.item_id}/${Date.now()}_${photoBlob.filename}`;
+    // The vault-public bucket RLS (migration 026) requires the first path
+    // segment to be an org_id the user has active membership in:
+    //   (storage.foldername(name))[1] in (select id::text from orgs where
+    //     id in (select user_active_org_ids()))
+    // Previously we uploaded to `${item_id}/...` which always failed the
+    // RLS check; every photo upload through this path was silently rejected
+    // and the mutation retried up to MAX_RETRIES with no visible error.
+    const storagePath = `${mutation.org_id}/${photoBlob.item_id}/${Date.now()}_${photoBlob.filename}`;
     const { error: uploadError } = await supabase.storage
       .from('vault-public')
       .upload(storagePath, photoBlob.blob);


### PR DESCRIPTION
## Summary

Photo uploads from `EditItemForm` (and any caller of `storePhotoBlob` + mutation queue) were being **silently rejected at the storage layer** by RLS on the `vault-public` bucket. The three previous PRs (#270, #271, #272) all fixed real bugs, but none of their code ever executed because the upload itself returned an error first.

## Root cause

The `vault-public` bucket policy in `supabase/migrations/026_data_vault.sql:162-168`:

\`\`\`sql
create policy vault_public_insert on storage.objects
  for insert with check (
    bucket_id = 'vault-public'
    and (storage.foldername(name))[1] in (
      select id::text from orgs where id in (select user_active_org_ids())
    )
  );
\`\`\`

The **first folder segment of the storage path must be an org_id** the caller is a member of. But `executeMutation` was uploading to:

\`\`\`ts
const storagePath = \`\${photoBlob.item_id}/\${Date.now()}_\${photoBlob.filename}\`;
\`\`\`

First folder = \`item_id\`. It will never match an org_id. The RLS check fails, \`supabase.storage.from('vault-public').upload(...)\` returns an error, \`executeMutation\` returns \`"Photo upload failed: ..."\`, the mutation is marked failed, and is retried up to \`MAX_RETRIES = 5\` on every subsequent sync — same path, same failure, every time.

## Why it looked like a mystery

I spent three PRs fixing downstream code that never ran:

- **#270** added \`org_id\`/\`property_id\` to the \`photos\` insert — fix was correct, but the insert never executed because the storage upload failed first.
- **#271** mirrored the inserted row into IndexedDB via \`.select().single()\` — same story.
- **#272** deferred \`triggerSync\` to a macrotask to avoid a blob-storage race — valid bug, but orthogonal.

All three are still useful and will apply correctly once the storage upload actually succeeds.

## Fix

Match the path convention used by \`uploadToVault\` (\`src/lib/vault/actions.ts:42\`), which is already compliant:

\`\`\`ts
// BEFORE
const storagePath = \`\${photoBlob.item_id}/\${Date.now()}_\${photoBlob.filename}\`;

// AFTER
const storagePath = \`\${mutation.org_id}/\${photoBlob.item_id}/\${Date.now()}_\${photoBlob.filename}\`;
\`\`\`

\`mutation.org_id\` is set when the mutation is enqueued with the item's actual org (via \`EditItemForm\` → \`offlineStore.updateItem\`).

## Cleanup note

Users who hit this bug have failed mutations stuck in their local \`OfflineDB.mutation_queue\` with \`retry_count >= MAX_RETRIES\`. Those won't auto-retry even after the fix deploys — they're skipped. New mutations (created after the fix deploys) will work. Users can clear the stuck ones via browser DevTools → Application → IndexedDB → delete \`OfflineDB.mutation_queue\` rows. A follow-up PR could auto-prune mutations that have been failed > N days.

## Test plan

- [x] \`npm run type-check\`
- [x] \`npx vitest run src/lib/offline/\` — 38/38 pass
- [ ] Manual: add a photo via edit form → save → confirm photo appears on detail panel AND edit page (both should work together now that storage upload + insert + cache mirror all run in sequence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)