### PR TITLE
feat(perf): web-vitals + custom marks for /map TTRC (Phase 0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@turf/intersect": "^7.3.4",
         "@turf/union": "^7.3.4",
         "@types/leaflet-draw": "^1.0.13",
+        "@vercel/speed-insights": "^2.0.0",
         "ai": "^6.0.138",
         "dexie": "^4.4.2",
         "framer-motion": "^12.38.0",
@@ -4678,6 +4679,44 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@turf/intersect": "^7.3.4",
     "@turf/union": "^7.3.4",
     "@types/leaflet-draw": "^1.0.13",
+    "@vercel/speed-insights": "^2.0.0",
     "ai": "^6.0.138",
     "dexie": "^4.4.2",
     "framer-motion": "^12.38.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { createClient } from '@/lib/supabase/server';
 import type { Data } from '@puckeditor/core';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headersList = await headers();
@@ -43,6 +44,7 @@ export default async function RootLayout({
         <body className="antialiased">
           {children}
           {modal}
+          <SpeedInsights />
         </body>
       </html>
     );
@@ -91,6 +93,7 @@ export default async function RootLayout({
             </OfflineProvider>
           </UserLocationProvider>
         </ConfigProvider>
+        <SpeedInsights />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,5 +1,11 @@
 import { HomeMapView } from '@/components/map/HomeMapView';
+import { PerfOverlay } from '@/components/perf/PerfOverlay';
 
 export default function MapPage() {
-  return <HomeMapView />;
+  return (
+    <>
+      <HomeMapView />
+      <PerfOverlay />
+    </>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 import { getConfig } from '@/lib/config/server';
 import { LandingRenderer } from '@/components/landing/LandingRenderer';
 import { HomeMapView } from '@/components/map/HomeMapView';
+import { PerfOverlay } from '@/components/perf/PerfOverlay';
 import { PlatformLanding } from '@/components/platform/PlatformLanding';
 import { PuckPageRenderer } from '@/components/puck/PuckPageRenderer';
 import { PreviewReloadListener } from '@/components/puck/PreviewReloadListener';
@@ -71,5 +72,10 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   }
 
   // Fallback — render map (current behavior)
-  return <HomeMapView />;
+  return (
+    <>
+      <HomeMapView />
+      <PerfOverlay />
+    </>
+  );
 }

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -29,6 +29,7 @@ import { clipLayerToBoundary, filterItemsByBoundary } from "@/lib/geo/spatial";
 import type { GeoLayerSummary, GeoLayerProperty } from "@/lib/geo/types";
 import type { FeatureCollection } from "geojson";
 import type { SheetState } from "@/components/ui/MultiSnapBottomSheet";
+import { mark } from '@/lib/perf/marks';
 
 const MapView = dynamic(() => import("@/components/map/MapView"), {
   ssr: false,
@@ -79,6 +80,8 @@ function HomeMapViewContent() {
   const [geoLayerData, setGeoLayerData] = useState<Map<string, FeatureCollection>>(new Map());
   const [boundaryGeoJSON, setBoundaryGeoJSON] = useState<FeatureCollection | null>(null);
 
+  mark('ttrc:hydrate-start');
+
   useEffect(() => {
     async function fetchData() {
       if (!propertyId) { setLoading(false); return; }
@@ -109,6 +112,7 @@ function HomeMapViewContent() {
                 setItems(itemData);
                 setItemTypes(typeData);
                 setCustomFields(fieldData);
+                mark('ttrc:idb-resolved');
               }
               // Fetch org public-contribution settings
               if (propData.org_id) {
@@ -140,6 +144,7 @@ function HomeMapViewContent() {
         setItems(itemData);
         setItemTypes(typeData);
         setCustomFields(fieldData);
+        mark('ttrc:idb-resolved');
 
         // Check authentication via cached session, and load org contribution settings
         try {
@@ -207,6 +212,8 @@ function HomeMapViewContent() {
           setGeoLayerData((prev) => new Map(prev).set(layerId, layerResult.layer.geojson));
         }
       }
+
+      mark('ttrc:geolayers-resolved');
 
       // Load boundary layer if one is marked as property boundary
       const boundaryLayer = result.layers.find((l) => l.is_property_boundary);

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -19,6 +19,7 @@ import FeaturePopup from "@/components/geo/FeaturePopup";
 import LayerControlPanel from "@/components/geo/LayerControlPanel";
 import type { GeoLayerSummary } from "@/lib/geo/types";
 import type { FeatureCollection, Feature } from "geojson";
+import { mark } from '@/lib/perf/marks';
 
 interface MapViewProps {
   items: Item[];
@@ -41,6 +42,28 @@ function FlyToUser({ trigger }: { trigger: number }) {
       map.flyTo([position.lat, position.lng], map.getZoom(), { duration: 1 });
     }
   }, [trigger, position, map]);
+  return null;
+}
+
+/** Marks first user interaction with the map */
+function InteractiveMarker() {
+  const map = useMap();
+  useEffect(() => {
+    function onInput() {
+      mark('ttrc:interactive');
+      map.off('movestart', onInput);
+      map.off('zoomstart', onInput);
+      map.off('click', onInput);
+    }
+    map.on('movestart', onInput);
+    map.on('zoomstart', onInput);
+    map.on('click', onInput);
+    return () => {
+      map.off('movestart', onInput);
+      map.off('zoomstart', onInput);
+      map.off('click', onInput);
+    };
+  }, [map]);
   return null;
 }
 
@@ -75,6 +98,12 @@ export default function MapView({
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [selectedFeature, setSelectedFeature] = useState<{ feature: Feature; layerName: string } | null>(null);
 
+  useEffect(() => {
+    if (items.length === 0) return;
+    mark('ttrc:first-marker');
+    mark('ttrc:all-markers');
+  }, [items.length]);
+
   // Build a lookup map for item types
   const typeMap = new Map(itemTypes.map((t) => [t.id, t]));
 
@@ -105,7 +134,14 @@ export default function MapView({
         zoomControl={false}
       >
         <MapResizer fullscreen={fullscreen} />
-        <TileLayer attribution={theme.tileAttribution} url={theme.tileUrl} />
+        <InteractiveMarker />
+        <TileLayer
+          attribution={theme.tileAttribution}
+          url={theme.tileUrl}
+          eventHandlers={{
+            tileload: () => mark('ttrc:first-paint-tile'),
+          }}
+        />
         {config.customMap && (
           <ImageOverlay
             url={config.customMap.url}

--- a/src/components/perf/PerfOverlay.tsx
+++ b/src/components/perf/PerfOverlay.tsx
@@ -37,15 +37,17 @@ export function PerfOverlay() {
     return () => window.clearInterval(id);
   }, [enabled]);
 
-  if (!enabled) return null;
-
   function copyJson() {
     const payload = JSON.stringify({ cacheState, entries }, null, 2);
     navigator.clipboard?.writeText(payload).catch(() => {});
   }
 
+  if (!enabled) return null;
+
   return (
     <div
+      role="region"
+      aria-label="Performance overlay"
       data-testid="perf-overlay"
       style={{
         position: 'fixed',
@@ -68,6 +70,7 @@ export function PerfOverlay() {
         <button
           type="button"
           onClick={copyJson}
+          aria-label="Copy performance data"
           style={{ background: '#444', color: '#fff', border: 0, padding: '2px 6px', borderRadius: 3, cursor: 'pointer' }}
         >
           copy
@@ -76,14 +79,14 @@ export function PerfOverlay() {
       <table style={{ borderCollapse: 'collapse', width: '100%' }}>
         <thead>
           <tr>
-            <th style={{ textAlign: 'left', padding: '2px 4px' }}>name</th>
-            <th style={{ textAlign: 'right', padding: '2px 4px' }}>start</th>
-            <th style={{ textAlign: 'right', padding: '2px 4px' }}>dur</th>
+            <th scope="col" style={{ textAlign: 'left', padding: '2px 4px' }}>name</th>
+            <th scope="col" style={{ textAlign: 'right', padding: '2px 4px' }}>start</th>
+            <th scope="col" style={{ textAlign: 'right', padding: '2px 4px' }}>dur</th>
           </tr>
         </thead>
         <tbody>
-          {entries.map((e, i) => (
-            <tr key={`${e.name}-${i}`}>
+          {entries.map((e) => (
+            <tr key={e.name}>
               <td style={{ padding: '1px 4px', whiteSpace: 'nowrap' }}>{e.name}</td>
               <td style={{ padding: '1px 4px', textAlign: 'right' }}>{e.startTime.toFixed(0)}</td>
               <td style={{ padding: '1px 4px', textAlign: 'right' }}>{e.duration.toFixed(0)}</td>

--- a/src/components/perf/PerfOverlay.tsx
+++ b/src/components/perf/PerfOverlay.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { getReport, type PerfEntry } from '@/lib/perf/marks';
+
+const REFRESH_MS = 500;
+
+export function PerfOverlay() {
+  const params = useSearchParams();
+  const [enabled, setEnabled] = useState(false);
+  const [entries, setEntries] = useState<PerfEntry[]>([]);
+  const [cacheState, setCacheState] = useState<'cold' | 'warm' | 'unknown'>('unknown');
+
+  useEffect(() => {
+    const flag =
+      params?.get('perf') === '1' ||
+      (typeof window !== 'undefined' && window.localStorage.getItem('perfOverlay') === '1');
+    setEnabled(!!flag);
+  }, [params]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof navigator === 'undefined') return;
+    const sw = (navigator as Navigator).serviceWorker;
+    if (!sw) {
+      setCacheState('unknown');
+      return;
+    }
+    setCacheState(sw.controller ? 'warm' : 'cold');
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    setEntries(getReport());
+    const id = window.setInterval(() => setEntries(getReport()), REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  function copyJson() {
+    const payload = JSON.stringify({ cacheState, entries }, null, 2);
+    navigator.clipboard?.writeText(payload).catch(() => {});
+  }
+
+  return (
+    <div
+      data-testid="perf-overlay"
+      style={{
+        position: 'fixed',
+        bottom: 8,
+        right: 8,
+        zIndex: 9999,
+        maxHeight: '40vh',
+        maxWidth: 360,
+        overflow: 'auto',
+        background: 'rgba(0,0,0,0.78)',
+        color: '#fff',
+        font: '11px ui-monospace, Menlo, monospace',
+        padding: 8,
+        borderRadius: 6,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.4)',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <strong>perf · {cacheState}</strong>
+        <button
+          type="button"
+          onClick={copyJson}
+          style={{ background: '#444', color: '#fff', border: 0, padding: '2px 6px', borderRadius: 3, cursor: 'pointer' }}
+        >
+          copy
+        </button>
+      </div>
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', padding: '2px 4px' }}>name</th>
+            <th style={{ textAlign: 'right', padding: '2px 4px' }}>start</th>
+            <th style={{ textAlign: 'right', padding: '2px 4px' }}>dur</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e, i) => (
+            <tr key={`${e.name}-${i}`}>
+              <td style={{ padding: '1px 4px', whiteSpace: 'nowrap' }}>{e.name}</td>
+              <td style={{ padding: '1px 4px', textAlign: 'right' }}>{e.startTime.toFixed(0)}</td>
+              <td style={{ padding: '1px 4px', textAlign: 'right' }}>{e.duration.toFixed(0)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default PerfOverlay;

--- a/src/components/perf/__tests__/PerfOverlay.test.tsx
+++ b/src/components/perf/__tests__/PerfOverlay.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PerfOverlay } from '../PerfOverlay';
+import { mark, _resetForTest } from '@/lib/perf/marks';
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn(),
+}));
+
+import { useSearchParams } from 'next/navigation';
+
+describe('PerfOverlay', () => {
+  beforeEach(() => {
+    _resetForTest();
+    performance.clearMarks();
+    performance.clearMeasures();
+    localStorage.clear();
+  });
+
+  it('renders nothing when ?perf=1 is absent and localStorage flag is unset', () => {
+    (useSearchParams as any).mockReturnValue(new URLSearchParams(''));
+    const { container } = render(<PerfOverlay />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the marks table when ?perf=1 is present', () => {
+    (useSearchParams as any).mockReturnValue(new URLSearchParams('perf=1'));
+    mark('ttrc:hydrate-start');
+    render(<PerfOverlay />);
+    expect(screen.getByTestId('perf-overlay')).toBeInTheDocument();
+    expect(screen.getByText(/ttrc:hydrate-start/)).toBeInTheDocument();
+  });
+
+  it('renders when localStorage.perfOverlay is "1"', () => {
+    (useSearchParams as any).mockReturnValue(new URLSearchParams(''));
+    localStorage.setItem('perfOverlay', '1');
+    render(<PerfOverlay />);
+    expect(screen.getByTestId('perf-overlay')).toBeInTheDocument();
+  });
+
+  it('shows cold tag when no service worker controller is present', () => {
+    (useSearchParams as any).mockReturnValue(new URLSearchParams('perf=1'));
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { controller: null },
+    });
+    render(<PerfOverlay />);
+    expect(screen.getByText(/cold/i)).toBeInTheDocument();
+  });
+});

--- a/src/lib/perf/__tests__/marks.test.ts
+++ b/src/lib/perf/__tests__/marks.test.ts
@@ -57,4 +57,26 @@ describe('perf marks', () => {
     expect(() => mark('test:ssr')).not.toThrow();
     (globalThis as any).performance = originalPerf;
   });
+
+  it('getReport() returns [] when performance is undefined (SSR safety)', () => {
+    const originalPerf = (globalThis as any).performance;
+    (globalThis as any).performance = undefined;
+    expect(getReport()).toEqual([]);
+    (globalThis as any).performance = originalPerf;
+  });
+
+  it('measure() swallows throw when startMark is missing', () => {
+    expect(() => measure('test:bad', 'never-marked')).not.toThrow();
+    const entries = performance.getEntriesByName('test:bad', 'measure');
+    expect(entries.length).toBe(0);
+  });
+
+  it('getReport() excludes third-party marks not emitted via our mark()', () => {
+    performance.mark('thirdparty:x');
+    mark('ttrc:y');
+    const report = getReport();
+    const names = report.map((e) => e.name);
+    expect(names).toContain('ttrc:y');
+    expect(names).not.toContain('thirdparty:x');
+  });
 });

--- a/src/lib/perf/__tests__/marks.test.ts
+++ b/src/lib/perf/__tests__/marks.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mark, measure, getReport, _resetForTest } from '../marks';
+
+describe('perf marks', () => {
+  beforeEach(() => {
+    _resetForTest();
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  it('mark() records a performance entry', () => {
+    mark('test:a');
+    const entries = performance.getEntriesByName('test:a', 'mark');
+    expect(entries.length).toBe(1);
+  });
+
+  it('mark() is idempotent for the same name within a session', () => {
+    mark('test:a');
+    mark('test:a');
+    const entries = performance.getEntriesByName('test:a', 'mark');
+    expect(entries.length).toBe(1);
+  });
+
+  it('measure() between two marks records the duration', () => {
+    mark('test:start');
+    mark('test:end');
+    measure('test:span', 'test:start', 'test:end');
+    const entries = performance.getEntriesByName('test:span', 'measure');
+    expect(entries.length).toBe(1);
+    expect(entries[0].duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('measure() defaults endMark to now', () => {
+    mark('test:start');
+    measure('test:to-now', 'test:start');
+    const entries = performance.getEntriesByName('test:to-now', 'measure');
+    expect(entries.length).toBe(1);
+  });
+
+  it('getReport() returns marks and measures sorted by startTime', () => {
+    mark('test:a');
+    mark('test:b');
+    measure('test:a-to-b', 'test:a', 'test:b');
+    const report = getReport();
+    const names = report.map((r) => r.name);
+    expect(names).toContain('test:a');
+    expect(names).toContain('test:b');
+    expect(names).toContain('test:a-to-b');
+    for (let i = 1; i < report.length; i++) {
+      expect(report[i].startTime).toBeGreaterThanOrEqual(report[i - 1].startTime);
+    }
+  });
+
+  it('mark() is a no-op when window is undefined (SSR safety)', () => {
+    const originalPerf = (globalThis as any).performance;
+    (globalThis as any).performance = undefined;
+    expect(() => mark('test:ssr')).not.toThrow();
+    (globalThis as any).performance = originalPerf;
+  });
+});

--- a/src/lib/perf/marks.ts
+++ b/src/lib/perf/marks.ts
@@ -1,0 +1,66 @@
+/**
+ * SSR-safe wrappers around the browser Performance API for TTRC instrumentation.
+ *
+ * - mark(name) is idempotent within a session — first call wins.
+ * - measure(name, start, end?) records a duration entry; end defaults to "now".
+ * - getReport() returns all marks + measures we have recorded, sorted by startTime.
+ */
+
+const seen = new Set<string>();
+
+function hasPerf(): boolean {
+  return typeof globalThis !== 'undefined' && typeof globalThis.performance !== 'undefined';
+}
+
+export function mark(name: string): void {
+  if (!hasPerf()) return;
+  if (seen.has(name)) return;
+  seen.add(name);
+  try {
+    performance.mark(name);
+  } catch {
+    // performance.mark can throw if the API is partially polyfilled; swallow.
+  }
+}
+
+export function measure(name: string, startMark: string, endMark?: string): void {
+  if (!hasPerf()) return;
+  try {
+    if (endMark) {
+      performance.measure(name, startMark, endMark);
+    } else {
+      performance.measure(name, startMark);
+    }
+  } catch {
+    // measure throws if either mark is missing; swallow so callers don't have to guard.
+  }
+}
+
+export interface PerfEntry {
+  name: string;
+  duration: number;
+  startTime: number;
+  type: 'mark' | 'measure';
+}
+
+export function getReport(): PerfEntry[] {
+  if (!hasPerf()) return [];
+  const marks = performance.getEntriesByType('mark').map((e) => ({
+    name: e.name,
+    duration: e.duration,
+    startTime: e.startTime,
+    type: 'mark' as const,
+  }));
+  const measures = performance.getEntriesByType('measure').map((e) => ({
+    name: e.name,
+    duration: e.duration,
+    startTime: e.startTime,
+    type: 'measure' as const,
+  }));
+  return [...marks, ...measures].sort((a, b) => a.startTime - b.startTime);
+}
+
+/** Test-only: clear the idempotency set so a single test run can re-mark names. */
+export function _resetForTest(): void {
+  seen.clear();
+}

--- a/src/lib/perf/marks.ts
+++ b/src/lib/perf/marks.ts
@@ -7,6 +7,7 @@
  */
 
 const seen = new Set<string>();
+const emittedNames = new Set<string>();
 
 function hasPerf(): boolean {
   return typeof globalThis !== 'undefined' && typeof globalThis.performance !== 'undefined';
@@ -16,6 +17,7 @@ export function mark(name: string): void {
   if (!hasPerf()) return;
   if (seen.has(name)) return;
   seen.add(name);
+  emittedNames.add(name);
   try {
     performance.mark(name);
   } catch {
@@ -26,11 +28,12 @@ export function mark(name: string): void {
 export function measure(name: string, startMark: string, endMark?: string): void {
   if (!hasPerf()) return;
   try {
-    if (endMark) {
+    if (endMark !== undefined) {
       performance.measure(name, startMark, endMark);
     } else {
       performance.measure(name, startMark);
     }
+    emittedNames.add(name);
   } catch {
     // measure throws if either mark is missing; swallow so callers don't have to guard.
   }
@@ -57,10 +60,13 @@ export function getReport(): PerfEntry[] {
     startTime: e.startTime,
     type: 'measure' as const,
   }));
-  return [...marks, ...measures].sort((a, b) => a.startTime - b.startTime);
+  return [...marks, ...measures]
+    .filter((e) => emittedNames.has(e.name))
+    .sort((a, b) => a.startTime - b.startTime);
 }
 
 /** Test-only: clear the idempotency set so a single test run can re-mark names. */
 export function _resetForTest(): void {
   seen.clear();
+  emittedNames.clear();
 }


### PR DESCRIPTION
## Summary

Phase 0 of the Map TTRC improvements spec — pure measurement, no rendering changes.

- `@vercel/speed-insights/next` mounted in the root layout (LCP/INP/CLS/FCP/TTFB per route)
- New `src/lib/perf/marks.ts` SSR-safe wrapper around `performance.mark`/`measure`. `getReport()` filters to entries we emitted (excludes third-party noise from Leaflet/Supabase/etc.)
- New `src/components/perf/PerfOverlay.tsx` — opt-in overlay rendered only when `?perf=1` or `localStorage.perfOverlay === '1'`. Shows live marks table + cold/warm cache-state tag + copy-to-clipboard button
- Marks emitted from `HomeMapView` and `MapView`:
  - `ttrc:hydrate-start`
  - `ttrc:idb-resolved` (warm + cold paths)
  - `ttrc:geolayers-resolved`
  - `ttrc:first-paint-tile` (TileLayer first tileload)
  - `ttrc:first-marker` + `ttrc:all-markers` (effect on items.length)
  - `ttrc:interactive` (first map pan/zoom/click)

Spec: `docs/superpowers/specs/2026-05-02-map-ttrc-improvements-design.md` (on `docs/map-ttrc-spec`)
Plan: `docs/superpowers/plans/2026-05-02-map-ttrc-phase-0-measurement.md` (on `docs/map-ttrc-spec`)

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test -- src/lib/perf src/components/perf src/components/map` — 17 tests pass
- [x] `npm run build` — succeeds
- [ ] Vercel preview cold load: `?perf=1` snapshot below (mobile + desktop)
- [ ] Vercel preview warm load: `?perf=1` snapshot below (mobile + desktop)

{
  "cacheState": "warm",
  "entries": [
    {
      "name": "ttrc:hydrate-start",
      "duration": 0,
      "startTime": 387.19999998807907,
      "type": "mark"
    },
    {
      "name": "ttrc:idb-resolved",
      "duration": 0,
      "startTime": 407.10000002384186,
      "type": "mark"
    },
    {
      "name": "ttrc:geolayers-resolved",
      "duration": 0,
      "startTime": 693.6999999880791,
      "type": "mark"
    },
    {
      "name": "ttrc:first-marker",
      "duration": 0,
      "startTime": 701.5,
      "type": "mark"
    },
    {
      "name": "ttrc:all-markers",
      "duration": 0,
      "startTime": 701.6000000238419,
      "type": "mark"
    },
    {
      "name": "ttrc:first-paint-tile",
      "duration": 0,
      "startTime": 714.1999999880791,
      "type": "mark"
    },
    {
      "name": "ttrc:interactive",
      "duration": 0,
      "startTime": 3336.400000035763,
      "type": "mark"
    }
  ]
}


- [ ] Speed Insights dashboard shows `/map` after a few minutes of preview traffic

## Snapshots

_to attach: paste the overlay's `copy` JSON or screenshot for each of the four scenarios above._

🤖 Generated with [Claude Code](https://claude.com/claude-code)