### PR TITLE
fix(maintenance): simplify Upcoming Maintenance header (#287)

### DIFF
--- a/src/components/layout/blocks/UpcomingMaintenanceBlock.tsx
+++ b/src/components/layout/blocks/UpcomingMaintenanceBlock.tsx
@@ -149,23 +149,17 @@ export function UpcomingMaintenanceBlock({
   const { overdue, upcoming, unscheduled, lastCompleted } = buckets!;
   const totalUpcoming = overdue.length + upcoming.length + unscheduled.length;
   const hasUpcoming = totalUpcoming > 0;
-  const countLine = hasUpcoming
-    ? `${totalUpcoming} upcoming${overdue.length > 0 ? ` · ${overdue.length} overdue` : ''}`
-    : null;
 
   return (
     <div className="card p-4">
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          <span
-            aria-hidden
-            className="w-7 h-7 rounded-lg bg-sage-light/60 text-forest flex items-center justify-center text-sm"
-          >
-            🔧
-          </span>
-          <h3 className="font-heading text-forest-dark text-[15px]">Upcoming Maintenance</h3>
-        </div>
-        {countLine && <span className="text-xs text-gray-600">{countLine}</span>}
+      <div className="flex items-center gap-2 mb-3">
+        <span
+          aria-hidden
+          className="w-7 h-7 rounded-lg bg-sage-light/60 text-forest flex items-center justify-center text-sm"
+        >
+          🔧
+        </span>
+        <h3 className="font-heading text-forest-dark text-[15px]">Upcoming Maintenance</h3>
       </div>
 
       {error && (
@@ -189,7 +183,7 @@ export function UpcomingMaintenanceBlock({
             propertySlug={propertySlug}
           />
           <Subgroup
-            label="Upcoming"
+            label={null}
             tone="default"
             rows={upcoming}
             propertySlug={propertySlug}
@@ -221,7 +215,7 @@ function Subgroup({
   rows,
   propertySlug,
 }: {
-  label: 'Overdue' | 'Upcoming' | 'Unscheduled';
+  label: 'Overdue' | 'Unscheduled' | null;
   tone: 'overdue' | 'default';
   rows: ProjectRow[];
   propertySlug: string | null;
@@ -229,13 +223,15 @@ function Subgroup({
   if (rows.length === 0) return null;
   return (
     <div className="mt-2 first:mt-0">
-      <div
-        className={`text-[10px] uppercase tracking-wide font-semibold mb-1 ${
-          tone === 'overdue' ? 'text-red-700' : 'text-gray-600'
-        }`}
-      >
-        {label}
-      </div>
+      {label && (
+        <div
+          className={`text-[10px] uppercase tracking-wide font-semibold mb-1 ${
+            tone === 'overdue' ? 'text-red-700' : 'text-gray-600'
+          }`}
+        >
+          {label}
+        </div>
+      )}
       <ul className="space-y-1.5">
         {rows.map((p) => (
           <MaintenanceRow

--- a/src/components/layout/blocks/__tests__/UpcomingMaintenanceBlock.test.tsx
+++ b/src/components/layout/blocks/__tests__/UpcomingMaintenanceBlock.test.tsx
@@ -130,10 +130,11 @@ describe('UpcomingMaintenanceBlock', () => {
     );
 
     await screen.findByText('Upcoming Maintenance');
-    expect(screen.getByText('4 upcoming · 1 overdue')).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ upcoming/)).not.toBeInTheDocument();
 
     expect(screen.getByText('Overdue')).toBeInTheDocument();
-    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+    // The "Upcoming" subgroup label is intentionally suppressed — the card header already says it.
+    expect(screen.queryByText('Upcoming', { selector: 'div' })).not.toBeInTheDocument();
     expect(screen.getByText('Unscheduled')).toBeInTheDocument();
 
     expect(screen.getByText('3d late')).toBeInTheDocument();


### PR DESCRIPTION
Closes #287.

## Summary
- Remove the \"N upcoming · M overdue\" chip from the card header — the title already says \"Upcoming Maintenance\".
- Remove the redundant \"Upcoming\" subgroup label. Rows still render in their bucket; \"Overdue\" and \"Unscheduled\" labels remain (distinct state, not redundant).

## Test plan
- [x] \`npm run type-check\` clean
- [x] \`npx vitest run UpcomingMaintenanceBlock\` — 7/7 passing
- [ ] Visual check on item detail with mixed overdue/upcoming/unscheduled rows
- [ ] Visual check on caught-up + empty states

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)