### PR TITLE
fix(delete): invalidate offline cache after soft-delete

### DIFF
--- a/docs/adr/0006-offline-cache-soft-delete-visibility.md
+++ b/docs/adr/0006-offline-cache-soft-delete-visibility.md
@@ -1,0 +1,96 @@
+# ADR-0006: Offline Cache Must Mirror Server-Side RLS Visibility Filters (Soft-Delete in Particular)
+
+**Status:** Accepted
+
+**Date:** 2026-04-22
+
+**Owners:** @patjackson52
+
+## Context
+
+FieldMapper's offline-first PWA caches `item_updates` (and a dozen other tables) in IndexedDB via the sync engine in `src/lib/offline/sync-engine.ts`. The sync engine uses two mechanisms to keep the local cache in step with Supabase:
+
+1. **Delta sync** — on each `syncPropertyData` tick, re-fetch rows whose `updated_at` (or `created_at`, for tables without `updated_at`) is newer than the last sync. Cheap and bandwidth-efficient.
+2. **ID reconciliation** — fetch the full set of authoritative row ids for the scope, compare against local ids, and bulk-delete any local row the server no longer returns. Added by ADR-0002 after delta sync was shown to be blind to hard-deletes.
+
+PR #275 (update delete flow) introduced soft-delete on `item_updates` via `deleted_at` + a RESTRICTIVE RLS policy `item_updates_hide_deleted`. The server-side half worked correctly on day one: RLS filtered soft-deleted rows out of every read, including the one the reconciliation pass issues. But the feature shipped with a bug: deleted updates stayed visible in the UI after a successful server delete and an 8-second toast window, and only disappeared after the next sync trigger (online event, visibility change, or 5-minute poll).
+
+Root cause:
+
+- `item_updates` has no `updated_at` column, so delta sync is keyed on `created_at`. Soft-delete doesn't change `created_at`, so delta sync never re-fetches the row.
+- The ID reconciliation pass *would* catch it (the server's id set no longer includes the row under RLS), but reconciliation only runs during `syncPropertyData`, which mutations do not invoke.
+- `router.refresh()` — the only invalidation lever the feature used — re-runs server components but has no effect on IndexedDB or on client state previously hydrated from it. The parent component (`HomeMapView`) snapshots `updates` from `offlineStore.getItemUpdates()` at marker-click time; that snapshot stays in React state across the delete.
+
+In short: **any server-side visibility filter that can hide a row without mutating the delta-sync timestamp is invisible to the cache until the next full sync tick.** Soft-delete is the first case we hit; future equivalents (moderation queues with `published_at`, role-based scope changes, tombstoned status values) have the same shape.
+
+## Decision
+
+Adopt the following invariant for features that introduce server-side visibility filters:
+
+> **If a column or predicate can change whether a row is visible to a given reader under RLS without also bumping `updated_at`/`created_at`, the feature MUST:**
+>
+> 1. Either (a) bump `updated_at` on the change so delta sync picks it up, OR
+> 2. Provide an immediate client-side eviction and an explicit `triggerSync` / reconciliation path so the cache does not lie to the UI between mutation and next sync tick.
+
+For the update delete flow specifically, option 2 was chosen because `item_updates.created_at` is the historical event date (not a mutation timestamp) and bumping it on delete would corrupt timeline ordering. The concrete implementation:
+
+- The Zustand `deleteSlice` carries both the `pending` record (for the undo toast) and a `hiddenUpdateIds` list (an optimistic client filter).
+- `DetailPanel.handleDeleteUpdate` (after the server action succeeds) marks the id hidden, evicts the row from IndexedDB via `getOfflineDb().item_updates.delete(id)`, and filters `item.updates` before passing it to the layout renderer.
+- `DeleteToastHost.handleUndo` restores the row to IndexedDB via `db.item_updates.put(savedRow)` and clears the hidden flag.
+- `DeleteToastHost.handleExpire` leaves the hidden flag set (the row is gone server-side and from IndexedDB; the extra filter is belt-and-suspenders until page reload).
+
+This pattern — **optimistic local eviction + optional server-backed restore on undo + hidden-id filter on the derived UI state** — is the blessed template for any soft-delete-style feature.
+
+A companion refactor (tracked as a follow-up issue, not in this PR) will lift this logic into the sync engine itself, so future features don't have to hand-roll the eviction. Specifically: the reconciliation pass will (a) select `id, deleted_at` where the column exists and treat non-null `deleted_at` the same as "absent from server", and (b) expose an `evictLocal(table, id)` helper so mutation paths have a one-liner instead of `getOfflineDb().X.delete(id)` scattered everywhere. Until then, the per-feature pattern above is the contract.
+
+## Alternatives Considered
+
+- **Bump `updated_at` on soft-delete.** Would make delta sync detect the change naturally and is the cleanest mechanism — but `item_updates` has no `updated_at` column at all, and `created_at` is semantically the observation date (ordering anchor for the timeline). Adding `updated_at` to `item_updates` and backfilling it was rejected as out-of-scope for the delete PR; it's a reasonable follow-up if future features need more change detection on updates.
+
+- **Fire `syncPropertyData` after the server action succeeds.** Would eventually reconcile via the existing ID pass, but the round-trip is several hundred ms and the toast window is 8 s — UX would feel laggy, and a flaky network would leave the row visible after the toast disappears. Rejected as the sole mechanism; can be added as a belt-and-suspenders later.
+
+- **Broadcast a "row evicted" event through a client-side pub/sub.** A reactive layer (Zustand slice per table, or Dexie `liveQuery` subscriptions) would make cached reads auto-update. Larger architectural change, appropriate if/when a third bug in this class shows up. Deferred.
+
+- **Server-side hard-delete instead of soft-delete.** Sidesteps the cache-visibility problem entirely (a hard-delete is caught by the existing reconciliation pass). But loses the 8-second undo window and the audit trail, which are the whole point of this feature. Rejected.
+
+## Decision Drivers
+
+- **Failure mode is silent.** Server works, toast appears, network looks fine — but the UI lies. This mirrors the same "invisible failure" pattern ADR-0002 and ADR-0004 are about; the cost of rediscovery is high and the debugging surface is broad.
+- **The invariant generalizes.** Soft-delete is the first instance, not the last. Moderation queues with `published_at`, scheduled content with `scheduled_for`, role-driven hides via `visible_to` arrays — anything that flips visibility without changing the sync key fits the same pattern.
+- **The sync engine's reconciliation pass already understands visibility.** It was designed for hard-delete but the mechanism works for soft-delete if we teach it about `deleted_at`. The refactor is small and the primitive is reusable.
+- **Per-feature mitigation is cheap in isolation but expensive in aggregate.** Three features each adding their own eviction logic is a 10-minute cost each plus a shared "did everyone remember?" review burden. One sync-engine change retires the category.
+
+## Consequences
+
+**Positive:**
+- Future features that hide rows via RLS filters inherit a documented pattern (this ADR) and — once the sync-engine refactor lands — a central mechanism instead of per-feature eviction.
+- The pattern of "client-side hidden-id filter + IndexedDB eviction + undo-aware restore" is now named and reusable.
+- Future reviewers can reject PRs that ship a new visibility filter without either bumping `updated_at` or providing eviction logic, with a concrete ADR to cite.
+
+**Negative:**
+- Until the sync-engine refactor lands, each feature adding a new visibility filter has to copy the eviction pattern by hand. That duplication is a latent source of drift.
+- The `hiddenUpdateIds` client-side filter is session-scoped; a tab refresh clears it. On expire, the row is still filtered because the server also stops returning it — but any gap between "evict from cache" and "next server read" could theoretically leak the row back in if sync runs before the UI filter can hide it. In practice the eviction happens before `router.refresh()`, so the gap is empty.
+
+**Neutral:**
+- `hiddenUpdateIds` grows monotonically within a session; for delete-heavy sessions (thousands of deletes) this would matter, but realistic usage is at most a handful per session.
+- Storing the full saved row in the pending state (for undo restore) is an extra kilobyte or two of in-memory state. Negligible; simpler than re-fetching on undo.
+
+## Related Files
+
+- `src/lib/offline/sync-engine.ts:218` — the existing ID reconciliation pass, the natural home for the follow-up refactor
+- `src/lib/offline/store.ts:31` — `getItemUpdates` reads IndexedDB, no `deleted_at` filter at the store level (RLS filters server-side but the local copy is canonical for reads)
+- `src/stores/deleteSlice.ts` — Zustand slice with the `hiddenUpdateIds` invariant
+- `src/components/item/DetailPanel.tsx` — eviction on delete, restore on undo
+- `src/components/delete/DeleteToastHost.tsx` — undo / expire handling
+- `docs/adr/0002-offline-cache-drift-prevention.md` — sibling ADR; the hard-delete counterpart
+- `docs/adr/0004-offline-outbound-mutation-invariants.md` — sibling ADR; the outbound-mutation counterpart
+- `docs/adr/0005-update-soft-delete-and-undo-tokens.md` — the feature ADR; this ADR extends its "Consequences" with the client-cache constraint
+
+## Related Issues / PRs
+
+- #275 — update delete flow (this ADR emerged from post-deploy debugging on that branch)
+- #276 — follow-up: centralize soft-delete awareness in the offline sync engine
+
+## Tags
+
+`offline-sync`, `rls`, `soft-delete`, `indexeddb`, `cache-invariants`, `sync-engine`

--- a/src/components/delete/DeleteToastHost.tsx
+++ b/src/components/delete/DeleteToastHost.tsx
@@ -5,10 +5,12 @@ import { useDeleteStore } from '@/stores/deleteSlice';
 import { UndoToast } from './UndoToast';
 import { undoDeleteUpdate } from '@/app/items/[itemId]/updates/actions';
 import { track } from '@/lib/telemetry/track';
+import { getOfflineDb } from '@/lib/offline/db';
 
 export function DeleteToastHost() {
   const pending = useDeleteStore((s) => s.pending);
   const clearPending = useDeleteStore((s) => s.clearPending);
+  const unmarkHidden = useDeleteStore((s) => s.unmarkHidden);
   const router = useRouter();
 
   const handleUndo = async () => {
@@ -17,11 +19,28 @@ export function DeleteToastHost() {
     const elapsedMs = Date.now() - started;
     const res = await undoDeleteUpdate({ updateId: pending.updateId, undoToken: pending.undoToken });
     if ('success' in res) {
+      // Restore the row to the offline cache so the parent's next read sees it.
+      // If we never saved the row (e.g. delete came from a code path that
+      // didn't populate `pending.update`), skip — the next syncPropertyData
+      // reconciliation will re-fetch it from the server.
+      if (pending.update) {
+        try {
+          // Dexie accepts the enriched shape; sync will overwrite with the plain
+          // row later. Cast at the boundary since `Cached<ItemUpdate>` requires
+          // _synced_at which the saved row already has when it came from the
+          // offline cache.
+          await getOfflineDb().item_updates.put(pending.update as never);
+        } catch {
+          // best-effort
+        }
+      }
+      unmarkHidden(pending.updateId);
       track('update.delete.undone', { update_id: pending.updateId, elapsed_ms: elapsedMs });
       clearPending();
       router.refresh();
     } else {
-      // 'gone' or 'forbidden' — toast will fall off on next tick via onExpire
+      // 'gone' or 'forbidden' — row stays deleted server-side. Keep it hidden
+      // client-side; just dismiss the toast.
       clearPending();
     }
   };
@@ -29,6 +48,9 @@ export function DeleteToastHost() {
   const handleExpire = () => {
     if (!pending) return;
     track('update.delete.expired', { update_id: pending.updateId });
+    // Leave `hiddenUpdateIds` intact — the row is gone server-side and from
+    // IndexedDB (evicted at delete time); staying in the hidden list is a
+    // belt-and-suspenders filter until the page reloads.
     clearPending();
   };
 

--- a/src/components/delete/__tests__/UndoToast.test.tsx
+++ b/src/components/delete/__tests__/UndoToast.test.tsx
@@ -12,7 +12,7 @@ describe('UndoToast', () => {
     const expiresAtMs = Date.now() + 5500;
     render(
       <UndoToast
-        pending={{ updateId: 'u-1', undoToken: 't', expiresAtMs }}
+        pending={{ updateId: 'u-1', undoToken: 't', expiresAtMs, update: null }}
         onUndo={() => {}}
         onExpire={() => {}}
       />
@@ -24,7 +24,7 @@ describe('UndoToast', () => {
     const onUndo = vi.fn();
     render(
       <UndoToast
-        pending={{ updateId: 'u-1', undoToken: 't', expiresAtMs: Date.now() + 8000 }}
+        pending={{ updateId: 'u-1', undoToken: 't', expiresAtMs: Date.now() + 8000, update: null }}
         onUndo={onUndo}
         onExpire={() => {}}
       />
@@ -38,7 +38,7 @@ describe('UndoToast', () => {
     const onExpire = vi.fn();
     render(
       <UndoToast
-        pending={{ updateId: 'u-1', undoToken: 't', expiresAtMs: Date.now() + 200 }}
+        pending={{ updateId: 'u-1', undoToken: 't', expiresAtMs: Date.now() + 200, update: null }}
         onUndo={() => {}}
         onExpire={onExpire}
       />

--- a/src/components/item/DetailPanel.tsx
+++ b/src/components/item/DetailPanel.tsx
@@ -8,6 +8,7 @@ import { TimelineRail } from './timeline/TimelineRail';
 import MultiSnapBottomSheet, { type SheetState } from '@/components/ui/MultiSnapBottomSheet';
 import { formatDate } from '@/lib/utils';
 import { useEffect, useState } from 'react';
+import { getOfflineDb } from '@/lib/offline/db';
 import { useUserLocation } from '@/lib/location/provider';
 import { getDistanceToItem, formatDistance } from '@/lib/location/utils';
 import Link from 'next/link';
@@ -66,6 +67,8 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   const { userBaseRole } = usePermissions();
   const userRole = mapUserBaseRole(userBaseRole);
   const setPending = useDeleteStore((s) => s.setPending);
+  const markHidden = useDeleteStore((s) => s.markHidden);
+  const hiddenUpdateIds = useDeleteStore((s) => s.hiddenUpdateIds);
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
@@ -107,6 +110,9 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
       role: permission.kind,
       is_own: permission.kind === 'author',
     });
+    // Save the original row (from item.updates, hydrated from the offline
+    // cache) so we can restore it to IndexedDB if the user undoes.
+    const savedUpdate = item?.updates.find((u) => u.id === updateId) ?? null;
     const res = await softDeleteUpdate(updateId);
     if ('error' in res) {
       console.error('delete failed:', res.error);
@@ -120,7 +126,20 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
       updateId,
       undoToken: res.undoToken,
       expiresAtMs: res.expiresAtMs,
+      update: savedUpdate,
     });
+    // Optimistic UI: hide this id from the current render. item.updates is
+    // parent-owned React state hydrated from IndexedDB at marker-click time,
+    // so we can't mutate it here — filter via the store in `filteredItem`.
+    markHidden(updateId);
+    // Evict from the offline IndexedDB cache so subsequent reads (on next
+    // marker click or sync reconciliation) don't repopulate the stale row.
+    // If this fails, the sync reconciliation pass will eventually clean it up.
+    try {
+      await getOfflineDb().item_updates.delete(updateId);
+    } catch {
+      // best-effort; no action needed
+    }
     router.refresh();
   };
 
@@ -128,6 +147,14 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
   // undo toast persists if the user closes the panel immediately after a
   // delete. Only the DetailPanel chrome is gated on `item`.
   if (!item) return <DeleteToastHost />;
+
+  // Filter optimistically-hidden updates out before handing to children.
+  const filteredItem = hiddenUpdateIds.length === 0
+    ? item
+    : {
+        ...item,
+        updates: item.updates.filter((u) => !hiddenUpdateIds.includes(u.id)),
+      };
 
   const distance = getDistanceToItem(position, item);
   const layout = item.item_type?.layout ?? null;
@@ -162,7 +189,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
       </div>
       <LayoutRendererDispatch
         layout={layout}
-        item={item}
+        item={filteredItem}
         mode="live"
         context={isMobile ? 'bottom-sheet' : 'side-panel'}
         sheetState={isMobile ? 'full' : undefined}
@@ -299,7 +326,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
           Updates
         </h3>
         <TimelineRail
-          updates={item.updates}
+          updates={filteredItem.updates}
           maxItems={10}
           showScheduled={true}
           canAddUpdate={!!canAddUpdate}

--- a/src/stores/__tests__/deleteSlice.test.ts
+++ b/src/stores/__tests__/deleteSlice.test.ts
@@ -4,19 +4,48 @@ import { useDeleteStore } from '../deleteSlice';
 describe('deleteSlice', () => {
   beforeEach(() => {
     useDeleteStore.getState().clearPending();
+    useDeleteStore.getState().hiddenUpdateIds.forEach((id) => {
+      useDeleteStore.getState().unmarkHidden(id);
+    });
   });
 
   it('sets a pending delete and exposes expiresAt', () => {
     const expiresAt = Date.now() + 8000;
-    useDeleteStore.getState().setPending({ updateId: 'u-1', undoToken: 'tok', expiresAtMs: expiresAt });
+    useDeleteStore.getState().setPending({
+      updateId: 'u-1',
+      undoToken: 'tok',
+      expiresAtMs: expiresAt,
+      update: null,
+    });
     const s = useDeleteStore.getState();
     expect(s.pending?.updateId).toBe('u-1');
     expect(s.pending?.expiresAtMs).toBe(expiresAt);
   });
 
   it('clearPending returns to null', () => {
-    useDeleteStore.getState().setPending({ updateId: 'u-1', undoToken: 't', expiresAtMs: Date.now() + 8000 });
+    useDeleteStore.getState().setPending({
+      updateId: 'u-1',
+      undoToken: 't',
+      expiresAtMs: Date.now() + 8000,
+      update: null,
+    });
     useDeleteStore.getState().clearPending();
     expect(useDeleteStore.getState().pending).toBe(null);
+  });
+
+  it('markHidden adds an id; unmarkHidden removes it', () => {
+    const store = useDeleteStore.getState();
+    store.markHidden('u-1');
+    store.markHidden('u-2');
+    expect(useDeleteStore.getState().hiddenUpdateIds).toEqual(['u-1', 'u-2']);
+    store.unmarkHidden('u-1');
+    expect(useDeleteStore.getState().hiddenUpdateIds).toEqual(['u-2']);
+  });
+
+  it('markHidden is idempotent', () => {
+    const store = useDeleteStore.getState();
+    store.markHidden('u-1');
+    store.markHidden('u-1');
+    expect(useDeleteStore.getState().hiddenUpdateIds).toEqual(['u-1']);
   });
 });

--- a/src/stores/deleteSlice.ts
+++ b/src/stores/deleteSlice.ts
@@ -1,21 +1,41 @@
 'use client';
 
 import { create } from 'zustand';
+import type { ItemUpdate } from '@/lib/types';
 
 export type PendingDelete = {
   updateId: string;
   undoToken: string;
   expiresAtMs: number;
+  /**
+   * The original row, saved so we can restore it to the offline cache on undo.
+   * Null if the caller couldn't locate the row (undo-restore will rely on the
+   * next syncPropertyData reconciliation instead).
+   */
+  update: ItemUpdate | null;
 };
 
 type State = {
   pending: PendingDelete | null;
+  /**
+   * Client-side filter for optimistically-hidden updates. Added on soft-delete,
+   * removed on successful undo, retained on toast expiry (row is gone
+   * server-side too, so staying hidden is correct).
+   */
+  hiddenUpdateIds: string[];
   setPending: (p: PendingDelete) => void;
   clearPending: () => void;
+  markHidden: (id: string) => void;
+  unmarkHidden: (id: string) => void;
 };
 
 export const useDeleteStore = create<State>((set) => ({
   pending: null,
+  hiddenUpdateIds: [],
   setPending: (p) => set({ pending: p }),
   clearPending: () => set({ pending: null }),
+  markHidden: (id) =>
+    set((s) => (s.hiddenUpdateIds.includes(id) ? s : { hiddenUpdateIds: [...s.hiddenUpdateIds, id] })),
+  unmarkHidden: (id) =>
+    set((s) => ({ hiddenUpdateIds: s.hiddenUpdateIds.filter((x) => x !== id) })),
 }));


### PR DESCRIPTION
## Summary

Follow-up to #275. After deploying that PR, users reported that the delete flow *appeared* to work — kebab → confirm → toast all fired correctly — but the deleted update stayed visible in the timeline until the next sync tick (up to 5 minutes later). This PR fixes the UI drift and adds an ADR codifying the invariant so future features don't repeat the class of bug.

## Root cause

The server-side delete worked on day one: the toast only appears if `softDeleteUpdate` returns a valid undo token, which requires the `UPDATE item_updates SET deleted_at = ...` to succeed and the subsequent read to see the row. RLS correctly hides soft-deleted rows from all downstream reads, including the reconciliation pass.

The bug is client-side: the UI reads updates from the **offline IndexedDB cache** (`offlineStore.getItemUpdates`), which is populated by `syncPropertyData` using delta-sync keyed on `item_updates.created_at`. Soft-delete doesn't change `created_at`, so delta-sync never re-fetches the row. The ID reconciliation pass *would* catch it — the server's id set no longer includes the row under RLS — but reconciliation only runs during `syncPropertyData`, which mutations don't invoke. `router.refresh()` re-runs server components but doesn't touch IndexedDB or the parent component's React state that was hydrated from it.

Net effect: server is correct, cache is stale, UI reads from cache, user sees ghost row until the next online event / visibility change / 5-min poll.

## Fix

Two layers, matching the pattern established by ADR 0002 (inbound drift) and 0004 (outbound mutation invariants):

1. **Optimistic client filter.** Extend `deleteSlice` with `hiddenUpdateIds` and a saved `ItemUpdate` on `pending` (for undo restore). `DetailPanel.handleDeleteUpdate` marks the id hidden and filters `item.updates` before handing it to children — the row disappears from the rendered timeline the moment the server action returns.
2. **Cache eviction.** `DetailPanel.handleDeleteUpdate` also calls `getOfflineDb().item_updates.delete(id)` so subsequent marker-click reads from IndexedDB don't resurrect the row. `DeleteToastHost.handleUndo` restores via `db.item_updates.put(savedRow)` and clears the hidden flag. `handleExpire` keeps the hidden flag set as belt-and-suspenders.

## ADR 0006

`docs/adr/0006-offline-cache-soft-delete-visibility.md` — codifies the invariant:

> Any server-side visibility filter that can hide a row without mutating the delta-sync timestamp (`updated_at`/`created_at`) is invisible to the cache until the next full-sync reconciliation tick, and must provide either (a) a timestamp bump or (b) explicit client eviction.

References sibling ADRs 0002 and 0004 so together they form the offline-sync contract, and points at #276 for the follow-up refactor that lifts soft-delete awareness into the sync engine itself (so future features don't have to hand-roll the eviction).

## Test plan

- [x] `npm run test` — 1338 passing (+2 new `deleteSlice` tests for `markHidden`/`unmarkHidden`)
- [x] `npm run type-check` — clean
- [ ] Manual smoke: delete own update → row disappears from timeline immediately, toast shows, Undo within 8s → row returns. Same flow but let toast expire → row stays gone without needing to wait for next sync tick or reload.
- [ ] Manual smoke: delete → close/reopen the item's bottom sheet → deleted row does not reappear (offline cache was evicted).
- [ ] Manual smoke: delete → Undo → close/reopen bottom sheet → restored row is present (re-put into cache on undo).

## Related

- PR #275 — introduced the feature that this PR fixes
- ADR 0005 — feature decision record (soft-delete + undo tokens)
- ADR 0006 — this PR (client-cache visibility invariant)
- Issue #276 — follow-up refactor: centralize soft-delete awareness in the sync engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)