### PR TITLE
fix(delete): service-role client for soft-delete UPDATE (RLS still blocks via SELECT USING)

### DIFF
--- a/docs/adr/0007-rls-policy-authoring-patterns.md
+++ b/docs/adr/0007-rls-policy-authoring-patterns.md
@@ -50,15 +50,23 @@ This means:
 
 Before merging any policy change, walk through the matrix: for every feature that mutates any column the policy references, does the post-mutation state still pass USING? If not, and the policy is RESTRICTIVE, expect errors.
 
-### 3. The PostgREST `return=representation` trap
+### 3. Any UPDATE via PostgREST enforces SELECT USING on the new row
 
-PostgREST's default `Prefer` header for `PATCH` (and `POST`) is `return=representation`. Supabase's `.update(...)` and `.insert(...)` both inherit this — they issue `UPDATE ... RETURNING` under the hood unless you explicitly pass `{ returning: 'minimal' }` or chain `.select()` in a way that opts out.
+PostgREST's default `Prefer` header for `PATCH` is `return=representation`, so Supabase's `.update(...)` issues `UPDATE ... RETURNING` under the hood. Postgres then evaluates SELECT policies' `USING` against the **new row** to decide visibility for the returned result. When that evaluation fails — *including* for a permissive SELECT policy with a single USING branch — the UPDATE is rejected with `new row violates row-level security policy for table "<table>"` (no policy name, because the rejection is "no permissive policy allowed the new row's post-state to be visible").
 
-Every mutation through `@supabase/supabase-js` therefore triggers the post-update SELECT policy evaluation described in rule 2. There is no way to write a client-side query that says "mutate this and don't look at the result" without passing the `returning: 'minimal'` option or sending raw SQL via a stored function.
+This is the trap that bit PR #275 twice:
 
-Implication: **policy authors should assume every mutation re-reads its result through SELECT RLS**, and design policies accordingly. The column-matrix walkthrough from rule 2 is not optional — it's part of writing the policy.
+- First attempt used a RESTRICTIVE policy with `USING (deleted_at IS NULL)`. New row with `deleted_at` populated failed → error named the policy explicitly.
+- Second attempt (migration 048) moved the filter into the permissive `item_updates_select` policy. New row still failed → error lost the policy name but the UPDATE was still rejected.
+- Third attempt (migration 048 + server-action refactor to service-role client) finally worked — because service role bypasses RLS entirely.
 
-If you find yourself tempted to use `returning: 'minimal'` in application code to work around a policy problem, stop: the problem is the policy, not the client. Fix the policy so the post-state passes its own USING; return=minimal should be reserved for deletes-without-restore or other cases where the client legitimately doesn't care about the result.
+**Implication:** any UPDATE via `@supabase/supabase-js` that mutates a column referenced by a SELECT policy's USING will be rejected whenever the post-update state fails that USING. You cannot flip a visibility-filter column from "visible" to "hidden" through a user-auth Supabase client. You have three options:
+
+1. **Use the service-role client for the mutation** (`createServiceClient()` from `@/lib/supabase/server`). Authorization must still be enforced via a pre-check (e.g., the `can_user_delete_update` RPC). This is the pragmatic fix for the update-delete flow.
+2. **Wrap the mutation in a SECURITY DEFINER RPC** that performs its own permission check and the UPDATE. Callers invoke `supabase.rpc('soft_delete_update', ...)` instead of `.from(...).update(...)`. Cleaner architecturally; more migration work.
+3. **Remove the visibility filter from RLS** and enforce it in application code. Rejected — loses defense in depth and every future read path has to remember to filter.
+
+Column-mutation matrix (repeat of rule 2): before merging a policy change, walk through every feature that mutates any column the policy references. For each one, does the post-mutation state still pass USING? If the new state *intentionally* fails USING (as with soft-delete), the mutation path needs option 1 or 2 above. Mocked unit tests won't catch this — only a real mutation through PostgREST will.
 
 ### 4. RLS-enabled tables need policies for every command the app uses
 

--- a/src/app/items/[itemId]/updates/__tests__/actions.test.ts
+++ b/src/app/items/[itemId]/updates/__tests__/actions.test.ts
@@ -20,6 +20,10 @@ vi.mock('@/lib/supabase/server', () => ({
     auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
     rpc: vi.fn().mockResolvedValue({ data: false, error: null }),
   })),
