### PR TITLE
feat(maintenance): route to detail viewer first; add Edit affordance (#288)

### DIFF
--- a/e2e/tests/admin/maintenance.spec.ts
+++ b/e2e/tests/admin/maintenance.spec.ts
@@ -13,7 +13,8 @@ test.describe.serial('Scheduled Maintenance admin', () => {
     await page.getByRole('link', { name: /^Maintenance$/ }).click();
     await page.waitForURL(/\/admin\/maintenance$/);
     await expect(page.getByRole('heading', { name: /Scheduled Maintenance/i })).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('In progress')).toBeVisible();
+    // "In progress" appears in both the stat card and any status pill — scope to first match.
+    await expect(page.getByText('In progress').first()).toBeVisible();
     await expect(page.getByText('Due in 2 weeks')).toBeVisible();
   });
 
@@ -45,10 +46,12 @@ test.describe.serial('Scheduled Maintenance admin', () => {
     await page.getByRole('button', { name: /^Add \d+ item/ }).click();
 
     await expect(page.getByText(/Linked items \(1\)/)).toBeVisible({ timeout: 10000 });
-    // Use click() rather than check() — the checkbox is controlled by server state
-    // (completed_at), so React re-renders it back to unchecked until router.refresh()
-    // lands the update. click() fires the onChange without post-state assertion.
-    await page.locator('[aria-label^="Mark "]').first().click();
+    // The checkbox is controlled by server state (completed_at); React re-renders
+    // it to checked only after router.refresh() lands. Wait for that flip so the
+    // next test sees "1/1 done" on the list.
+    const checkbox = page.locator('[aria-label^="Mark "]').first();
+    await checkbox.click();
+    await expect(checkbox).toBeChecked({ timeout: 10000 });
   });
 
   test('project row appears on list with completion progress', async ({ page }) => {

--- a/src/__tests__/maintenance/MaintenancePublicViewer.test.tsx
+++ b/src/__tests__/maintenance/MaintenancePublicViewer.test.tsx
@@ -157,4 +157,38 @@ describe('MaintenancePublicViewer', () => {
     expect(screen.getByText(/Reference material/i)).toBeInTheDocument();
     expect(screen.getByText('Spring Cleaning Protocol')).toBeInTheDocument();
   });
+
+  it('renders an Edit link to the admin edit form when canEdit is true', () => {
+    render(
+      <MaintenancePublicViewer
+        project={project}
+        propertySlug="default"
+        propertyName="Discovery Park"
+        items={items}
+        knowledge={[]}
+        progress={{ completed: 0, total: 2 }}
+        isOrgMember={true}
+        canEdit={true}
+      />,
+    );
+    const editLink = screen.getByTestId('mpv-edit');
+    expect(editLink).toBeInTheDocument();
+    expect(editLink.getAttribute('href')).toBe('/p/default/admin/maintenance/p-1');
+  });
+
+  it('does not render an Edit link when canEdit is false', () => {
+    render(
+      <MaintenancePublicViewer
+        project={project}
+        propertySlug="default"
+        propertyName="Discovery Park"
+        items={items}
+        knowledge={[]}
+        progress={{ completed: 0, total: 2 }}
+        isOrgMember={false}
+        canEdit={false}
+      />,
+    );
+    expect(screen.queryByTestId('mpv-edit')).toBeNull();
+  });
 });

