### PR TITLE
fix(puck): wrap nbsp-joined paste content in RichText block

### DIFF
--- a/src/lib/puck/components/page/RichText.tsx
+++ b/src/lib/puck/components/page/RichText.tsx
@@ -8,7 +8,7 @@ export function RichText({ content, alignment, columns, textSize = 'large' }: Ri
 
   return (
     <div className={`mx-auto max-w-4xl px-4 py-8 ${alignClass} ${colClass}`}>
-      <div className={`prose ${proseSize} max-w-none prose-headings:text-[var(--color-primary-dark)] prose-a:text-[var(--color-primary)]`}>
+      <div className={`prose ${proseSize} max-w-none prose-headings:text-[var(--color-primary-dark)] prose-a:text-[var(--color-primary)] [overflow-wrap:anywhere]`}>
         <RichTextContent content={content} />
       </div>
     </div>

--- a/src/lib/puck/components/page/__tests__/page-components.test.tsx
+++ b/src/lib/puck/components/page/__tests__/page-components.test.tsx
@@ -102,6 +102,13 @@ describe('RichText', () => {
     const prose = container.querySelector('.prose') as HTMLElement;
     expect(prose.className).toContain('prose-xl');
   });
+
+  it('applies overflow-wrap:anywhere so nbsp-joined paste content wraps (e.g. from Quill)', () => {
+    const nbspJoined = '<p>Eagle&nbsp;Scout&nbsp;Fairbanks&nbsp;Jackson&nbsp;of&nbsp;Troop&nbsp;1564</p>';
+    const { container } = render(<RichText content={nbspJoined} alignment="left" columns={1} />);
+    const prose = container.querySelector('.prose') as HTMLElement;
+    expect(prose.className).toContain('[overflow-wrap:anywhere]');
+  });
 });
 
 // ImageBlock


### PR DESCRIPTION
## Summary
- Puck `RichText` block lets pasted content overflow the page horizontally when source HTML has `&nbsp;` joiners (e.g. content pasted from Quill.js). Adds `[overflow-wrap:anywhere]` to the prose wrapper so the browser can break across non-breaking-space runs and long unbreakable strings.
- One-line CSS guard. Retroactive — fixes already-saved bad content with no data migration.

## Root cause
Quill encodes every space as `&nbsp;` (U+00A0) in clipboard HTML. By CSS spec, `&nbsp;` is non-breaking → with default `overflow-wrap: normal` the browser treats the entire paragraph as one giant word → forces parent width → page overflows.

`src/lib/puck/components/page/RichText.tsx:11` has no `overflow-wrap` / `break-words` guard, so there is no recovery. `dangerouslySetInnerHTML` at line 36 renders the saved HTML as-is.

## Why `overflow-wrap: anywhere` and not `break-words`
Both produce identical wrap behavior in normal layout, but `anywhere` also affects `min-content` width calculation. Matters for the `columns=2` variant (line 6) which puts the prose in a multi-column flow where intrinsic sizing decisions can re-introduce the overflow.

`overflow-wrap` inherits, so all descendants of the prose wrapper get it.

## Out of scope (tracked separately)
The saved HTML also contains Quill leftovers (`<div class="_RichTextEditor_*">`, `<div class="rich-text">`, `xmlns="http://www.w3.org/1999/xhtml"` on `<p>`). These don't cause the overflow but indicate Puck's `richtext` field accepts pasted HTML wholesale. Proper sanitization (DOMPurify with allowlist) is filed as a follow-up issue and aligns with #297 (TipTap unification — TipTap's `PasteFormatDialog` already handles this for the knowledge editor).

## Test plan
- [x] Unit test asserts `[overflow-wrap:anywhere]` is on the prose wrapper
- [x] `npm run test -- --run src/lib/puck/components/page` — 60 passed
- [x] `npm run type-check` — clean
- [ ] Manual verify: paste a long nbsp-joined paragraph into a Puck `RichText` block, save, reload — text should wrap within the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)