+  // The service-role client is used to perform the actual UPDATE + audit
+  // INSERT (bypasses the deleted_at SELECT USING clause that blocks the
+  // mutation under RLS).
+  createServiceClient: vi.fn(() => ({ from: mockFrom })),
 }));
 
 beforeEach(() => {

--- a/src/app/items/[itemId]/updates/actions.ts
+++ b/src/app/items/[itemId]/updates/actions.ts
@@ -1,12 +1,32 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { signUndoToken, verifyUndoToken } from '@/lib/delete-updates/undo-token';
 
 const UNDO_WINDOW_MS = 13_000; // 8s UI + 5s grace
 
 type SoftDeleteSuccess = { undoToken: string; expiresAtMs: number; deletedAt: string };
 type SoftDeleteError = { error: string };
+
+/**
+ * Why the service-role client is used for the mutations below:
+ *
+ * The item_updates_select SELECT policy includes `deleted_at IS NULL` in its
+ * USING expression (migration 048). Postgres enforces SELECT USING against
+ * the NEW row during UPDATE — not just for RETURNING, and not only when the
+ * policy is restrictive. When an authenticated user flips deleted_at to a
+ * non-null value, the new row no longer matches the SELECT USING, and
+ * Postgres throws 'new row violates row-level security policy for table
+ * "item_updates"'. See ADR-0007 and issue/PR thread on #278 for the full
+ * analysis.
+ *
+ * We've already authorized the caller via the `can_user_delete_update` RPC
+ * pre-check. Running the UPDATE + audit insert as the service role bypasses
+ * RLS on the mutation (which is what we need to transition deleted_at from
+ * null to not-null), without skipping authorization. Similarly for undo: the
+ * service role is needed to READ the soft-deleted row (hidden under RLS) and
+ * to UPDATE it back to visible.
+ */
 
 export async function softDeleteUpdate(
   updateId: string
@@ -16,7 +36,6 @@ export async function softDeleteUpdate(
   if (!userRes?.user) return { error: 'unauthenticated' };
   const actorId = userRes.user.id;
 
-  // Permission check is enforced by RLS; we still pre-check for a clean error
   const { data: canDelete, error: rpcErr } = await supabase.rpc(
     'can_user_delete_update',
     { p_user_id: actorId, p_update_id: updateId }
@@ -24,7 +43,6 @@ export async function softDeleteUpdate(
   if (rpcErr) return { error: rpcErr.message };
   if (!canDelete) return { error: 'forbidden' };
 
-  // Read the update first (for audit metadata + reason classification)
   const { data: row, error: readErr } = await supabase
     .from('item_updates')
     .select('id, created_by, org_id, property_id')
@@ -38,14 +56,15 @@ export async function softDeleteUpdate(
   const reason = isSelfDelete ? 'author' : 'moderation';
 
   const deletedAt = new Date().toISOString();
-  const { error: updErr } = await supabase
+  const service = createServiceClient();
+
+  const { error: updErr } = await service
     .from('item_updates')
     .update({ deleted_at: deletedAt, deleted_by: actorId, delete_reason: reason })
     .eq('id', updateId);
   if (updErr) return { error: updErr.message };
 
-  // Audit
-  await supabase.from('audit_log').insert({
+  await service.from('audit_log').insert({
     action: 'update.delete',
     update_id: updateId,
     actor_user_id: actorId,
@@ -78,7 +97,10 @@ export async function undoDeleteUpdate(
   if (verified.updateId !== args.updateId) return { error: 'forbidden' };
   if (verified.actorId !== actorId) return { error: 'forbidden' };
 
-  const { data: row } = await supabase
+  // Soft-deleted rows are invisible under the user-auth SELECT RLS, so use
+  // service role to read and to flip deleted_at back to null.
+  const service = createServiceClient();
+  const { data: row } = await service
     .from('item_updates')
     .select('id, created_by, deleted_at')
     .eq('id', args.updateId)
@@ -86,13 +108,13 @@ export async function undoDeleteUpdate(
   if (!row) return { error: 'not_found' };
   if (!row.deleted_at) return { success: true }; // already restored; idempotent
 
-  const { error: updErr } = await supabase
+  const { error: updErr } = await service
     .from('item_updates')
     .update({ deleted_at: null, deleted_by: null, delete_reason: null })
     .eq('id', args.updateId);
   if (updErr) return { error: updErr.message };
 
-  await supabase.from('audit_log').insert({
+  await service.from('audit_log').insert({
     action: 'update.undo_delete',
     update_id: args.updateId,
     actor_user_id: actorId,


### PR DESCRIPTION
## Summary

Third follow-up on the delete-flow thread (after #275 ship, #277 cache fix, #278 first RLS fix). User hit a new RLS error in prod after #278 was deployed:

```
[telemetry] update.delete.initiated {update_id: 'b315...', role: 'admin', is_own: false}
delete failed: new row violates row-level security policy for table "item_updates"
```

The error now has no policy name, which is the "no permissive policy allowed the new row" variant. Diagnosed against prod with `supabase db query --linked`.

## Root cause (deeper than #278 captured)

Migration 048 moved the `deleted_at IS NULL` filter from a RESTRICTIVE policy into the permissive `item_updates_select` policy, on the assumption that Postgres would silently filter a failing new row out of RETURNING instead of throwing. That assumption is wrong: **Postgres still throws `new row violates row-level security policy` when the new row fails the OR of all permissive SELECT policies' USING during UPDATE via PostgREST** (because `return=representation` triggers RETURNING, which triggers post-update SELECT-USING evaluation).

Verified end-to-end:

- Schema 047 + 048 applied correctly in prod (`supabase db query --linked` against `pg_policies` shows the intended state).
- User is an active `org_admin` of the update's org; `check_permission(user, property_id, 'updates', 'delete_any')` returns `true`; `can_user_delete_update(user, update_id)` returns `true`.
- Simulated the failing UPDATE in a SQL transaction via `set local role authenticated` + `set local request.jwt.claims`. Got the exact production error.
- Altering `item_updates_select` USING to drop the `deleted_at IS NULL` clause → UPDATE succeeds. Altering it back → UPDATE fails. Conclusively isolated that single clause as the blocker.
- Running the same UPDATE as `postgres` (RLS-bypass) → succeeds cleanly, no errors.

So: an RLS user cannot flip a SELECT-USING-gated column from "visible" to "hidden" through the user-auth Supabase client. The fix must bypass RLS for the mutation step.

## Fix

In `src/app/items/[itemId]/updates/actions.ts`:

- `softDeleteUpdate`: keep the user-auth client for `auth.getUser()` + the `can_user_delete_update` RPC pre-check + the initial read. Switch to `createServiceClient()` for the `UPDATE` on `item_updates` and the `INSERT` on `audit_log`.
- `undoDeleteUpdate`: same pattern. Additionally needs the service-role client to **read** the soft-deleted row (invisible under the user-auth SELECT USING) before restoring it.

Authorization is still enforced end-to-end:
- `softDeleteUpdate` refuses if `can_user_delete_update` returns false. The RPC is SECURITY DEFINER and does its own property/org/role resolution via `check_permission`.
- `undoDeleteUpdate` refuses if the HMAC token fails validation, if the actor doesn't match the token, or if the updateId doesn't match the token.

`createServiceClient()` is the existing helper in `src/lib/supabase/server.ts` (already used for setup/migration flows). No new env vars, no migration.

## ADR 0007 updated

Rule 3 rewritten. Was: "PostgREST's return=representation trap." Now broader: "Any UPDATE via PostgREST enforces SELECT USING on the new row." Adds three remediation options (service-role client, SECURITY DEFINER RPC, remove filter from RLS) with pros/cons. The first is what this PR takes; the second is the cleaner long-term architecture; the third is a non-starter for defense-in-depth reasons.

## Test plan

- [x] `npm run test` — 1338 passing (existing test updated to mock `createServiceClient`)
- [x] `npm run type-check` — clean
- [ ] Once merged + deployed: retry the delete flow on prod with update `b315e281-ef56-4189-b903-cab5f73d034b`. Toast should appear, `deleted_at` should be populated on the row, `audit_log` should have a `update.delete` row.
- [ ] Undo within 8s: `deleted_at` returns to null, audit row `update.undo_delete` added.
- [ ] Let toast expire: row stays soft-deleted.

## Why not a SECURITY DEFINER RPC instead?

Cleaner architecturally but requires a new migration and refactors the server action into a thin wrapper around `supabase.rpc('soft_delete_update', ...)`. I chose the service-role path for this PR because (a) the server action is already the authoritative entry point for the flow, (b) the migration for RPCs would introduce a new policy / grant surface, and (c) the user has been waiting for this to work in prod for several rounds. The RPC refactor is a reasonable follow-up if we find ourselves reaching for the service-role pattern a second time for a similar RLS-visibility bug.

## Related

- #275 — feature PR
- #277 — client-side cache fix (still needed)
- #278 — first RLS fix attempt (shipped, partial, superseded by this)
- ADR 0005, 0006, 0007 — feature + cache-invariant + RLS-authoring decision records (0007 rule 3 updated in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)