### PR TITLE
feat(puck): server-side HTML sanitization for richtext content (closes #304)

### DIFF
--- a/docs/playbooks/puck-html-sanitize.md
+++ b/docs/playbooks/puck-html-sanitize.md
@@ -1,0 +1,86 @@
+# Puck HTML Sanitization Playbook
+
+## What this is
+
+Server-side HTML sanitization (DOMPurify allowlist + NBSP normalization) on
+every save to `properties.puck_pages` and `properties.puck_pages_draft`.
+Implemented in:
+
+- `src/lib/puck/sanitize-html.ts` — allowlist + sanitizer
+- `src/lib/puck/sanitize-data.ts` — `sanitizePuckDataForWrite` walks the Puck
+  tree and applies the sanitizer to richtext props
+- `src/app/admin/site-builder/actions.ts` — calls the sanitizer in
+  `savePuckPageDraft`, `savePuckRootDraft`, `publishPuckPages`,
+  `publishPuckRoot`
+
+Spec: `docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md`
+Issue: #304
+
+## Operator tasks
+
+### Run the one-time backfill
+
+The backfill re-saves all existing `puck_pages` / `puck_pages_draft` /
+`puck_root` / `puck_root_draft` rows through the sanitizer. Idempotent —
+already-clean rows skip the UPDATE.
+
+```bash
+# 1. Pull production env vars
+vercel env pull .env.local
+
+# 2. Export them
+set -a; . .env.local; set +a
+
+# 3. Dry run — review the diff
+npm run backfill:puck-sanitize
+
+# 4. Apply — actually write
+npm run backfill:puck-sanitize -- --apply
+```
+
+Save the output of step 3 and step 4 to the PR for record.
+
+### Extending the allowlist
+
+If a future requirement needs (for example) `<table>` support in Puck pages:
+
+1. Edit `src/lib/puck/sanitize-html.ts` `ALLOWED_TAGS` constant — add
+   `'table', 'thead', 'tbody', 'tr', 'th', 'td'`.
+2. If the new tag uses attributes, add them to `ALLOWED_ATTR`.
+3. Add a unit test in `src/lib/puck/__tests__/sanitize-html.test.ts`
+   confirming the new tag round-trips.
+4. Note: data already saved BEFORE the allowlist extension had the tag
+   stripped at write time and that data is gone. To recover, restore from a
+   Supabase point-in-time backup. Re-running the backfill after extending
+   the allowlist does not bring stripped data back.
+
+### Disabling sanitization (emergency)
+
+If sanitization is over-aggressively breaking content:
+
+1. Revert the actions changes — comment out the `sanitizePuckDataForWrite`
+   call in `savePuckPageDraft` / `savePuckRootDraft` and use
+   `parseResult.data` directly.
+2. Deploy.
+3. Existing already-sanitized data stays as-is — no automatic restore.
+
+### Rotating the sanitization library
+
+`isomorphic-dompurify` is the only dependency owned by this feature. To
+upgrade:
+
+```bash
+npm install isomorphic-dompurify@latest
+npm run test -- --run src/lib/puck
+```
+
+If tests pass, ship. If not, the new version may have changed default URI
+regex or hook semantics — read the upstream changelog.
+
+## Cost / performance notes
+
+- Save path: ~5–20 ms additional per `savePuckPageDraft` call (DOMPurify
+  parse + serialize). Save is a user action — acceptable.
+- Render path: unchanged. No sanitization at render.
+- Backfill: O(rows × richtext-blocks). For current data volume (~tens of
+  rows), under one minute total.

--- a/docs/superpowers/plans/2026-05-02-puck-html-sanitize.md
+++ b/docs/superpowers/plans/2026-05-02-puck-html-sanitize.md
@@ -1,0 +1,1097 @@
+# Puck Rich-Text HTML Sanitization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sanitize HTML written to `properties.puck_pages` and `properties.puck_pages_draft` at write time using DOMPurify with a strict allowlist + NBSP normalization, plus a one-time backfill script.
+
+**Architecture:** New `sanitizeRichTextHtml(input)` wraps `isomorphic-dompurify` with our allowlist + NBSP regex. Existing `sanitize-data.ts` extracts a shared walker and adds `sanitizePuckDataForWrite` that runs HTML sanitization on richtext props. Site-builder server actions call the write-variant before persisting. A standalone `tsx` script re-saves all `puck_pages` and `puck_pages_draft` rows through the same pipeline.
+
+**Tech Stack:** TypeScript, Vitest, `isomorphic-dompurify`, `tsx` (TS script runner), Supabase service-role client.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/lib/puck/sanitize-html.ts` | DOMPurify config + allowlist + NBSP normalizer; exports `sanitizeRichTextHtml` |
+| Create | `src/lib/puck/__tests__/sanitize-html.test.ts` | Unit tests for the sanitizer |
+| Modify | `src/lib/puck/sanitize-data.ts` | Extract shared walker; add `sanitizePuckDataForWrite` |
+| Modify | `src/lib/puck/__tests__/sanitize-data.test.ts` | Tests for `sanitizePuckDataForWrite` |
+| Modify | `src/app/admin/site-builder/actions.ts` | Call `sanitizePuckDataForWrite` in 4 places |
+| Create | `scripts/backfill-puck-sanitize.ts` | One-time backfill with `--dry-run` / `--apply` |
+| Modify | `package.json` | Add `tsx` devDep; add `backfill:puck-sanitize` npm script |
+| Create | `docs/playbooks/puck-html-sanitize.md` | Operator runbook for backfill + future allowlist edits |
+
+---
+
+## Task 1: Install `isomorphic-dompurify` + `tsx`
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install runtime dep**
+
+```bash
+cd /Users/patrick/birdhouse-mapper/.worktrees/puck-html-sanitize
+npm install isomorphic-dompurify@^2.30.0
+```
+
+Expected: package.json `dependencies` gains `"isomorphic-dompurify"`. No errors.
+
+- [ ] **Step 2: Install dev dep**
+
+```bash
+npm install -D tsx@^4.20.0
+```
+
+Expected: package.json `devDependencies` gains `"tsx"`.
+
+- [ ] **Step 3: Verify install**
+
+```bash
+node -e "require('isomorphic-dompurify')"
+npx tsx --version
+```
+
+Expected: no error from first command; tsx prints a version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add isomorphic-dompurify and tsx for puck html sanitization"
+```
+
+---
+
+## Task 2: Implement `sanitize-html.ts` (TDD)
+
+**Files:**
+- Create: `src/lib/puck/sanitize-html.ts`
+- Create: `src/lib/puck/__tests__/sanitize-html.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/puck/__tests__/sanitize-html.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { sanitizeRichTextHtml } from '../sanitize-html';
+
+const NBSP = ' ';
+
+describe('sanitizeRichTextHtml', () => {
+  it('passes allowlisted tags through', () => {
+    expect(sanitizeRichTextHtml('<p>hi</p>')).toBe('<p>hi</p>');
+    expect(sanitizeRichTextHtml('<strong>bold</strong>')).toBe('<strong>bold</strong>');
+    expect(sanitizeRichTextHtml('<h2>title</h2>')).toBe('<h2>title</h2>');
+  });
+
+  it('strips disallowed tags but keeps text content', () => {
+    expect(sanitizeRichTextHtml('<div>hi</div>')).toBe('hi');
+    expect(sanitizeRichTextHtml('<span>x</span>')).toBe('x');
+    expect(sanitizeRichTextHtml('<h1>x</h1>')).toBe('x');
+    expect(sanitizeRichTextHtml('<h5>x</h5>')).toBe('x');
+    expect(sanitizeRichTextHtml('<table><tr><td>x</td></tr></table>')).toBe('x');
+  });
+
+  it('strips script tags and event handlers', () => {
+    const result = sanitizeRichTextHtml('<p onclick="alert(1)">x</p><script>alert(1)</script>');
+    expect(result).not.toContain('onclick');
+    expect(result).not.toContain('script');
+    expect(result).toContain('x');
+  });
+
+  it('strips class, style, id, xmlns, data-* attributes', () => {
+    const input = '<p class="x" style="color:red" id="y" xmlns="ns" data-foo="bar">hi</p>';
+    expect(sanitizeRichTextHtml(input)).toBe('<p>hi</p>');
+  });
+
+  it('removes javascript: and data: URLs from href', () => {
+    expect(sanitizeRichTextHtml('<a href="javascript:alert(1)">x</a>')).not.toContain('javascript:');
+    expect(sanitizeRichTextHtml('<a href="data:text/html,foo">x</a>')).not.toContain('data:');
+  });
+
+  it('preserves http/https/mailto/relative href', () => {
+    expect(sanitizeRichTextHtml('<a href="https://example.com">x</a>')).toContain('href="https://example.com"');
+    expect(sanitizeRichTextHtml('<a href="/path">x</a>')).toContain('href="/path"');
+    expect(sanitizeRichTextHtml('<a href="mailto:a@b.com">x</a>')).toContain('href="mailto:a@b.com"');
+  });
+
+  it('auto-adds rel="noopener noreferrer" when target=_blank', () => {
+    const result = sanitizeRichTextHtml('<a href="https://example.com" target="_blank">x</a>');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it('strips img event handlers but keeps allowlisted attrs', () => {
+    const result = sanitizeRichTextHtml('<img src="/x.jpg" alt="x" onerror="alert(1)" width="10">');
+    expect(result).not.toContain('onerror');
+    expect(result).toContain('src="/x.jpg"');
+    expect(result).toContain('alt="x"');
+    expect(result).toContain('width="10"');
+  });
+
+  it('collapses runs of 2+ NBSP/spaces to single ASCII space', () => {
+    expect(sanitizeRichTextHtml(`<p>a${NBSP}${NBSP}b</p>`)).toBe('<p>a b</p>');
+    expect(sanitizeRichTextHtml(`<p>a  b</p>`)).toBe('<p>a b</p>');
+    expect(sanitizeRichTextHtml(`<p>a${NBSP} ${NBSP}b</p>`)).toBe('<p>a b</p>');
+  });
+
+  it('preserves isolated NBSP', () => {
+    expect(sanitizeRichTextHtml(`<p>10${NBSP}km</p>`)).toBe(`<p>10${NBSP}km</p>`);
+    expect(sanitizeRichTextHtml(`<p>Mr.${NBSP}Smith</p>`)).toBe(`<p>Mr.${NBSP}Smith</p>`);
+  });
+
+  it('removes Quill paste artifacts (wrapper divs + xmlns) and preserves single NBSPs', () => {
+    const quillSample = `<div class="_RichTextEditor_z25h4_1"><div class="rich-text"><p xmlns="http://www.w3.org/1999/xhtml">Eagle${NBSP}Scout${NBSP}Fairbanks</p></div></div>`;
+    const result = sanitizeRichTextHtml(quillSample);
+    expect(result).not.toContain('_RichTextEditor');
+    expect(result).not.toContain('rich-text');
+    expect(result).not.toContain('xmlns');
+    expect(result).toContain(`Eagle${NBSP}Scout${NBSP}Fairbanks`);
+    expect(result.startsWith('<p>')).toBe(true);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(sanitizeRichTextHtml('')).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/patrick/birdhouse-mapper/.worktrees/puck-html-sanitize
+npm run test -- --run src/lib/puck/__tests__/sanitize-html.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL with `Cannot find module '../sanitize-html'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/puck/sanitize-html.ts`:
+
+```ts
+/**
+ * HTML sanitization for Puck richtext field content.
+ *
+ * Allowlist lives in this file. To extend (e.g. permit tables in Puck pages),
+ * add the tag to ALLOWED_TAGS and any new attributes to ALLOWED_ATTR.
+ *
+ * Called from sanitizePuckDataForWrite (sanitize-data.ts) on every save.
+ */
+import DOMPurify from 'isomorphic-dompurify';
+
+const ALLOWED_TAGS = [
+  'p',
+  'a',
+  'strong',
+  'em',
+  'u',
+  's',
+  'code',
+  'pre',
+  'blockquote',
+  'ul',
+  'ol',
+  'li',
+  'h2',
+  'h3',
+  'h4',
+  'br',
+  'hr',
+  'img',
+];
+
+const ALLOWED_ATTR = ['href', 'target', 'rel', 'src', 'alt', 'width', 'height'];
+
+// DOMPurify defaults reject javascript:, data:, vbscript: in URI attributes.
+// We rely on those defaults rather than overriding ALLOWED_URI_REGEXP.
+
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+/**
+ * Sanitize a single richtext HTML string.
+ *
+ * Strips all tags not on the allowlist (text content kept), drops all
+ * attributes not on the allowlist, removes javascript:/data: URI schemes,
+ * auto-adds rel="noopener noreferrer" to target=_blank links, and collapses
+ * runs of 2+ NBSP/space characters to a single ASCII space (isolated NBSPs
+ * preserved).
+ */
+export function sanitizeRichTextHtml(input: string): string {
+  if (!input) return '';
+  try {
+    const sanitized = DOMPurify.sanitize(input, {
+      ALLOWED_TAGS,
+      ALLOWED_ATTR,
+    });
+    return normalizeNbsp(sanitized);
+  } catch {
+    return '';
+  }
+}
+
+// Match runs of 2+ of: U+0020 (space) or U+00A0 (NBSP), in any combination.
+const NBSP_RUN_REGEX = /[  ]{2,}/g;
+
+function normalizeNbsp(html: string): string {
+  return html.replace(NBSP_RUN_REGEX, ' ');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run test -- --run src/lib/puck/__tests__/sanitize-html.test.ts 2>&1 | tail -15
+```
+
+Expected: all 11 tests pass.
+
+If any test fails, read the failure and adjust the implementation. Common pitfall: DOMPurify global hooks added more than once across hot reload — for a one-shot vitest run this is fine.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/puck/sanitize-html.ts src/lib/puck/__tests__/sanitize-html.test.ts
+git commit -m "feat(puck): sanitizeRichTextHtml — DOMPurify allowlist + nbsp normalization
+
+Strict allowlist of structural/inline tags. Drops class/style/id/xmlns/
+data-*/event handlers. Rejects javascript:/data: URIs (DOMPurify default).
+Auto-adds rel='noopener noreferrer' on target=_blank. Collapses runs of
+2+ NBSP/space to single ASCII space; isolated NBSP preserved.
+
+Spec: docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md"
+```
+
+---
+
+## Task 3: Add `sanitizePuckDataForWrite` to `sanitize-data.ts`
+
+**Files:**
+- Modify: `src/lib/puck/sanitize-data.ts`
+- Modify: `src/lib/puck/__tests__/sanitize-data.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/puck/__tests__/sanitize-data.test.ts` (after the existing `describe('sanitizePuckData')` block):
+
+```ts
+describe('sanitizePuckDataForWrite', () => {
+  it('runs HTML sanitization on richtext props', () => {
+    const data = {
+      content: [
+        { type: 'RichText', props: { content: '<p>hi<script>alert(1)</script></p>' } },
+      ],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.content[0] as any).props.content).not.toContain('script');
+    expect((result.content[0] as any).props.content).toContain('hi');
+  });
+
+  it('still nullifies empty richtext strings', () => {
+    const data = {
+      content: [{ type: 'RichText', props: { content: '' } }],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.content[0] as any).props.content).toBeNull();
+  });
+
+  it('walks nested slot components recursively', () => {
+    const data = {
+      content: [
+        {
+          type: 'Container',
+          props: {
+            children: [
+              { type: 'Card', props: { text: '<div>x</div><span>y</span>' } },
+            ],
+          },
+        },
+      ],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    const inner = (result.content[0] as any).props.children[0].props.text;
+    expect(inner).toBe('xy');
+  });
+
+  it('leaves non-richtext props untouched', () => {
+    const data = {
+      content: [
+        { type: 'Custom', props: { customProp: '<p>html</p>', alt: 'pic' } },
+      ],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.content[0] as any).props.customProp).toBe('<p>html</p>');
+    expect((result.content[0] as any).props.alt).toBe('pic');
+  });
+
+  it('processes root.content blocks', () => {
+    const data = {
+      content: [],
+      root: {
+        content: [
+          { type: 'Card', props: { quote: '<p onclick="x">q</p>' } },
+        ],
+      },
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.root!.content![0] as any).props.quote).not.toContain('onclick');
+  });
+});
+```
+
+Also add the import to the top of the test file (next to the existing `sanitizePuckData` import):
+
+```ts
+import { sanitizePuckData, sanitizePuckDataForWrite } from '../sanitize-data';
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm run test -- --run src/lib/puck/__tests__/sanitize-data.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — `sanitizePuckDataForWrite` is not exported from `../sanitize-data`.
+
+- [ ] **Step 3: Refactor `sanitize-data.ts` and add the new export**
+
+Replace the entire contents of `src/lib/puck/sanitize-data.ts` with:
+
+```ts
+import type { Data } from '@puckeditor/core';
+import { sanitizeRichTextHtml } from './sanitize-html';
+
+/**
+ * Prop names that are richtext fields in Puck component configs.
+ * Puck's RichTextRender crashes when these are empty strings — it creates
+ * { type: "text", text: "" } which ProseMirror rejects. Setting to null
+ * makes Puck create a safe empty doc instead.
+ */
+const RICHTEXT_PROP_NAMES = ['content', 'text', 'quote'];
+
+type Component = { type: string; props: Record<string, unknown> };
+
+/**
+ * Walk every Puck component in the data tree and call `fn` for each
+ * richtext-typed prop. The callback's return value replaces the prop value.
+ */
+function walkRichTextProps(
+  data: Data,
+  fn: (key: string, value: unknown) => unknown
+): void {
+  function walkComponents(components: Component[]) {
+    for (const component of components) {
+      if (!component.props) continue;
+      for (const key of RICHTEXT_PROP_NAMES) {
+        if (key in component.props) {
+          component.props[key] = fn(key, component.props[key]);
+        }
+      }
+      // Recursively walk slot content (arrays of components in props)
+      for (const value of Object.values(component.props)) {
+        if (
+          Array.isArray(value) &&
+          value.length > 0 &&
+          (value[0] as Component | undefined)?.type &&
+          (value[0] as Component | undefined)?.props
+        ) {
+          walkComponents(value as Component[]);
+        }
+      }
+    }
+  }
+
+  if (data.content) walkComponents(data.content as Component[]);
+  if (data.zones) {
+    for (const zone of Object.values(data.zones)) {
+      walkComponents(zone as Component[]);
+    }
+  }
+  if (data.root?.content) {
+    walkComponents(data.root.content as Component[]);
+  }
+}
+
+/**
+ * Sanitize Puck data on **load** to prevent ProseMirror "Empty text nodes"
+ * crash. Puck's RichTextRender converts empty string "" to a doc with a
+ * zero-length text node which crashes ProseMirror's Node.fromJSON. Setting
+ * empty richtext to null makes Puck use { type: "doc", content: [] }
+ * instead (safe).
+ */
+export function sanitizePuckData(data: Data): Data {
+  const clone = JSON.parse(JSON.stringify(data)) as Data;
+  walkRichTextProps(clone, (_key, value) => (value === '' ? null : value));
+  return clone;
+}
+
+/**
+ * Sanitize Puck data on **write**. Performs everything sanitizePuckData does
+ * and additionally runs every non-empty richtext string through
+ * sanitizeRichTextHtml — strips disallowed tags/attributes, normalizes NBSP
+ * runs, blocks javascript:/data: URIs.
+ *
+ * Call from server actions before persisting to Supabase.
+ */
+export function sanitizePuckDataForWrite(data: Data): Data {
+  const clone = JSON.parse(JSON.stringify(data)) as Data;
+  walkRichTextProps(clone, (_key, value) => {
+    if (value === '') return null;
+    if (typeof value === 'string') return sanitizeRichTextHtml(value);
+    return value;
+  });
+  return clone;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run test -- --run src/lib/puck/__tests__/sanitize-data.test.ts 2>&1 | tail -15
+```
+
+Expected: all existing `sanitizePuckData` tests still pass + 5 new `sanitizePuckDataForWrite` tests pass.
+
+- [ ] **Step 5: Run full type-check**
+
+```bash
+npm run type-check 2>&1 | tail -10
+```
+
+Expected: clean (no errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/puck/sanitize-data.ts src/lib/puck/__tests__/sanitize-data.test.ts
+git commit -m "feat(puck): sanitizePuckDataForWrite walks tree and HTML-sanitizes richtext props
+
+Extracts shared walker walkRichTextProps used by both load-side and
+write-side sanitizers. Write variant additionally runs every non-empty
+richtext string through sanitizeRichTextHtml.
+
+Load-side sanitizePuckData semantics unchanged."
+```
+
+---
+
+## Task 4: Wire `savePuckPageDraft` and `savePuckRootDraft` to sanitize on write
+
+**Files:**
+- Modify: `src/app/admin/site-builder/actions.ts:58-95` (`savePuckPageDraft`) and `:97-115` (`savePuckRootDraft`)
+
+- [ ] **Step 1: Read current state of both functions**
+
+```bash
+sed -n '58,115p' src/app/admin/site-builder/actions.ts
+```
+
+Confirm both functions exist and match the shape described in the spec. If shape has drifted, stop and reassess.
+
+- [ ] **Step 2: Add the import to `actions.ts`**
+
+At the top of `src/app/admin/site-builder/actions.ts`, add the import next to the existing `puckDataSchema` import:
+
+```ts
+import { puckDataSchema } from '@/lib/puck/schemas';
+import { sanitizePuckDataForWrite } from '@/lib/puck/sanitize-data';
+```
+
+- [ ] **Step 3: Modify `savePuckPageDraft`**
+
+Locate the line:
+
+```ts
+const merged = { ...existing, [path]: parseResult.data };
+```
+
+Replace with:
+
+```ts
+const sanitized = sanitizePuckDataForWrite(parseResult.data as Parameters<typeof sanitizePuckDataForWrite>[0]);
+const merged = { ...existing, [path]: sanitized };
+```
+
+- [ ] **Step 4: Modify `savePuckRootDraft`**
+
+Locate the lines (around line 107-110):
+
+```ts
+  const { error } = await supabase
+    .from('properties')
+    .update({ puck_root_draft: parseResult.data as unknown as Record<string, unknown> })
+    .eq('id', result.propertyId);
+```
+
+Replace with:
+
+```ts
+  const sanitized = sanitizePuckDataForWrite(parseResult.data as Parameters<typeof sanitizePuckDataForWrite>[0]);
+  const { error } = await supabase
+    .from('properties')
+    .update({ puck_root_draft: sanitized as unknown as Record<string, unknown> })
+    .eq('id', result.propertyId);
+```
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npm run type-check 2>&1 | tail -5
+```
+
+Expected: clean. If a `Data` type mismatch surfaces, the cast `as Parameters<typeof sanitizePuckDataForWrite>[0]` should silence it; if not, replace with `as any` (acceptable here — `parseResult.data` is already a Zod-validated payload).
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -10
+```
+
+Expected: all pass. No new tests added in this task — integration tested via Task 6.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/admin/site-builder/actions.ts
+git commit -m "feat(puck): sanitize HTML before saving puck_pages_draft and puck_root_draft
+
+Routes savePuckPageDraft and savePuckRootDraft through
+sanitizePuckDataForWrite so foreign HTML (Quill/Word/Google Docs paste)
+is cleaned at write time. Render path unchanged."
+```
+
+---
+
+## Task 5: Defense-in-depth re-sanitize in `publishPuckPages` and `publishPuckRoot`
+
+**Files:**
+- Modify: `src/app/admin/site-builder/actions.ts:121-146` (`publishPuckPages`) and `:148-173` (`publishPuckRoot`)
+
+- [ ] **Step 1: Modify `publishPuckPages`**
+
+Locate the block:
+
+```ts
+  const { error } = await supabase
+    .from('properties')
+    .update({ puck_pages: property.puck_pages_draft })
+    .eq('id', result.propertyId);
+```
+
+Replace with:
+
+```ts
+  // Defense-in-depth: re-sanitize even though draft was sanitized on save.
+  // Idempotent — clean data passes through unchanged.
+  const draft = property.puck_pages_draft as Record<string, unknown> | null;
+  let sanitizedPages: Record<string, unknown> | null = null;
+  if (draft && typeof draft === 'object') {
+    sanitizedPages = {};
+    for (const [pagePath, pageData] of Object.entries(draft)) {
+      sanitizedPages[pagePath] = sanitizePuckDataForWrite(
+        pageData as Parameters<typeof sanitizePuckDataForWrite>[0]
+      );
+    }
+  }
+
+  const { error } = await supabase
+    .from('properties')
+    .update({ puck_pages: sanitizedPages })
+    .eq('id', result.propertyId);
+```
+
+- [ ] **Step 2: Modify `publishPuckRoot`**
+
+Locate the block:
+
+```ts
+  const { error } = await supabase
+    .from('properties')
+    .update({ puck_root: property.puck_root_draft })
+    .eq('id', result.propertyId);
+```
+
+Replace with:
+
+```ts
+  // Defense-in-depth: re-sanitize. Idempotent.
+  const sanitizedRoot = property.puck_root_draft
+    ? sanitizePuckDataForWrite(
+        property.puck_root_draft as Parameters<typeof sanitizePuckDataForWrite>[0]
+      )
+    : null;
+
+  const { error } = await supabase
+    .from('properties')
+    .update({ puck_root: sanitizedRoot as unknown as Record<string, unknown> | null })
+    .eq('id', result.propertyId);
+```
+
+- [ ] **Step 3: Type-check + tests**
+
+```bash
+npm run type-check && npm run test 2>&1 | tail -10
+```
+
+Expected: clean type-check; all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/site-builder/actions.ts
+git commit -m "feat(puck): defense-in-depth re-sanitize on publish
+
+publishPuckPages and publishPuckRoot now re-run sanitizePuckDataForWrite
+on the draft before promoting it to the live puck_pages/puck_root column.
+Idempotent — clean data is unchanged."
+```
+
+---
+
+## Task 6: Backfill script
+
+**Files:**
+- Create: `scripts/backfill-puck-sanitize.ts`
+- Modify: `package.json` (add `backfill:puck-sanitize` script)
+- Create: `docs/playbooks/puck-html-sanitize.md`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/backfill-puck-sanitize.ts`:
+
+```ts
+#!/usr/bin/env tsx
+/**
+ * One-time backfill: re-saves every property's puck_pages and puck_pages_draft
+ * (and puck_root / puck_root_draft) through sanitizePuckDataForWrite.
+ *
+ * Usage:
+ *   # dry-run: show what would change, no writes
+ *   npm run backfill:puck-sanitize
+ *
+ *   # apply: actually update rows where content changed
+ *   npm run backfill:puck-sanitize -- --apply
+ *
+ * Requires:
+ *   SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in env (load via vercel env pull
+ *   or .env.local).
+ */
+import { createClient } from '@supabase/supabase-js';
+import { sanitizePuckDataForWrite } from '../src/lib/puck/sanitize-data';
+import type { Data } from '@puckeditor/core';
+
+const APPLY = process.argv.includes('--apply');
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('FATAL: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in env.');
+  console.error('Hint: run `vercel env pull .env.local` then export the vars before running.');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false },
+});
+
+interface Row {
+  id: string;
+  puck_pages: Record<string, unknown> | null;
+  puck_pages_draft: Record<string, unknown> | null;
+  puck_root: Record<string, unknown> | null;
+  puck_root_draft: Record<string, unknown> | null;
+}
+
+function sanitizePagesMap(map: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!map) return null;
+  const out: Record<string, unknown> = {};
+  for (const [path, data] of Object.entries(map)) {
+    out[path] = sanitizePuckDataForWrite(data as Data);
+  }
+  return out;
+}
+
+function sanitizeRoot(data: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!data) return null;
+  return sanitizePuckDataForWrite(data as Data) as unknown as Record<string, unknown>;
+}
+
+async function main() {
+  console.log(APPLY ? 'Mode: APPLY (writes will happen)' : 'Mode: DRY-RUN (no writes)');
+
+  const { data: rows, error } = await supabase
+    .from('properties')
+    .select('id, puck_pages, puck_pages_draft, puck_root, puck_root_draft');
+
+  if (error) {
+    console.error('Failed to read properties:', error.message);
+    process.exit(1);
+  }
+
+  let scanned = 0;
+  let changed = 0;
+  let updated = 0;
+  let errors = 0;
+
+  for (const row of (rows ?? []) as Row[]) {
+    scanned++;
+    const next = {
+      puck_pages: sanitizePagesMap(row.puck_pages),
+      puck_pages_draft: sanitizePagesMap(row.puck_pages_draft),
+      puck_root: sanitizeRoot(row.puck_root),
+      puck_root_draft: sanitizeRoot(row.puck_root_draft),
+    };
+
+    const beforeJson = JSON.stringify({
+      puck_pages: row.puck_pages,
+      puck_pages_draft: row.puck_pages_draft,
+      puck_root: row.puck_root,
+      puck_root_draft: row.puck_root_draft,
+    });
+    const afterJson = JSON.stringify(next);
+
+    if (beforeJson === afterJson) {
+      continue;
+    }
+
+    changed++;
+    console.log(
+      `[${row.id}] would change: ` +
+        `pages=${row.puck_pages ? 'yes' : 'no'} ` +
+        `pagesDraft=${row.puck_pages_draft ? 'yes' : 'no'} ` +
+        `root=${row.puck_root ? 'yes' : 'no'} ` +
+        `rootDraft=${row.puck_root_draft ? 'yes' : 'no'} ` +
+        `(bytes ${beforeJson.length} → ${afterJson.length})`
+    );
+
+    if (!APPLY) continue;
+
+    const { error: updateError } = await supabase
+      .from('properties')
+      .update(next)
+      .eq('id', row.id);
+
+    if (updateError) {
+      errors++;
+      console.error(`[${row.id}] UPDATE failed: ${updateError.message}`);
+    } else {
+      updated++;
+    }
+  }
+
+  console.log('---');
+  console.log(`Scanned:  ${scanned}`);
+  console.log(`Changed:  ${changed}`);
+  console.log(`Updated:  ${updated}`);
+  console.log(`Errors:   ${errors}`);
+  if (!APPLY && changed > 0) {
+    console.log('\nDry run complete. Re-run with `-- --apply` to persist.');
+  }
+  if (errors > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Add npm script**
+
+Open `package.json` and add to the `"scripts"` block (after `"test:watch"`):
+
+```json
+    "backfill:puck-sanitize": "tsx scripts/backfill-puck-sanitize.ts",
+```
+
+So the scripts block now contains the line above.
+
+- [ ] **Step 3: Verify the script type-checks**
+
+```bash
+npx tsc --noEmit scripts/backfill-puck-sanitize.ts 2>&1 | tail -10
+```
+
+If errors, fix them. Note: the project's main `tsconfig.json` may not include `scripts/`. If `tsc` complains about `Cannot find module`, set the include path explicitly:
+
+```bash
+npx tsc --noEmit --module nodenext --target es2022 --moduleResolution nodenext --esModuleInterop scripts/backfill-puck-sanitize.ts 2>&1 | tail -10
+```
+
+If still erroring on path imports, the issue is `tsx` will resolve at runtime via Node's resolver — the `tsc --noEmit` check is best-effort. Skip this sub-step if it produces module-resolution errors that don't reflect runtime behavior; we'll catch real bugs in Step 4.
+
+- [ ] **Step 4: Smoke-run in dry mode**
+
+```bash
+# The operator must have SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY set.
+# Use vercel env pull to populate .env.local, then export.
+set -a; . .env.local; set +a
+npm run backfill:puck-sanitize 2>&1 | tail -20
+```
+
+Expected output: prints "Mode: DRY-RUN", scans rows, prints zero or more "would change" lines, prints summary.
+
+If `SUPABASE_URL` is not set in `.env.local`, set it explicitly:
+```bash
+SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL npm run backfill:puck-sanitize
+```
+
+- [ ] **Step 5: Write the operator playbook**
+
+Create `docs/playbooks/puck-html-sanitize.md`:
+
+```markdown
+# Puck HTML Sanitization Playbook
+
+## What this is
+
+Server-side HTML sanitization (DOMPurify allowlist + NBSP normalization) on
+every save to `properties.puck_pages` and `properties.puck_pages_draft`.
+Implemented in:
+
+- `src/lib/puck/sanitize-html.ts` — allowlist + sanitizer
+- `src/lib/puck/sanitize-data.ts` — `sanitizePuckDataForWrite` walks the Puck
+  tree and applies the sanitizer to richtext props
+- `src/app/admin/site-builder/actions.ts` — calls the sanitizer in
+  `savePuckPageDraft`, `savePuckRootDraft`, `publishPuckPages`,
+  `publishPuckRoot`
+
+Spec: `docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md`
+Issue: #304
+
+## Operator tasks
+
+### Run the one-time backfill
+
+The backfill re-saves all existing `puck_pages` / `puck_pages_draft` /
+`puck_root` / `puck_root_draft` rows through the sanitizer. Idempotent —
+already-clean rows skip the UPDATE.
+
+```bash
+# 1. Pull production env vars
+vercel env pull .env.local
+
+# 2. Export them
+set -a; . .env.local; set +a
+
+# 3. Dry run — review the diff
+npm run backfill:puck-sanitize
+
+# 4. Apply — actually write
+npm run backfill:puck-sanitize -- --apply
+```
+
+Save the output of step 3 and step 4 to the PR for record.
+
+### Extending the allowlist
+
+If a future requirement needs (for example) `<table>` support in Puck pages:
+
+1. Edit `src/lib/puck/sanitize-html.ts` `ALLOWED_TAGS` constant — add
+   `'table', 'thead', 'tbody', 'tr', 'th', 'td'`.
+2. If the new tag uses attributes, add them to `ALLOWED_ATTR`.
+3. Add a unit test in `src/lib/puck/__tests__/sanitize-html.test.ts`
+   confirming the new tag round-trips.
+4. Run the backfill **again** so existing data that previously had the tag
+   stripped is *not* re-stripped — but if data had the tag stripped before
+   the allowlist extension, that data is gone (the original was overwritten).
+   To recover, restore from a Supabase point-in-time backup.
+
+### Disabling sanitization (emergency)
+
+If sanitization is over-aggressively breaking content:
+
+1. Revert the actions changes — comment out the `sanitizePuckDataForWrite`
+   call in `savePuckPageDraft` / `savePuckRootDraft` and use
+   `parseResult.data` directly.
+2. Deploy.
+3. Existing already-sanitized data stays as-is — no automatic restore.
+
+### Rotating the sanitization library
+
+`isomorphic-dompurify` is the only dependency owned by this feature. To
+upgrade:
+
+```bash
+npm install isomorphic-dompurify@latest
+npm run test -- --run src/lib/puck
+```
+
+If tests pass, ship. If not, the new version may have changed default URI
+regex or hook semantics — read the upstream changelog.
+
+## Cost / performance notes
+
+- Save path: ~5–20 ms additional per `savePuckPageDraft` call (DOMPurify
+  parse + serialize). Save is a user action — acceptable.
+- Render path: unchanged. No sanitization at render.
+- Backfill: O(rows × richtext-blocks). For current data volume (~tens of
+  rows), under one minute total.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/backfill-puck-sanitize.ts package.json docs/playbooks/puck-html-sanitize.md
+git commit -m "feat(puck): backfill script + operator playbook
+
+Backfill re-runs every property row through sanitizePuckDataForWrite.
+Defaults to --dry-run; --apply to persist. Idempotent.
+
+Playbook covers: backfill procedure, allowlist extensions, emergency
+disable, library rotation, perf notes."
+```
+
+---
+
+## Task 7: Manual XSS smoke verification
+
+**Files:** none (manual verification on preview deploy)
+
+- [ ] **Step 1: Push branch and let preview deploy build**
+
+```bash
+git push -u origin fix/puck-html-sanitize
+```
+
+Wait for the Vercel preview deploy to complete (visible in PR comments after Task 8 opens the PR; for now just verify build via CI).
+
+- [ ] **Step 2: On the preview deploy, paste an XSS payload**
+
+Visit the preview deploy's Puck editor (e.g.
+`https://birdhouse-mapper-<sha>.vercel.app/admin/properties/default/site-builder/...`).
+
+Add a `RichText` block. Paste this into the rich-text field via the browser's paste-from-text mechanism (developer tools → Elements → set `innerHTML` of the contenteditable):
+
+```html
+<script>alert('xss-test-1')</script><p onclick="alert('xss-test-2')">click me</p><a href="javascript:alert('xss-test-3')">link</a><img src=x onerror="alert('xss-test-4')">
+```
+
+Save the page.
+
+- [ ] **Step 3: Reload and inspect**
+
+Reload the page. Open browser DevTools → Elements. Locate the rendered `RichText` block.
+
+Expected:
+- No `<script>` tag in the DOM
+- No `onclick` attribute on the `<p>`
+- The `<a>` either has no `href` or a sanitized href (no `javascript:`)
+- The `<img>` has no `onerror`
+- Page loads without alerts firing
+
+If any alert fires or any unsafe attribute is present, the sanitizer config is broken — return to Task 2 and add a regression test.
+
+- [ ] **Step 4: Document the smoke test in the PR**
+
+Comment on the PR with the steps above and a screenshot of DevTools showing the sanitized DOM.
+
+---
+
+## Task 8: Run backfill in production + open PR
+
+**Files:** none (operator action + PR creation)
+
+- [ ] **Step 1: Run dry-run against production**
+
+```bash
+cd /Users/patrick/birdhouse-mapper/.worktrees/puck-html-sanitize
+vercel env pull .env.local
+set -a; . .env.local; set +a
+npm run backfill:puck-sanitize 2>&1 | tee /tmp/backfill-dryrun.log | tail -20
+```
+
+Expected: prints summary. No errors. Save `/tmp/backfill-dryrun.log` for the PR.
+
+- [ ] **Step 2: Apply backfill**
+
+```bash
+npm run backfill:puck-sanitize -- --apply 2>&1 | tee /tmp/backfill-apply.log | tail -20
+```
+
+Expected: same scan count as dry-run; `Updated: <changed count>`; `Errors: 0`.
+
+- [ ] **Step 3: Verify in DB**
+
+```bash
+psql "$SUPABASE_DB_URL" -c "select id, jsonb_path_query_array(puck_pages, '$.**.props.content') from properties where puck_pages is not null limit 5;"
+```
+
+Spot-check that no row contains `_RichTextEditor` class names or `xmlns="http://www.w3.org/1999/xhtml"` attributes anymore.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+gh pr create --base main --head fix/puck-html-sanitize \
+  --title "feat(puck): server-side HTML sanitization for richtext content (closes #304)" \
+  --body "$(cat <<'EOF'
+## Summary
+Server-side DOMPurify allowlist + NBSP normalization on every save to `properties.puck_pages` and `properties.puck_pages_draft`. One-time backfill cleaned existing rows.
+
+Closes #304. Companion to PR #303 (Tier 1 CSS workaround).
+
+## Changes
+- **New:** `src/lib/puck/sanitize-html.ts` — DOMPurify wrapper, strict allowlist, `rel="noopener noreferrer"` auto-add, NBSP run collapsing
+- **Modified:** `src/lib/puck/sanitize-data.ts` — extracted shared walker, added `sanitizePuckDataForWrite`
+- **Modified:** `src/app/admin/site-builder/actions.ts` — `savePuckPageDraft` / `savePuckRootDraft` / `publishPuckPages` / `publishPuckRoot` route through the sanitizer
+- **New:** `scripts/backfill-puck-sanitize.ts` + `npm run backfill:puck-sanitize`
+- **New:** `docs/playbooks/puck-html-sanitize.md`
+- **Spec:** `docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md`
+
+## Backfill output
+<details><summary>Dry run</summary>
+
+```
+$(cat /tmp/backfill-dryrun.log)
+```
+</details>
+
+<details><summary>Apply</summary>
+
+```
+$(cat /tmp/backfill-apply.log)
+```
+</details>
+
+## Test plan
+- [x] `npm run test -- --run src/lib/puck` — all pass
+- [x] `npm run type-check` — clean
+- [x] Manual XSS smoke test on preview (script/onclick/javascript:/onerror all stripped)
+- [x] Backfill dry-run + apply against prod, no errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Watch CI**
+
+```bash
+gh pr checks $(gh pr view --json number -q .number) --repo patjackson52/birdhouse-mapper --watch
+```
+
+Expected: `Lint, Type Check & Build` passes; `Playwright E2E` passes; Vercel previews pass; `Migration Dry Run` may fail (pre-existing token issue tracked in #300).
+
+---
+
+## Self-Review
+
+- [x] **Spec coverage:** Spec sections — Goals/Scope (Task 1-6), Decisions table (locked in spec, executed across all tasks), Allowlist (Task 2), NBSP normalization (Task 2), Architecture file map (Tasks 2-6), Backfill (Task 6), Error handling (Task 2 implementation has try/catch fallback), Testing (Tasks 2-3 unit + Task 7 manual), Acceptance criteria (Tasks 1-8). No gaps.
+- [x] **Placeholder scan:** No "TBD"/"TODO"/"implement later"/"add appropriate error handling"/etc. All code blocks contain real code.
+- [x] **Type / name consistency:** `sanitizeRichTextHtml` (Task 2) used in `sanitizePuckDataForWrite` (Task 3), called from `savePuckPageDraft`/`savePuckRootDraft`/`publishPuckPages`/`publishPuckRoot` (Tasks 4-5), referenced in backfill script (Task 6). `RICHTEXT_PROP_NAMES`, `walkRichTextProps`, `Component` type used consistently.
+- [x] **Manual prerequisites surfaced:** Task 8 requires `vercel env pull` (operator must be logged into Vercel CLI). Task 7 requires preview deploy URL.
+- [x] **Rollback path:** Playbook §"Disabling sanitization (emergency)" + git revert of the per-task commits.
+
+---

--- a/docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md
+++ b/docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md
@@ -1,0 +1,184 @@
+# Puck Rich-Text HTML Sanitization — Design
+
+**Status:** Approved (parameter decisions locked 2026-05-02)
+**Issue:** #304
+**Predecessor:** PR #303 (Tier 1 CSS workaround for non-breaking-space overflow)
+**Related:** #297 (TipTap unification — supersedes this design if/when it ships)
+
+## Goal
+
+Sanitize HTML written to `properties.puck_pages` and `properties.puck_pages_draft` so pasted content from external rich-text editors (Quill, Word, Google Docs, etc.) cannot:
+
+1. Pollute saved data with foreign wrapper divs, classes, `xmlns` attributes, inline styles
+2. Re-introduce horizontal-overflow problems (e.g., NBSP joiners, `style="white-space: nowrap"`, `style="width: 9999px"`)
+3. Carry an XSS payload (e.g., `<a href="javascript:...">`, `<img onerror=...>`)
+
+Tier 1 CSS guard (PR #303) prevents the visible breakage. This Tier 2 makes the data itself clean.
+
+## Scope
+
+**In scope**
+- Server-side HTML sanitization at write time for the three Puck `richtext` field props (`content`, `text`, `quote` per `src/lib/puck/sanitize-data.ts:9`)
+- One-time backfill script that re-saves all `puck_pages` and `puck_pages_draft` rows through the new sanitizer
+- Tests covering: paste-from-Quill sample, XSS attempts, isolated NBSP preservation, allowlist enforcement
+
+**Out of scope**
+- Replacing Puck's built-in `richtext` field with TipTap (#297)
+- Sanitizing TipTap-authored HTML in `knowledge_items.body_html` (TipTap's `PasteFormatDialog` handles paste at edit time)
+- Migrating away from `dangerouslySetInnerHTML` in `RichText.tsx`
+- Schema / column changes
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **Library:** `isomorphic-dompurify` | Works server (Node) + edge + client; faster than `sanitize-html`; battle-tested XSS coverage |
+| 2 | **Backfill:** save-time + one-time script | Save-time alone leaves existing dirty rows. Backfill is near-no-op for current data volume but the code path will exist for future rescue scenarios |
+| 3 | **NBSP policy:** runs of 2+ → single regular space; isolated NBSP preserved | Preserves legitimate non-breaking-space use ("10 km", "Mr. Smith") |
+| 4 | **Allowlist:** strict | No existing content to preserve; goal is forward-protection. Reject anything not on the list. |
+
+### Allowlist
+
+**Tags:** `p, a, strong, em, u, s, code, pre, blockquote, ul, ol, li, h2, h3, h4, br, hr, img`
+
+**Attributes:**
+- `a`: `href` (validate scheme: only `http:`, `https:`, `mailto:`, relative paths; reject `javascript:`, `data:`, `vbscript:`), `target`, `rel`. Auto-add `rel="noopener noreferrer"` when `target="_blank"`.
+- `img`: `src` (same scheme validation as `href`), `alt`, `width`, `height`
+- All other tags: no attributes. `class`, `style`, `id`, `xmlns`, `data-*`, event handlers — all stripped.
+
+DOMPurify's default behavior on disallowed tags is to strip the tag but keep its inner text — exactly what we want for foreign wrapper divs.
+
+### NBSP Normalization
+
+Run **after** DOMPurify on its output string. DOMPurify decodes entities, so by the time we run our regex the content contains the literal U+00A0 character (NBSP), not the `&nbsp;` text reference.
+
+```ts
+// Match runs of 2+ NBSP, regular space, or any combination thereof.
+// The character class contains: U+0020 (space), U+00A0 (NBSP).
+function normalizeNbsp(html: string): string {
+  return html.replace(/[  ]{2,}/g, ' ');
+}
+```
+
+Single isolated NBSP is left alone (preserves "10 km", "Mr. Smith"). Runs of 2+ collapse to one ASCII space — losing the non-break property is intentional, since 2+ consecutive NBSPs are almost always a paste artifact.
+
+## Architecture
+
+### Components
+
+```
+src/lib/puck/
+├── sanitize-html.ts             [NEW] DOMPurify config + nbsp normalizer
+├── sanitize-data.ts             [MODIFY] integrate sanitize-html into walkComponents
+├── __tests__/
+│   ├── sanitize-html.test.ts    [NEW]
+│   └── sanitize-data.test.ts    [MODIFY: add cases covering richtext sanitization]
+
+src/app/admin/site-builder/
+└── actions.ts                   [MODIFY] savePuckPageDraft + publishPuckPages call sanitizer before write
+
+scripts/
+└── backfill-puck-sanitize.mjs   [NEW] one-time script: read all properties, sanitize, write back
+```
+
+### Data flow
+
+```
+User saves page in Puck editor
+        |
+        v
+PuckPageEditor.tsx                            (client)
+        |
+        v
+savePuckPageDraft(path, data)                 (server action)
+        |
+        v
+sanitizePuckData(data)                        (existing — handles empty richtext)
+        |
+        v
+sanitizeRichTextProps(data)                   (NEW — runs HTML through DOMPurify + nbsp-normalize)
+        |
+        v
+Supabase UPDATE properties SET puck_pages_draft = ...
+```
+
+`publishPuckPages` reads `puck_pages_draft` and copies to `puck_pages`. Since draft is already sanitized, publish doesn't need to re-sanitize. Defense-in-depth: re-sanitize on publish anyway — idempotent, no perf cost worth measuring.
+
+### Why save-time, not render-time
+
+- Render-time is hot path; sanitization on every page view is wasted work
+- Saved data should be clean at rest — render-time sanitization papers over a data-quality problem
+- Save-time also catches the issue once and propagates the clean version everywhere
+
+## Backfill Script
+
+`scripts/backfill-puck-sanitize.mjs`
+
+**Behavior:**
+1. Load Supabase env via `vercel env pull` or `.env.local` (whichever the operator uses)
+2. `SELECT id, puck_pages, puck_pages_draft FROM properties WHERE puck_pages IS NOT NULL OR puck_pages_draft IS NOT NULL`
+3. For each row, run both columns through `sanitizePuckData` + `sanitizeRichTextProps`
+4. Compare before/after JSON. If unchanged, skip. If changed, log diff summary and queue update.
+5. Run with `--dry-run` flag default; `--apply` actually writes.
+6. Print summary: rows scanned / rows changed / rows updated / errors.
+
+**Safety:**
+- `--dry-run` first; operator reviews diff summary before `--apply`
+- Idempotent: re-running `--apply` on an already-clean DB is a no-op
+- No DDL — only data updates; rolled back via Supabase point-in-time restore if needed
+- Run from operator's machine, not CI — service-role key never enters CI
+
+## Error Handling
+
+- Sanitization failure (malformed input that throws): log and fall back to empty string for **that field only**. Do not swallow other field values.
+- Network/Supabase errors during backfill: continue, log row IDs that failed, exit non-zero.
+- DOMPurify init failure server-side (jsdom unavailable): log clearly, fail fast — should not happen in normal Node runtimes since `isomorphic-dompurify` bundles its own jsdom.
+
+## Testing
+
+**Unit (Vitest)**
+
+`sanitize-html.test.ts`:
+- Allowlisted tags pass through
+- Disallowed tags (`script`, `iframe`, `style`, `link`, `meta`, `form`, `input`, `div`, `span`, `table`, `h1`, `h5`, `h6`) stripped (text content kept)
+- `class`, `style`, `id`, `xmlns`, `data-*`, event handlers stripped
+- `<a href="javascript:...">` — href removed
+- `<img onerror=...>` — onerror removed
+- `<a target="_blank">` auto-adds `rel="noopener noreferrer"`
+- Quill paste sample (the actual saved HTML from PR #303 conversation): wrapper divs gone, `xmlns` gone, NBSP runs collapsed
+- Single NBSP preserved
+- Empty input returns empty string
+- Throws-input falls back to empty string (no uncaught throw)
+
+`sanitize-data.test.ts` (extend existing):
+- `walkComponents` invokes HTML sanitizer on `content`, `text`, `quote` props
+- Non-richtext props untouched
+- Nested slot components also processed (recursive walk)
+
+**Integration**
+
+`actions.test.ts` (create if not present): `savePuckPageDraft` with malicious payload → DB row contains sanitized output (mock Supabase client, assert UPDATE payload).
+
+**Manual / E2E**
+- Paste a sample with `<script>alert(1)</script>` into a Puck `RichText` block, save, reload — no alert, no `<script>` in DOM.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| DOMPurify config drift if multiple call sites diverge | Single shared config module (`sanitize-html.ts`); both runtimes import same allowlist |
+| Backfill bug overwrites good data | `--dry-run` default; manual operator review of diff before `--apply` |
+| Allowlist too strict, breaks future legitimate content (e.g., team adds tables to a page) | Allowlist lives in one file; PR to extend is small. Document the location prominently in the file header. |
+| Performance: HTML parse on every save | Save is rare (user action). Acceptable. |
+
+## Acceptance Criteria
+
+- [ ] `isomorphic-dompurify` installed; server-action runtime works
+- [ ] `src/lib/puck/sanitize-html.ts` exports `sanitizeRichTextHtml(input: string): string`
+- [ ] `src/lib/puck/sanitize-data.ts` calls `sanitizeRichTextHtml` on `content`/`text`/`quote` props
+- [ ] `savePuckPageDraft` and `publishPuckPages` route through the sanitizer
+- [ ] Backfill script committed to `scripts/`, documented in playbook
+- [ ] Operator runs backfill with `--dry-run` then `--apply`; logs attached to PR
+- [ ] All unit tests pass (`npm run test`)
+- [ ] `npm run type-check` passes
+- [ ] Manual XSS smoke test passes on preview deploy

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,7 @@ const nextConfig = {
     serverActions: {
       bodySizeLimit: '10mb',
     },
+    serverComponentsExternalPackages: ['isomorphic-dompurify'],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "ai": "^6.0.138",
         "dexie": "^4.4.2",
         "framer-motion": "^12.38.0",
+        "isomorphic-dompurify": "^2.36.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
@@ -87,9 +88,16 @@
         "jsdom": "^29.0.1",
         "postcss": "^8.4.33",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.21.0",
         "typescript": "^5.3.3",
         "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -176,7 +184,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
       "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
@@ -193,7 +200,6 @@
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
       "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -230,7 +236,6 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -272,7 +277,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -285,7 +289,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -305,7 +308,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
       "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -329,7 +331,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
       "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -357,7 +358,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -381,7 +381,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
       "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -406,7 +405,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -575,6 +573,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -642,7 +1082,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -4891,6 +5330,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ai": {
       "version": "6.0.138",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.138.tgz",
@@ -5304,7 +5752,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -5746,7 +6193,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -5775,6 +6221,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5792,7 +6262,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -5877,7 +6346,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -6080,6 +6548,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -6131,7 +6608,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -6322,6 +6798,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -7237,7 +7756,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7543,7 +8062,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -7607,6 +8125,32 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iceberg-js": {
@@ -8060,7 +8604,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -8220,6 +8763,81 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.36.0.tgz",
+      "integrity": "sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "jsdom": "^28.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.5"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -9214,7 +9832,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
@@ -10356,7 +10973,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11450,7 +12066,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11511,7 +12126,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -11707,7 +12322,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -12499,7 +13113,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -12645,7 +13258,6 @@
       "version": "7.0.27",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
       "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.27"
@@ -12658,7 +13270,6 @@
       "version": "7.0.27",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -12677,7 +13288,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -12690,7 +13300,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -12756,6 +13365,27 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -12905,7 +13535,6 @@
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
       "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -13388,7 +14017,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -13401,7 +14029,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -13411,7 +14038,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -13421,7 +14047,6 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -13734,7 +14359,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -13744,7 +14368,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ai": "^6.0.138",
     "dexie": "^4.4.2",
     "framer-motion": "^12.38.0",
+    "isomorphic-dompurify": "^2.36.0",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
@@ -100,6 +101,7 @@
     "jsdom": "^29.0.1",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.21.0",
     "typescript": "^5.3.3",
     "vitest": "^4.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "backfill:puck-sanitize": "tsx scripts/backfill-puck-sanitize.ts",
     "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "test:e2e:smoke": "playwright test --config=e2e/playwright.config.ts --grep @smoke --reporter=line",
     "visual:comment": "bash scripts/visual-comment.sh",

--- a/scripts/backfill-puck-sanitize.ts
+++ b/scripts/backfill-puck-sanitize.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env tsx
+/**
+ * One-time backfill: re-saves every property's puck_pages and puck_pages_draft
+ * (and puck_root / puck_root_draft) through sanitizePuckDataForWrite.
+ *
+ * Usage:
+ *   # dry-run: show what would change, no writes
+ *   npm run backfill:puck-sanitize
+ *
+ *   # apply: actually update rows where content changed
+ *   npm run backfill:puck-sanitize -- --apply
+ *
+ * Requires:
+ *   SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in env (load via vercel env pull
+ *   or .env.local).
+ */
+import { createClient } from '@supabase/supabase-js';
+import { sanitizePuckDataForWrite } from '../src/lib/puck/sanitize-data';
+import type { Data } from '@puckeditor/core';
+
+const APPLY = process.argv.includes('--apply');
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('FATAL: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in env.');
+  console.error('Hint: run `vercel env pull .env.local` then export the vars before running.');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false },
+});
+
+interface Row {
+  id: string;
+  puck_pages: Record<string, unknown> | null;
+  puck_pages_draft: Record<string, unknown> | null;
+  puck_root: Record<string, unknown> | null;
+  puck_root_draft: Record<string, unknown> | null;
+}
+
+function sanitizePagesMap(map: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!map) return null;
+  const out: Record<string, unknown> = {};
+  for (const [path, data] of Object.entries(map)) {
+    out[path] = sanitizePuckDataForWrite(data as Data);
+  }
+  return out;
+}
+
+function sanitizeRoot(data: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!data) return null;
+  return sanitizePuckDataForWrite(data as Data) as unknown as Record<string, unknown>;
+}
+
+async function main() {
+  console.log(APPLY ? 'Mode: APPLY (writes will happen)' : 'Mode: DRY-RUN (no writes)');
+
+  const { data: rows, error } = await supabase
+    .from('properties')
+    .select('id, puck_pages, puck_pages_draft, puck_root, puck_root_draft');
+
+  if (error) {
+    console.error('Failed to read properties:', error.message);
+    process.exit(1);
+  }
+
+  let scanned = 0;
+  let changed = 0;
+  let updated = 0;
+  let errors = 0;
+
+  for (const row of (rows ?? []) as Row[]) {
+    scanned++;
+    const next = {
+      puck_pages: sanitizePagesMap(row.puck_pages),
+      puck_pages_draft: sanitizePagesMap(row.puck_pages_draft),
+      puck_root: sanitizeRoot(row.puck_root),
+      puck_root_draft: sanitizeRoot(row.puck_root_draft),
+    };
+
+    const beforeJson = JSON.stringify({
+      puck_pages: row.puck_pages,
+      puck_pages_draft: row.puck_pages_draft,
+      puck_root: row.puck_root,
+      puck_root_draft: row.puck_root_draft,
+    });
+    const afterJson = JSON.stringify(next);
+
+    if (beforeJson === afterJson) {
+      continue;
+    }
+
+    changed++;
+    console.log(
+      `[${row.id}] would change: ` +
+        `pages=${row.puck_pages ? 'yes' : 'no'} ` +
+        `pagesDraft=${row.puck_pages_draft ? 'yes' : 'no'} ` +
+        `root=${row.puck_root ? 'yes' : 'no'} ` +
+        `rootDraft=${row.puck_root_draft ? 'yes' : 'no'} ` +
+        `(bytes ${beforeJson.length} → ${afterJson.length})`
+    );
+
+    if (!APPLY) continue;
+
+    const { error: updateError } = await supabase
+      .from('properties')
+      .update(next)
+      .eq('id', row.id);
+
+    if (updateError) {
+      errors++;
+      console.error(`[${row.id}] UPDATE failed: ${updateError.message}`);
+    } else {
+      updated++;
+    }
+  }
+
+  console.log('---');
+  console.log(`Scanned:  ${scanned}`);
+  console.log(`Changed:  ${changed}`);
+  console.log(`Updated:  ${updated}`);
+  console.log(`Errors:   ${errors}`);
+  if (!APPLY && changed > 0) {
+    console.log('\nDry run complete. Re-run with `-- --apply` to persist.');
+  }
+  if (errors > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/src/app/admin/site-builder/actions.ts
+++ b/src/app/admin/site-builder/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { invalidateConfig } from '@/lib/config/server';
 import { puckDataSchema } from '@/lib/puck/schemas';
+import { sanitizePuckDataForWrite } from '@/lib/puck/sanitize-data';
 import { validatePageSlug, type PageMeta } from '@/lib/puck/page-utils';
 
 // ---------------------------------------------------------------------------
@@ -82,7 +83,8 @@ export async function savePuckPageDraft(path: string, data: unknown) {
       ? (property.puck_pages_draft as Record<string, unknown>)
       : {};
 
-  const merged = { ...existing, [path]: parseResult.data };
+  const sanitized = sanitizePuckDataForWrite(parseResult.data as Parameters<typeof sanitizePuckDataForWrite>[0]);
+  const merged = { ...existing, [path]: sanitized };
 
   const { error } = await supabase
     .from('properties')
@@ -104,9 +106,10 @@ export async function savePuckRootDraft(data: unknown) {
   if ('error' in result) return result;
 
   const supabase = createClient();
+  const sanitized = sanitizePuckDataForWrite(parseResult.data as Parameters<typeof sanitizePuckDataForWrite>[0]);
   const { error } = await supabase
     .from('properties')
-    .update({ puck_root_draft: parseResult.data as unknown as Record<string, unknown> })
+    .update({ puck_root_draft: sanitized as unknown as Record<string, unknown> })
     .eq('id', result.propertyId);
 
   if (error) return { error: error.message };

--- a/src/app/admin/site-builder/actions.ts
+++ b/src/app/admin/site-builder/actions.ts
@@ -137,9 +137,22 @@ export async function publishPuckPages() {
     return { error: `Failed to read draft: ${readError?.message ?? 'not found'}` };
   }
 
+  // Defense-in-depth: re-sanitize even though draft was sanitized on save.
+  // Idempotent — clean data passes through unchanged.
+  const draft = property.puck_pages_draft as Record<string, unknown> | null;
+  let sanitizedPages: Record<string, unknown> | null = null;
+  if (draft && typeof draft === 'object') {
+    sanitizedPages = {};
+    for (const [pagePath, pageData] of Object.entries(draft)) {
+      sanitizedPages[pagePath] = sanitizePuckDataForWrite(
+        pageData as Parameters<typeof sanitizePuckDataForWrite>[0]
+      );
+    }
+  }
+
   const { error } = await supabase
     .from('properties')
-    .update({ puck_pages: property.puck_pages_draft })
+    .update({ puck_pages: sanitizedPages })
     .eq('id', result.propertyId);
 
   if (error) return { error: error.message };
@@ -164,9 +177,16 @@ export async function publishPuckRoot() {
     return { error: `Failed to read draft: ${readError?.message ?? 'not found'}` };
   }
 
+  // Defense-in-depth: re-sanitize. Idempotent.
+  const sanitizedRoot = property.puck_root_draft
+    ? sanitizePuckDataForWrite(
+        property.puck_root_draft as Parameters<typeof sanitizePuckDataForWrite>[0]
+      )
+    : null;
+
   const { error } = await supabase
     .from('properties')
-    .update({ puck_root: property.puck_root_draft })
+    .update({ puck_root: sanitizedRoot as unknown as Record<string, unknown> | null })
     .eq('id', result.propertyId);
 
   if (error) return { error: error.message };

--- a/src/app/admin/site-builder/actions.ts
+++ b/src/app/admin/site-builder/actions.ts
@@ -471,15 +471,31 @@ export async function applyTemplate(
   const result = await getPropertyId();
   if ('error' in result) return result;
 
+  const sanitizedRoot = sanitizePuckDataForWrite(
+    rootParse.data as Parameters<typeof sanitizePuckDataForWrite>[0]
+  );
+
+  const sanitizedPages: Record<string, unknown> = {};
+  for (const [pagePath, pageData] of Object.entries(pagesData)) {
+    const pageParse = puckDataSchema.safeParse(pageData);
+    if (pageParse.success) {
+      sanitizedPages[pagePath] = sanitizePuckDataForWrite(
+        pageParse.data as Parameters<typeof sanitizePuckDataForWrite>[0]
+      );
+    } else {
+      sanitizedPages[pagePath] = pageData;
+    }
+  }
+
   const supabase = createClient();
   const { error } = await supabase
     .from('properties')
     .update({
       puck_template: templateId,
-      puck_root: rootParse.data as unknown as Record<string, unknown>,
-      puck_root_draft: rootParse.data as unknown as Record<string, unknown>,
-      puck_pages: pagesData as Record<string, unknown>,
-      puck_pages_draft: pagesData as Record<string, unknown>,
+      puck_root: sanitizedRoot as unknown as Record<string, unknown>,
+      puck_root_draft: sanitizedRoot as unknown as Record<string, unknown>,
+      puck_pages: sanitizedPages as Record<string, unknown>,
+      puck_pages_draft: sanitizedPages as Record<string, unknown>,
     })
     .eq('id', result.propertyId);
 

--- a/src/lib/puck/__tests__/sanitize-data.test.ts
+++ b/src/lib/puck/__tests__/sanitize-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizePuckData } from '../sanitize-data';
+import { sanitizePuckData, sanitizePuckDataForWrite } from '../sanitize-data';
 import type { Data } from '@puckeditor/core';
 
 describe('sanitizePuckData', () => {
@@ -152,5 +152,72 @@ describe('sanitizePuckData', () => {
 
     const result = sanitizePuckData(data);
     expect((result.root as any).content[0].props.text).toBeNull();
+  });
+});
+
+describe('sanitizePuckDataForWrite', () => {
+  it('runs HTML sanitization on richtext props', () => {
+    const data = {
+      content: [
+        { type: 'RichText', props: { content: '<p>hi<script>alert(1)</script></p>' } },
+      ],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.content[0] as any).props.content).not.toContain('script');
+    expect((result.content[0] as any).props.content).toContain('hi');
+  });
+
+  it('still nullifies empty richtext strings', () => {
+    const data = {
+      content: [{ type: 'RichText', props: { content: '' } }],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.content[0] as any).props.content).toBeNull();
+  });
+
+  it('walks nested slot components recursively', () => {
+    const data = {
+      content: [
+        {
+          type: 'Container',
+          props: {
+            children: [
+              { type: 'Card', props: { text: '<div>x</div><span>y</span>' } },
+            ],
+          },
+        },
+      ],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    const inner = (result.content[0] as any).props.children[0].props.text;
+    expect(inner).toBe('xy');
+  });
+
+  it('leaves non-richtext props untouched', () => {
+    const data = {
+      content: [
+        { type: 'Custom', props: { customProp: '<p>html</p>', alt: 'pic' } },
+      ],
+      root: {},
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect((result.content[0] as any).props.customProp).toBe('<p>html</p>');
+    expect((result.content[0] as any).props.alt).toBe('pic');
+  });
+
+  it('processes root.content blocks', () => {
+    const data = {
+      content: [],
+      root: {
+        content: [
+          { type: 'Card', props: { quote: '<p onclick="x">q</p>' } },
+        ],
+      },
+    };
+    const result = sanitizePuckDataForWrite(data as any);
+    expect(((result.root as any).content[0] as any).props.quote).not.toContain('onclick');
   });
 });

--- a/src/lib/puck/__tests__/sanitize-html.test.ts
+++ b/src/lib/puck/__tests__/sanitize-html.test.ts
@@ -78,4 +78,24 @@ describe('sanitizeRichTextHtml', () => {
   it('returns empty string for empty input', () => {
     expect(sanitizeRichTextHtml('')).toBe('');
   });
+
+  it('returns literal U+00A0 (not entity) in output', () => {
+    const result = sanitizeRichTextHtml(`<p>10${NBSP}km</p>`);
+    expect(result).toContain(NBSP);           // literal NBSP present
+    expect(result).not.toContain('&nbsp;');   // no entity reference
+  });
+
+  it('is idempotent — sanitize(sanitize(x)) === sanitize(x)', () => {
+    const inputs = [
+      '<p>hi</p>',
+      `<p>a${NBSP}${NBSP}b</p>`,
+      '<a href="https://example.com" target="_blank">x</a>',
+      '<div>x<script>y</script></div>',
+      '',
+    ];
+    for (const input of inputs) {
+      const once = sanitizeRichTextHtml(input);
+      expect(sanitizeRichTextHtml(once)).toBe(once);
+    }
+  });
 });

--- a/src/lib/puck/__tests__/sanitize-html.test.ts
+++ b/src/lib/puck/__tests__/sanitize-html.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeRichTextHtml } from '../sanitize-html';
+
+const NBSP = ' ';
+
+describe('sanitizeRichTextHtml', () => {
+  it('passes allowlisted tags through', () => {
+    expect(sanitizeRichTextHtml('<p>hi</p>')).toBe('<p>hi</p>');
+    expect(sanitizeRichTextHtml('<strong>bold</strong>')).toBe('<strong>bold</strong>');
+    expect(sanitizeRichTextHtml('<h2>title</h2>')).toBe('<h2>title</h2>');
+  });
+
+  it('strips disallowed tags but keeps text content', () => {
+    expect(sanitizeRichTextHtml('<div>hi</div>')).toBe('hi');
+    expect(sanitizeRichTextHtml('<span>x</span>')).toBe('x');
+    expect(sanitizeRichTextHtml('<h1>x</h1>')).toBe('x');
+    expect(sanitizeRichTextHtml('<h5>x</h5>')).toBe('x');
+    expect(sanitizeRichTextHtml('<table><tr><td>x</td></tr></table>')).toBe('x');
+  });
+
+  it('strips script tags and event handlers', () => {
+    const result = sanitizeRichTextHtml('<p onclick="alert(1)">x</p><script>alert(1)</script>');
+    expect(result).not.toContain('onclick');
+    expect(result).not.toContain('script');
+    expect(result).toContain('x');
+  });
+
+  it('strips class, style, id, xmlns, data-* attributes', () => {
+    const input = '<p class="x" style="color:red" id="y" xmlns="ns" data-foo="bar">hi</p>';
+    expect(sanitizeRichTextHtml(input)).toBe('<p>hi</p>');
+  });
+
+  it('removes javascript: and data: URLs from href', () => {
+    expect(sanitizeRichTextHtml('<a href="javascript:alert(1)">x</a>')).not.toContain('javascript:');
+    expect(sanitizeRichTextHtml('<a href="data:text/html,foo">x</a>')).not.toContain('data:');
+  });
+
+  it('preserves http/https/mailto/relative href', () => {
+    expect(sanitizeRichTextHtml('<a href="https://example.com">x</a>')).toContain('href="https://example.com"');
+    expect(sanitizeRichTextHtml('<a href="/path">x</a>')).toContain('href="/path"');
+    expect(sanitizeRichTextHtml('<a href="mailto:a@b.com">x</a>')).toContain('href="mailto:a@b.com"');
+  });
+
+  it('auto-adds rel="noopener noreferrer" when target=_blank', () => {
+    const result = sanitizeRichTextHtml('<a href="https://example.com" target="_blank">x</a>');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it('strips img event handlers but keeps allowlisted attrs', () => {
+    const result = sanitizeRichTextHtml('<img src="/x.jpg" alt="x" onerror="alert(1)" width="10">');
+    expect(result).not.toContain('onerror');
+    expect(result).toContain('src="/x.jpg"');
+    expect(result).toContain('alt="x"');
+    expect(result).toContain('width="10"');
+  });
+
+  it('collapses runs of 2+ NBSP/spaces to single ASCII space', () => {
+    expect(sanitizeRichTextHtml(`<p>a${NBSP}${NBSP}b</p>`)).toBe('<p>a b</p>');
+    expect(sanitizeRichTextHtml(`<p>a  b</p>`)).toBe('<p>a b</p>');
+    expect(sanitizeRichTextHtml(`<p>a${NBSP} ${NBSP}b</p>`)).toBe('<p>a b</p>');
+  });
+
+  it('preserves isolated NBSP', () => {
+    expect(sanitizeRichTextHtml(`<p>10${NBSP}km</p>`)).toBe(`<p>10${NBSP}km</p>`);
+    expect(sanitizeRichTextHtml(`<p>Mr.${NBSP}Smith</p>`)).toBe(`<p>Mr.${NBSP}Smith</p>`);
+  });
+
+  it('removes Quill paste artifacts (wrapper divs + xmlns) and preserves single NBSPs', () => {
+    const quillSample = `<div class="_RichTextEditor_z25h4_1"><div class="rich-text"><p xmlns="http://www.w3.org/1999/xhtml">Eagle${NBSP}Scout${NBSP}Fairbanks</p></div></div>`;
+    const result = sanitizeRichTextHtml(quillSample);
+    expect(result).not.toContain('_RichTextEditor');
+    expect(result).not.toContain('rich-text');
+    expect(result).not.toContain('xmlns');
+    expect(result).toContain(`Eagle${NBSP}Scout${NBSP}Fairbanks`);
+    expect(result.startsWith('<p>')).toBe(true);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(sanitizeRichTextHtml('')).toBe('');
+  });
+});

--- a/src/lib/puck/sanitize-data.ts
+++ b/src/lib/puck/sanitize-data.ts
@@ -1,4 +1,5 @@
 import type { Data } from '@puckeditor/core';
+import { sanitizeRichTextHtml } from './sanitize-html';
 
 /**
  * Prop names that are richtext fields in Puck component configs.
@@ -8,52 +9,76 @@ import type { Data } from '@puckeditor/core';
  */
 const RICHTEXT_PROP_NAMES = ['content', 'text', 'quote'];
 
-/**
- * Sanitize Puck data to prevent ProseMirror "Empty text nodes" crash.
- *
- * Root cause: Puck's RichTextRender converts empty string "" to
- * { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "" }] }] }
- * which crashes ProseMirror's Node.fromJSON. Setting empty richtext to null
- * makes Puck use { type: "doc", content: [] } instead (safe).
- */
-export function sanitizePuckData(data: Data): Data {
-  const clone = JSON.parse(JSON.stringify(data));
+type Component = { type: string; props: Record<string, unknown> };
 
-  function walkComponents(
-    components: Array<{ type: string; props: Record<string, unknown> }>
-  ) {
+/**
+ * Walk every Puck component in the data tree and call `fn` for each
+ * richtext-typed prop. The callback's return value replaces the prop value.
+ */
+function walkRichTextProps(
+  data: Data,
+  fn: (key: string, value: unknown) => unknown
+): void {
+  function walkComponents(components: Component[]) {
     for (const component of components) {
       if (!component.props) continue;
-      // Nullify empty richtext strings to prevent ProseMirror crash
-      for (let i = 0; i < RICHTEXT_PROP_NAMES.length; i++) {
-        const key = RICHTEXT_PROP_NAMES[i];
-        if (component.props[key] === '') {
-          component.props[key] = null;
+      for (const key of RICHTEXT_PROP_NAMES) {
+        if (key in component.props) {
+          component.props[key] = fn(key, component.props[key]);
         }
       }
       // Recursively walk slot content (arrays of components in props)
       for (const value of Object.values(component.props)) {
-        if (Array.isArray(value) && value.length > 0 && value[0]?.type && value[0]?.props) {
-          walkComponents(value);
+        if (
+          Array.isArray(value) &&
+          value.length > 0 &&
+          (value[0] as Component | undefined)?.type &&
+          (value[0] as Component | undefined)?.props
+        ) {
+          walkComponents(value as Component[]);
         }
       }
     }
   }
 
-  if (clone.content) {
-    walkComponents(clone.content);
-  }
-
-  if (clone.zones) {
-    for (const zone of Object.values(clone.zones)) {
-      walkComponents(zone as Array<{ type: string; props: Record<string, unknown> }>);
+  if (data.content) walkComponents(data.content as Component[]);
+  if (data.zones) {
+    for (const zone of Object.values(data.zones)) {
+      walkComponents(zone as Component[]);
     }
   }
-
-  // Chrome root content also has components with richtext
-  if (clone.root?.content) {
-    walkComponents(clone.root.content);
+  if ((data.root as any)?.content) {
+    walkComponents((data.root as any).content as Component[]);
   }
+}
 
+/**
+ * Sanitize Puck data on **load** to prevent ProseMirror "Empty text nodes"
+ * crash. Puck's RichTextRender converts empty string "" to a doc with a
+ * zero-length text node which crashes ProseMirror's Node.fromJSON. Setting
+ * empty richtext to null makes Puck use { type: "doc", content: [] }
+ * instead (safe).
+ */
+export function sanitizePuckData(data: Data): Data {
+  const clone = JSON.parse(JSON.stringify(data)) as Data;
+  walkRichTextProps(clone, (_key, value) => (value === '' ? null : value));
+  return clone;
+}
+
+/**
+ * Sanitize Puck data on **write**. Performs everything sanitizePuckData does
+ * and additionally runs every non-empty richtext string through
+ * sanitizeRichTextHtml — strips disallowed tags/attributes, normalizes NBSP
+ * runs, blocks javascript:/data: URIs.
+ *
+ * Call from server actions before persisting to Supabase.
+ */
+export function sanitizePuckDataForWrite(data: Data): Data {
+  const clone = JSON.parse(JSON.stringify(data)) as Data;
+  walkRichTextProps(clone, (_key, value) => {
+    if (value === '') return null;
+    if (typeof value === 'string') return sanitizeRichTextHtml(value);
+    return value;
+  });
   return clone;
 }

--- a/src/lib/puck/sanitize-data.ts
+++ b/src/lib/puck/sanitize-data.ts
@@ -47,8 +47,9 @@ function walkRichTextProps(
       walkComponents(zone as Component[]);
     }
   }
-  if ((data.root as any)?.content) {
-    walkComponents((data.root as any).content as Component[]);
+  const rootContent = (data.root as { content?: Component[] } | undefined)?.content;
+  if (rootContent) {
+    walkComponents(rootContent);
   }
 }
 

--- a/src/lib/puck/sanitize-html.ts
+++ b/src/lib/puck/sanitize-html.ts
@@ -34,18 +34,14 @@ const ALLOWED_ATTR = ['href', 'target', 'rel', 'src', 'alt', 'width', 'height'];
 // DOMPurify defaults reject javascript:, data:, vbscript: in URI attributes.
 // We rely on those defaults rather than overriding ALLOWED_URI_REGEXP.
 
+// NOTE: addHook mutates the global isomorphic-dompurify singleton. If any other
+// caller in this codebase ever imports and uses isomorphic-dompurify, this hook
+// will run on their sanitize() calls too. Today this is the only call site.
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   // Auto-add rel for target=_blank links.
   if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
     node.setAttribute('rel', 'noopener noreferrer');
   }
-  // Strip any data-* attributes that DOMPurify lets through by default.
-  const toRemove: string[] = [];
-  for (let i = 0; i < node.attributes.length; i++) {
-    const attr = node.attributes[i];
-    if (attr.name.startsWith('data-')) toRemove.push(attr.name);
-  }
-  toRemove.forEach((name) => node.removeAttribute(name));
 });
 
 /**
@@ -63,9 +59,11 @@ export function sanitizeRichTextHtml(input: string): string {
     const sanitized = DOMPurify.sanitize(input, {
       ALLOWED_TAGS,
       ALLOWED_ATTR,
+      ALLOW_DATA_ATTR: false,
     });
-    // DOMPurify (via jsdom) encodes U+00A0 as &nbsp; — decode it back so
-    // callers receive the literal character, and NBSP normalization works.
+    // jsdom (the DOM impl isomorphic-dompurify uses on the server) serializes U+00A0
+    // as &nbsp;. Decode back to the literal character so callers and the NBSP-run
+    // regex below operate on real characters, not entity strings.
     const decoded = sanitized.replace(/&nbsp;/g, ' ');
     return normalizeNbsp(decoded);
   } catch {

--- a/src/lib/puck/sanitize-html.ts
+++ b/src/lib/puck/sanitize-html.ts
@@ -1,0 +1,81 @@
+/**
+ * HTML sanitization for Puck richtext field content.
+ *
+ * Allowlist lives in this file. To extend (e.g. permit tables in Puck pages),
+ * add the tag to ALLOWED_TAGS and any new attributes to ALLOWED_ATTR.
+ *
+ * Called from sanitizePuckDataForWrite (sanitize-data.ts) on every save.
+ */
+import DOMPurify from 'isomorphic-dompurify';
+
+const ALLOWED_TAGS = [
+  'p',
+  'a',
+  'strong',
+  'em',
+  'u',
+  's',
+  'code',
+  'pre',
+  'blockquote',
+  'ul',
+  'ol',
+  'li',
+  'h2',
+  'h3',
+  'h4',
+  'br',
+  'hr',
+  'img',
+];
+
+const ALLOWED_ATTR = ['href', 'target', 'rel', 'src', 'alt', 'width', 'height'];
+
+// DOMPurify defaults reject javascript:, data:, vbscript: in URI attributes.
+// We rely on those defaults rather than overriding ALLOWED_URI_REGEXP.
+
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  // Auto-add rel for target=_blank links.
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+  // Strip any data-* attributes that DOMPurify lets through by default.
+  const toRemove: string[] = [];
+  for (let i = 0; i < node.attributes.length; i++) {
+    const attr = node.attributes[i];
+    if (attr.name.startsWith('data-')) toRemove.push(attr.name);
+  }
+  toRemove.forEach((name) => node.removeAttribute(name));
+});
+
+/**
+ * Sanitize a single richtext HTML string.
+ *
+ * Strips all tags not on the allowlist (text content kept), drops all
+ * attributes not on the allowlist, removes javascript:/data: URI schemes,
+ * auto-adds rel="noopener noreferrer" to target=_blank links, and collapses
+ * runs of 2+ NBSP/space characters to a single ASCII space (isolated NBSPs
+ * preserved).
+ */
+export function sanitizeRichTextHtml(input: string): string {
+  if (!input) return '';
+  try {
+    const sanitized = DOMPurify.sanitize(input, {
+      ALLOWED_TAGS,
+      ALLOWED_ATTR,
+    });
+    // DOMPurify (via jsdom) encodes U+00A0 as &nbsp; — decode it back so
+    // callers receive the literal character, and NBSP normalization works.
+    const decoded = sanitized.replace(/&nbsp;/g, ' ');
+    return normalizeNbsp(decoded);
+  } catch {
+    return '';
+  }
+}
+
+// Match runs of 2+ of: U+0020 (ASCII space) or U+00A0 (NBSP), in any mix.
+const NBSP_RUN_REGEX = /[  ]{2,}/g;
+
+function normalizeNbsp(html: string): string {
+  return html.replace(NBSP_RUN_REGEX, ' ');
+}


### PR DESCRIPTION
## Summary
Server-side DOMPurify allowlist + NBSP normalization on every save to `properties.puck_pages`, `puck_pages_draft`, `puck_root`, `puck_root_draft`. One-time backfill script committed for cleaning existing rows.

Closes #304. Companion to PR #303 (Tier 1 CSS workaround). Both layers stay in place — Tier 1 prevents visible breakage, Tier 2 keeps the data clean.

## Changes
- **New:** `src/lib/puck/sanitize-html.ts` — DOMPurify wrapper, strict allowlist (`p, a, strong, em, u, s, code, pre, blockquote, ul, ol, li, h2, h3, h4, br, hr, img`), `ALLOW_DATA_ATTR: false`, `rel="noopener noreferrer"` auto-add for `target=_blank`, NBSP run collapsing (isolated NBSP preserved)
- **Modified:** `src/lib/puck/sanitize-data.ts` — extracted shared walker, added `sanitizePuckDataForWrite` for write-side use
- **Modified:** `src/app/admin/site-builder/actions.ts` — `savePuckPageDraft`, `savePuckRootDraft`, `publishPuckPages`, `publishPuckRoot`, **and `applyTemplate`** all route through the sanitizer
- **New:** `scripts/backfill-puck-sanitize.ts` + `npm run backfill:puck-sanitize` — one-time backfill, defaults to `--dry-run`, idempotent
- **New:** `docs/playbooks/puck-html-sanitize.md` — operator runbook (backfill, allowlist extensions, emergency disable)
- **Spec:** `docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-02-puck-html-sanitize.md`

## Verification
- `npm run type-check` — clean
- `npm run test` — 1444 passed across 200 files (16 new)
- Code review (superpowers:code-reviewer) — addressed all Important + Minor findings in commit `47c575d`

## Manual test plan (deferred to operator)
- [ ] Paste `<script>alert('xss-test')</script>` and other malicious payloads into a Puck `RichText` block on the preview deploy → no alert, no `<script>` in DOM
- [ ] Run backfill against prod: `vercel env pull .env.local && set -a; . .env.local; set +a && npm run backfill:puck-sanitize` (dry-run) then `npm run backfill:puck-sanitize -- --apply`
- [ ] Attach backfill output to PR

## Commits
- `3315be0` chore: add isomorphic-dompurify and tsx
- `13c378e` feat(puck): sanitizeRichTextHtml — DOMPurify allowlist + nbsp normalization
- `22aa8ab` feat(puck): sanitizePuckDataForWrite walks tree and HTML-sanitizes richtext props
- `2ca5f5e` feat(puck): sanitize HTML before saving puck_pages_draft and puck_root_draft
- `61316d0` feat(puck): defense-in-depth re-sanitize on publish
- `466e4ce` feat(puck): backfill script + operator playbook
- `47c575d` fix(puck): address review feedback (applyTemplate gap, ALLOW_DATA_ATTR, idempotency test, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)