### PR TITLE
perf(map): parallelize fetches + defer sync + preconnect tiles (Phase 1)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,6 +68,7 @@ export default async function RootLayout({
       <head>
         <style dangerouslySetInnerHTML={{ __html: `:root { ${cssVars} }` }} />
         <link rel="manifest" href="/api/manifest.json" />
+        <link rel="preconnect" href="https://basemaps.cartocdn.com" crossOrigin="anonymous" />
         <meta name="theme-color" content="#2563eb" />
         <link rel="icon" type="image/png" sizes="32x32" href="/defaults/logos/favicon-32.png" />
         <meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -205,13 +205,21 @@ function HomeMapViewContent() {
       );
       setVisibleGeoLayerIds(defaultVisible);
 
-      // Load GeoJSON for default visible layers
-      for (const layerId of Array.from(defaultVisible)) {
-        const layerResult = await getGeoLayerPublic(layerId);
-        if ('success' in layerResult) {
-          setGeoLayerData((prev) => new Map(prev).set(layerId, layerResult.layer.geojson));
+      // Load GeoJSON for default visible layers in parallel
+      const layerResults = await Promise.all(
+        Array.from(defaultVisible).map((layerId) =>
+          getGeoLayerPublic(layerId).then((r) => ({ layerId, result: r })),
+        ),
+      );
+      setGeoLayerData((prev) => {
+        const next = new Map(prev);
+        for (const { layerId, result } of layerResults) {
+          if ('success' in result) {
+            next.set(layerId, result.layer.geojson);
+          }
         }
-      }
+        return next;
+      });
 
       mark('ttrc:geolayers-resolved');
 

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -31,6 +31,16 @@ import type { FeatureCollection } from "geojson";
 import type { SheetState } from "@/components/ui/MultiSnapBottomSheet";
 import { mark } from '@/lib/perf/marks';
 
+function runWhenIdle(fn: () => void, timeoutMs = 2000): void {
+  if (typeof window === 'undefined') return;
+  const ric = (window as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(fn, { timeout: timeoutMs });
+  } else {
+    window.setTimeout(fn, 0);
+  }
+}
+
 const MapView = dynamic(() => import("@/components/map/MapView"), {
   ssr: false,
   loading: () => (
@@ -169,17 +179,19 @@ function HomeMapViewContent() {
           setIsAuthenticated(false);
         }
 
-        // Trigger background sync and refresh data when done
+        // Trigger background sync after the browser is idle so it doesn't compete with first-paint
         if (resolvedOrgId && offlineStore.isOnline) {
-          offlineStore.syncProperty(propertyId, resolvedOrgId).then(async () => {
-            const [freshItems, freshTypes, freshFields] = await Promise.all([
-              offlineStore.getItems(propertyId),
-              offlineStore.getItemTypes(resolvedOrgId!),
-              offlineStore.getCustomFields(resolvedOrgId!),
-            ]);
-            setItems(freshItems);
-            setItemTypes(freshTypes);
-            setCustomFields(freshFields);
+          runWhenIdle(() => {
+            offlineStore.syncProperty(propertyId, resolvedOrgId).then(async () => {
+              const [freshItems, freshTypes, freshFields] = await Promise.all([
+                offlineStore.getItems(propertyId),
+                offlineStore.getItemTypes(resolvedOrgId!),
+                offlineStore.getCustomFields(resolvedOrgId!),
+              ]);
+              setItems(freshItems);
+              setItemTypes(freshTypes);
+              setCustomFields(freshFields);
+            });
           });
         }
       } catch (err) {

--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -146,22 +146,24 @@ function HomeMapViewContent() {
         setCustomFields(fieldData);
         mark('ttrc:idb-resolved');
 
-        // Check authentication via cached session, and load org contribution settings
+        // Check authentication and org settings in parallel
         try {
           const { createClient } = await import("@/lib/supabase/client");
           const supabase = createClient();
-          const { data: { user } } = await supabase.auth.getUser();
+          const [{ data: { user } }, orgSettingsResult] = await Promise.all([
+            supabase.auth.getUser(),
+            resolvedOrgId
+              ? supabase
+                  .from('orgs')
+                  .select('allow_public_contributions')
+                  .eq('id', resolvedOrgId)
+                  .single()
+              : Promise.resolve({ data: null }),
+          ]);
           setIsAuthenticated(!!user);
-
-          // Fetch org public-contribution settings
           if (resolvedOrgId) {
             setOrgId(resolvedOrgId);
-            const { data: orgSettings } = await supabase
-              .from('orgs')
-              .select('allow_public_contributions')
-              .eq('id', resolvedOrgId)
-              .single();
-            setAllowPublicContributions(orgSettings?.allow_public_contributions ?? false);
+            setAllowPublicContributions(orgSettingsResult.data?.allow_public_contributions ?? false);
           }
         } catch {
           setIsAuthenticated(false);


### PR DESCRIPTION
## Summary

Phase 1 of the Map TTRC improvements spec — quick wins, no architecture change. Branched off latest `main` (which now includes Phase 0 marks from #298).

- **1.1 Parallelize default geo-layer GeoJSON fetches** — `for-await` loop → `Promise.all` + single `setGeoLayerData`. Saves N×latency when N≥2 default-visible layers. (`01f40b9`)
- **1.2 Parallelize warm-path auth + org-settings** — two sequential awaits → single `Promise.all` (with `Promise.resolve({ data: null })` fallback when `resolvedOrgId` is falsy). Saves one round-trip on every warm visit. (`fceeb99`)
- **1.3 Defer background sync** — warm-path `syncProperty()` wrapped in `runWhenIdle` (local helper: `requestIdleCallback` with 2s timeout, Safari fallback to `setTimeout(0)`). Cold-path sync untouched (no benefit — nothing else to render). (`114a009`)
- **1.4 Preconnect to CARTO tile CDN** — `<link rel="preconnect" href="https://basemaps.cartocdn.com" crossOrigin="anonymous">` in root layout `<head>`. Saves DNS+TLS handshake (~100–300ms) on cold visits. (`9dd5b12`)
- **1.5 SW server-action cache** — **PUNTED to Phase 3** per the plan's spike contract. Reason: `propertyId` for `getPropertyGeoLayersPublic` is in the Next-Action POST body, not URL/headers. Disambiguating without reading the body would risk cross-property cache pollution. Phase 3's IDB-cached GeoJSON (per spec) handles this deterministically.
- **1.6 Lazy-load audit** — confirmed in code: default-layers fetch filters by `visible_default === true` only; `handleToggleGeoLayer` gates `getGeoLayerPublic` behind `!geoLayerData.has(layerId)`. Non-default layers fetch only on toggle and never re-fetch. No code change.

Spec: `docs/superpowers/specs/2026-05-02-map-ttrc-improvements-design.md` (on `docs/map-ttrc-spec`)
Plan: `docs/superpowers/plans/2026-05-02-map-ttrc-phase-1-quick-wins.md` (on `docs/map-ttrc-spec`)

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test -- src/components/map src/components/perf src/lib/perf` — 17 tests pass
- [x] `npm run build` — succeeds
- [ ] Vercel preview: `?perf=1` snapshot — `ttrc:geolayers-resolved − ttrc:idb-resolved` smaller than Phase 0 baseline (when ≥2 default layers)
- [ ] Vercel preview: `?perf=1` snapshot — `ttrc:idb-resolved − ttrc:hydrate-start` no regression
- [ ] Vercel preview: `?perf=1` snapshot — `ttrc:first-marker` no longer regressed by background sync work
- [ ] Vercel preview: LCP on cold mobile drops vs Phase 0 baseline

Supersedes #301 (stacked on Phase 0; rebased onto main now that #298 has merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)