### PR TITLE
feat(map): simplify marker popup to item name only (#295)

### DIFF
--- a/src/components/map/ItemMarker.tsx
+++ b/src/components/map/ItemMarker.tsx
@@ -3,10 +3,9 @@
 import { useState, useEffect } from 'react';
 import { Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
-import type { Item, ItemType, ItemStatus } from '@/lib/types';
-import type { IconValue } from '@/lib/types';
-import { statusLabels, statusColors } from '@/lib/utils';
-import { iconToHtml, IconRenderer } from '@/components/shared/IconPicker';
+import type { Item, ItemType } from '@/lib/types';
+import { statusColors } from '@/lib/utils';
+import { iconToHtml } from '@/components/shared/IconPicker';
 
 function createDivIcon(iconHtml: string, color: string) {
   return L.divIcon({
@@ -66,16 +65,6 @@ export default function ItemMarker({ item, itemType, onClick }: ItemMarkerProps)
       <Popup>
         <div className="text-center">
           <strong className="text-forest-dark">{item.name}</strong>
-          <br />
-          <span className="text-xs text-sage">{statusLabels[item.status]}</span>
-          {itemType && (
-            <>
-              <br />
-              <span className="text-xs text-forest">
-                <IconRenderer icon={itemType.icon} size={12} /> {itemType.name}
-              </span>
-            </>
-          )}
         </div>
       </Popup>
     </Marker>


### PR DESCRIPTION
## Summary
- Marker popup on `/map` now shows only the item name. Drops the status label row and item-type row.
- Closes #295.

## Files
- `src/components/map/ItemMarker.tsx` — popup body reduced to `<strong>{item.name}</strong>`; removed unused `statusLabels`, `IconRenderer`, `ItemStatus`, `IconValue` imports.

## Verification
- `npm run type-check` — clean
- `npm run test -- --run src/components/map` — 4 passed
- Visual: dev server requires Supabase env not present locally; change is JSX-only inside the existing `<Popup>` so the Leaflet popup still renders. Recommend smoke-checking on preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)