### PR TITLE
fix(maintenance): tappable rows on /map by resolving item's property slug

### DIFF
--- a/src/components/item/DetailPanel.tsx
+++ b/src/components/item/DetailPanel.tsx
@@ -61,6 +61,7 @@ interface DetailPanelProps {
 export default function DetailPanel({ item, onClose, isAuthenticated, canEditItem, canAddUpdate, onSheetStateChange }: DetailPanelProps) {
   const [isMobile, setIsMobile] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [itemPropertySlug, setItemPropertySlug] = useState<string | null>(null);
   const params = useParams();
   const router = useRouter();
   const slug = typeof params?.slug === 'string' ? params.slug : null;
@@ -98,6 +99,29 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
       onSheetStateChange?.(null);
     }
   }, [item?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Resolve the item's property slug from the offline cache so child blocks
+  // (e.g. UpcomingMaintenanceBlock) can build property-scoped URLs even on
+  // routes without a [slug] segment (e.g. /map on the default org).
+  useEffect(() => {
+    const propertyId = item?.property_id;
+    if (!propertyId) {
+      setItemPropertySlug(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const property = await getOfflineDb().properties.get(propertyId);
+        if (!cancelled) setItemPropertySlug(property?.slug ?? null);
+      } catch {
+        if (!cancelled) setItemPropertySlug(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [item?.property_id]);
 
   const { position } = useUserLocation();
 
@@ -201,7 +225,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
         canDeleteUpdate={canEditItem}
         currentUserId={currentUserId}
         userRole={userRole}
-        propertySlug={slug}
+        propertySlug={itemPropertySlug ?? slug}
         onDeleteUpdate={handleDeleteUpdate}
       />
     </div>


### PR DESCRIPTION
## Summary
- DetailPanel previously derived the property slug from `useParams()`, which is empty on routes without a `[slug]` segment (e.g. `/map` on the default org). That left `UpcomingMaintenanceBlock` rendering rows as plain `<div>`s instead of links.
- Now resolve the item's property slug from the offline `properties` cache (indexed by id, includes slug) and pass it — falling back to the route slug — to `LayoutRendererDispatch`.
- Rows are tappable on `/map`, `/p/[slug]`, anywhere.

## Out of scope
- Multi-property maintenance projects: schema change deferred to a separate PR. The `items.property_id`-driven slug used here is forward-compatible (item-context determines the URL).

## Test plan
- [x] `npm run type-check`
- [x] `UpcomingMaintenanceBlock` tests (7/7) pass
- [ ] Manual: on `/map` (default org), open an item with maintenance projects → click a row → lands on `/p/<itemPropertySlug>/maintenance/<id>` (anon) or `/admin/maintenance/<id>` (auth)
- [ ] Manual: on `/p/[slug]/...`, behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)