### PR TITLE
fix(item-detail): drop pb-24 spacer above maintenance block (#293)

### DIFF
--- a/src/components/item/DetailPanel.tsx
+++ b/src/components/item/DetailPanel.tsx
@@ -346,7 +346,7 @@ export default function DetailPanel({ item, onClose, isAuthenticated, canEditIte
       )}
 
       {/* Updates timeline */}
-      <div>
+      <div className="pb-24">
         <h3 className="text-xs font-medium text-sage uppercase tracking-wide mb-3">
           Updates
         </h3>

--- a/src/components/item/timeline/TimelineRail.tsx
+++ b/src/components/item/timeline/TimelineRail.tsx
@@ -39,7 +39,7 @@ export function TimelineRail({
   const open = updates.find((u) => u.id === openId) ?? null;
 
   return (
-    <div className="pb-24">
+    <div>
       {showScheduled && scheduled.length > 0 && (
         <ScheduledUpdatesSection
           updates={scheduled as any}


### PR DESCRIPTION
## Summary

- `TimelineRail` wrapper had `pb-24` (96px), originally added for the standalone bottom-sheet `DetailPanel` use (sticky-FAB safe-area).
- In `LayoutRendererV2`, the rail is rendered as a layout *block* via `TimelineBlock`, with the parent flex container already supplying `gap: spacing.blockGap` between blocks. The `pb-24` therefore stacked on top of the gap and produced a large empty band between **Updates** and **Upcoming Maintenance** on the item-detail page (`fairbankseagle.org` birdhouse view, mobile + desktop side-panel).
- Moved the padding to the legacy `DetailPanel` Updates wrapper — the only remaining caller that actually needs it for sheet-bottom clearance.

After the change the gap between Updates and Upcoming Maintenance reduces to `spacing.blockGap` (8–16px depending on layout preset) — consistent with every other inter-block gap.

Closes #293

## Visual Changes

### Before — production (item-detail, side-panel) — large empty band before Upcoming Maintenance

![before](https://github.com/user-attachments/assets/182849b5-efae-4b61-b62c-98f81adce18c)

### After — Vercel preview

_Will attach once preview deploy is live (mobile + side-panel)._

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run test -- src/components/item/timeline src/components/layout/blocks` — 77 tests pass
- [x] CI: Lint, Type Check & Build — pass
- [x] CI: Playwright E2E — pass
- [x] CI: Vercel preview deploys — pass (×2)
- [ ] Vercel preview: open a birdhouse item on mobile bottom-sheet → gap between Updates and Upcoming Maintenance is `blockGap`, not ~96px+gap
- [ ] Vercel preview: side-panel desktop view of same item — same expectation
- [ ] Vercel preview: legacy `DetailPanel` (no layout) bottom-sheet — last update card still has clearance from sheet bottom (no regression from moved `pb-24`)

## CI note

`Migration Dry Run` fails with `Unexpected error retrieving remote project status: {"message":"Unauthorized"}` at the `supabase link` step. This is **unrelated to this PR** — it adds zero migrations and zero Supabase changes (only two `className` tweaks in TSX). Root cause: the repo secret `SUPABASE_ACCESS_TOKEN` is expired/revoked. Reran the failed job once with the same result, so it is not a transient flake. Needs rotation in repo Settings → Secrets and variables → Actions before any PR can pass that job again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)