--- a/src/app/p/[slug]/maintenance/[id]/MaintenancePublicViewer.tsx
+++ b/src/app/p/[slug]/maintenance/[id]/MaintenancePublicViewer.tsx
@@ -28,6 +28,7 @@ interface Props {
   knowledge: KnowledgeRow[];
   progress: { completed: number; total: number };
   isOrgMember: boolean;
+  canEdit?: boolean;
 }
 
 function formatDate(iso: string | null, withYear = false): string {
@@ -55,6 +56,7 @@ export function MaintenancePublicViewer({
   knowledge,
   progress,
   isOrgMember,
+  canEdit = false,
 }: Props) {
   const percent =
     progress.total === 0 ? 0 : Math.floor((progress.completed / progress.total) * 100);
@@ -100,9 +102,20 @@ export function MaintenancePublicViewer({
           <MaintenanceStatusPill status={project.status} size="sm" />
         </div>
 
-        <h1 className="font-heading text-forest-dark text-2xl md:text-4xl font-semibold leading-tight mb-4">
-          {project.title}
-        </h1>
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <h1 className="font-heading text-forest-dark text-2xl md:text-4xl font-semibold leading-tight">
+            {project.title}
+          </h1>
+          {canEdit && (
+            <Link
+              href={`/p/${propertySlug}/admin/maintenance/${project.id}`}
+              className="btn-secondary shrink-0"
+              data-testid="mpv-edit"
+            >
+              Edit
+            </Link>
+          )}
+        </div>
 
         {project.description && (
           <p className="text-[15px] md:text-[17px] leading-relaxed text-gray-700 mb-5">

--- a/src/app/p/[slug]/maintenance/[id]/page.tsx
+++ b/src/app/p/[slug]/maintenance/[id]/page.tsx
@@ -102,18 +102,24 @@ async function loadData(slug: string, id: string) {
   const completed = (itemLinks ?? []).filter((l) => l.completed_at !== null).length;
   const total = itemLinks?.length ?? 0;
 
-  // isOrgMember: current user has active membership in this property's org
+  // isOrgMember: current user has active membership in this property's org.
+  // canEdit: membership role is org_admin or org_staff (mirrors RLS update policy
+  // in 049_scheduled_maintenance.sql).
   const { data: { user } } = await supabase.auth.getUser();
   let isOrgMember = false;
+  let canEdit = false;
   if (user) {
     const { data: membership } = await supabase
       .from('org_memberships')
-      .select('id')
+      .select('id, roles!inner(base_role)')
       .eq('user_id', user.id)
       .eq('org_id', property.org_id)
       .eq('status', 'active')
       .maybeSingle();
     isOrgMember = !!membership;
+    const baseRole = (membership as { roles?: { base_role?: string } } | null)
+      ?.roles?.base_role;
+    canEdit = baseRole === 'org_admin' || baseRole === 'org_staff';
   }
 
   return {
@@ -123,6 +129,7 @@ async function loadData(slug: string, id: string) {
     knowledge,
     progress: { completed, total },
     isOrgMember,
+    canEdit,
   };
 }
 
@@ -148,6 +155,7 @@ export default async function PublicMaintenanceProjectPage({ params }: PageProps
       knowledge={data.knowledge}
       progress={data.progress}
       isOrgMember={data.isOrgMember}
+      canEdit={data.canEdit}
     />
   );
 }

--- a/src/components/layout/LayoutRendererV2.tsx
+++ b/src/components/layout/LayoutRendererV2.tsx
@@ -254,7 +254,6 @@ export function renderBlockContent(
         <UpcomingMaintenanceBlock
           itemId={item.id}
           propertySlug={props.propertySlug ?? null}
-          isAuthenticated={props.isAuthenticated ?? false}
         />
       );
     }

--- a/src/components/layout/blocks/UpcomingMaintenanceBlock.tsx
+++ b/src/components/layout/blocks/UpcomingMaintenanceBlock.tsx
@@ -30,7 +30,6 @@ interface ProjectRow {
 interface Props {
   itemId: string;
   propertySlug?: string | null;
-  isAuthenticated?: boolean;
 }
 
 const ACTIVE_STATUSES: MaintenanceStatus[] = ['planned', 'in_progress'];
@@ -51,16 +50,13 @@ function formatDate(iso: string | null): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
 }
 
-function detailUrl(projectId: string, slug: string, isAuthenticated: boolean): string {
-  return isAuthenticated
-    ? `/p/${slug}/admin/maintenance/${projectId}`
-    : `/p/${slug}/maintenance/${projectId}`;
+function detailUrl(projectId: string, slug: string): string {
+  return `/p/${slug}/maintenance/${projectId}`;
 }
 
 export function UpcomingMaintenanceBlock({
   itemId,
   propertySlug = null,
-  isAuthenticated = false,
 }: Props) {
   const [rows, setRows] = useState<ProjectRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -191,21 +187,18 @@ export function UpcomingMaintenanceBlock({
             tone="overdue"
             rows={overdue}
             propertySlug={propertySlug}
-            isAuthenticated={isAuthenticated}
           />
           <Subgroup
             label="Upcoming"
             tone="default"
             rows={upcoming}
             propertySlug={propertySlug}
-            isAuthenticated={isAuthenticated}
           />
           <Subgroup
             label="Unscheduled"
             tone="default"
             rows={unscheduled}
             propertySlug={propertySlug}
-            isAuthenticated={isAuthenticated}
           />
         </>
       )}
@@ -227,13 +220,11 @@ function Subgroup({
   tone,
   rows,
   propertySlug,
-  isAuthenticated,
 }: {
   label: 'Overdue' | 'Upcoming' | 'Unscheduled';
   tone: 'overdue' | 'default';
   rows: ProjectRow[];
   propertySlug: string | null;
-  isAuthenticated: boolean;
 }) {
   if (rows.length === 0) return null;
   return (
@@ -252,7 +243,6 @@ function Subgroup({
             project={p}
             tone={tone}
             propertySlug={propertySlug}
-            isAuthenticated={isAuthenticated}
           />
         ))}
       </ul>
@@ -264,12 +254,10 @@ function MaintenanceRow({
   project,
   tone,
   propertySlug,
-  isAuthenticated,
 }: {
   project: ProjectRow;
   tone: 'overdue' | 'default';
   propertySlug: string | null;
-  isAuthenticated: boolean;
 }) {
   const isOverdue = tone === 'overdue';
   const baseClasses = `block rounded-lg px-3 py-2 transition-colors ${
@@ -327,7 +315,7 @@ function MaintenanceRow({
     return (
       <li>
         <a
-          href={detailUrl(project.id, propertySlug, isAuthenticated)}
+          href={detailUrl(project.id, propertySlug)}
           className={baseClasses}
           aria-label={`${project.title}, ${timeLabel}`}
         >

--- a/src/components/layout/blocks/__tests__/UpcomingMaintenanceBlock.test.tsx
+++ b/src/components/layout/blocks/__tests__/UpcomingMaintenanceBlock.test.tsx
@@ -74,16 +74,12 @@ describe('UpcomingMaintenanceBlock', () => {
   it('renders the loading skeleton before data arrives', () => {
     // Supabase resolves on next microtask; the first synchronous render shows the skeleton.
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug="property-a"
-        isAuthenticated={true}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug="property-a" />,
     );
     expect(screen.getByTestId('mp-block-skeleton')).toBeInTheDocument();
   });
 
-  it('renders the mixed state (overdue + upcoming + unscheduled + footer) for staff', async () => {
+  it('renders the mixed state (overdue + upcoming + unscheduled + footer)', async () => {
     supabaseResult = {
       data: [
         row({
@@ -130,11 +126,7 @@ describe('UpcomingMaintenanceBlock', () => {
     };
 
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug="property-a"
-        isAuthenticated={true}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug="property-a" />,
     );
 
     await screen.findByText('Upcoming Maintenance');
@@ -150,7 +142,7 @@ describe('UpcomingMaintenanceBlock', () => {
 
     const overdueLink = screen.getByText('Spring nestbox inspection').closest('a');
     expect(overdueLink).not.toBeNull();
-    expect(overdueLink?.getAttribute('href')).toBe('/p/property-a/admin/maintenance/p-overdue');
+    expect(overdueLink?.getAttribute('href')).toBe('/p/property-a/maintenance/p-overdue');
 
     const desc = screen.getByText(/Annual check for damage/i);
     expect(desc.className).toMatch(/line-clamp-1/);
@@ -174,11 +166,7 @@ describe('UpcomingMaintenanceBlock', () => {
     };
 
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug="property-a"
-        isAuthenticated={true}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug="property-a" />,
     );
 
     await screen.findByText('Upcoming Maintenance');
@@ -191,11 +179,7 @@ describe('UpcomingMaintenanceBlock', () => {
     supabaseResult = { data: [], error: null };
 
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug="property-a"
-        isAuthenticated={true}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug="property-a" />,
     );
 
     await screen.findByText('Upcoming Maintenance');
@@ -203,12 +187,12 @@ describe('UpcomingMaintenanceBlock', () => {
     expect(screen.queryByText(/Last maintained via/)).not.toBeInTheDocument();
   });
 
-  it('uses the public viewer URL for anonymous viewers', async () => {
+  it('always routes to the detail viewer URL (never the admin edit form)', async () => {
     supabaseResult = {
       data: [
         row({
-          id: 'p-anon',
-          title: 'Public view check',
+          id: 'p-x',
+          title: 'Detail view check',
           status: 'planned',
           scheduled_for: '2026-05-02',
           completed_at: null,
@@ -218,15 +202,11 @@ describe('UpcomingMaintenanceBlock', () => {
     };
 
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug="property-a"
-        isAuthenticated={false}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug="property-a" />,
     );
 
-    const link = (await screen.findByText('Public view check')).closest('a');
-    expect(link?.getAttribute('href')).toBe('/p/property-a/maintenance/p-anon');
+    const link = (await screen.findByText('Detail view check')).closest('a');
+    expect(link?.getAttribute('href')).toBe('/p/property-a/maintenance/p-x');
   });
 
   it('renders rows as non-anchor when propertySlug is null', async () => {
@@ -244,11 +224,7 @@ describe('UpcomingMaintenanceBlock', () => {
     };
 
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug={null}
-        isAuthenticated={true}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug={null} />,
     );
 
     const titleEl = await screen.findByText('Should not link');
@@ -259,11 +235,7 @@ describe('UpcomingMaintenanceBlock', () => {
     supabaseResult = { data: null, error: { message: 'network down' } };
 
     render(
-      <UpcomingMaintenanceBlock
-        itemId="item-1"
-        propertySlug="property-a"
-        isAuthenticated={true}
-      />,
+      <UpcomingMaintenanceBlock itemId="item-1" propertySlug="property-a" />,
     );
 
     await screen.findByText('Upcoming Maintenance');


### PR DESCRIPTION
Closes #288.

## Summary
- Tapping a scheduled maintenance row on item detail now always lands users on the public detail viewer (`/p/{slug}/maintenance/{id}`), regardless of auth state.
- The viewer renders an **Edit** link to the admin edit form only when the current user has `org_admin` or `org_staff` role (mirrors the RLS update policy in `049_scheduled_maintenance.sql`).
- `UpcomingMaintenanceBlock` no longer needs `isAuthenticated`; the conditional `/admin/maintenance/...` branch is removed.

## Changes
- `src/components/layout/blocks/UpcomingMaintenanceBlock.tsx` — drop `isAuthenticated`; always route to viewer.
- `src/components/layout/LayoutRendererV2.tsx` — stop passing `isAuthenticated` to the block.
- `src/app/p/[slug]/maintenance/[id]/page.tsx` — extend membership query to read `roles.base_role`; compute and pass `canEdit`.
- `src/app/p/[slug]/maintenance/[id]/MaintenancePublicViewer.tsx` — accept `canEdit`; render Edit link with `data-testid="mpv-edit"`.
- Tests updated; +2 viewer cases for Edit visibility.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` — 1411 passing (197 files)
- [x] `npm run build`
- [ ] Manual: signed-in org admin taps maintenance row on item detail → lands on viewer (not edit form); Edit button visible → clicking lands on edit form.
- [ ] Manual: anonymous viewer taps row → lands on viewer; no Edit button.
- [ ] Visual diff screenshots per `docs/playbooks/visual-diff-screenshots.md` (item detail tap behavior + viewer for admin vs anon).

## Out of scope
- `MaintenanceListView` row tap behavior on `/admin/maintenance` and property list pages.
- Changes to the edit form itself.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)