### PR TITLE
fix(pwa): kill blue halo on installed icons + dynamic favicon/apple-touch-icon (#314)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-pwa-logo-artifacts.md
+++ b/docs/superpowers/plans/2026-05-03-pwa-logo-artifacts.md
@@ -1,0 +1,342 @@
+# PWA Logo Artifacts Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the blue halo around installed PWA icons (#314) by switching the maskable safe-zone padding from opaque blue to white, replacing `fit: 'cover'` with `fit: 'contain'` (white background) so non-square logos aren't cropped, and adding a per-org `apple-touch-icon-180.png` variant plus dynamic favicon so iOS uses the org logo.
+
+**Architecture:** All icon variants are generated server-side by `sharp` in `src/app/admin/settings/logo-actions.ts` and uploaded to the Supabase `vault-public` bucket. URLs are resolved via `getLogoUrlServer()` in `src/lib/config/logo-server.ts`, which falls back to static defaults under `/defaults/logos/` when an org has no uploaded logo. The PWA manifest at `src/app/api/manifest.json/route.ts` references variant filenames; only the bytes change. `src/app/layout.tsx` renders the icon `<link>` tags.
+
+**Tech Stack:** Next.js 14, sharp (image processing), Supabase Storage, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-pwa-logo-artifacts-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/lib/config/logo-server.ts` — add `'apple-touch-icon-180.png'` to `LogoVariant` union and `DEFAULT_ICONS` map.
+- **Modify** `src/lib/config/__tests__/logo-server.test.ts` — assert the new variant's default fallback and storage URL.
+- **Modify** `src/app/admin/settings/logo-actions.ts` — change all `fit: 'cover'` → `fit: 'contain'` with white background, change maskable padding from blue to white, add new `apple-touch-icon-180.png` variant.
+- **Modify** `src/app/layout.tsx` — switch hard-coded favicon `<link>` to dynamic per-org URL, add `<link rel="apple-touch-icon">`.
+
+---
+
+### Task 1: Extend `LogoVariant` type and default map
+
+**Files:**
+- Modify: `src/lib/config/logo-server.ts`
+- Test: `src/lib/config/__tests__/logo-server.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Edit `src/lib/config/__tests__/logo-server.test.ts`. Inside the `it('returns variant-specific default when basePath is null', ...)` block, add an assertion for the new variant. Then add a new `it` block for the storage URL case.
+
+```ts
+  it('returns variant-specific default when basePath is null', () => {
+    expect(getLogoUrlServer(null, 'icon-192.png')).toBe('/defaults/logos/icon-192.png');
+    expect(getLogoUrlServer(null, 'icon-512.png')).toBe('/defaults/logos/icon-512.png');
+    expect(getLogoUrlServer(null, 'icon-512-maskable.png')).toBe('/defaults/logos/icon-512-maskable.png');
+    expect(getLogoUrlServer(null, 'favicon-32.png')).toBe('/defaults/logos/favicon-32.png');
+    expect(getLogoUrlServer(null, 'apple-touch-icon-180.png')).toBe('/defaults/logos/icon-192.png');
+    expect(getLogoUrlServer(null, 'original.png')).toBe('/defaults/logos/fieldmapper.png');
+  });
+
+  it('builds storage URL for apple-touch-icon-180 variant', () => {
+    const url = getLogoUrlServer('org-123', 'apple-touch-icon-180.png');
+    expect(url).toBe('https://storage.test/vault-public/org-123/apple-touch-icon-180.png');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/lib/config/__tests__/logo-server.test.ts --run`
+Expected: TypeScript error in the test file: `Argument of type '"apple-touch-icon-180.png"' is not assignable to parameter of type 'LogoVariant'`. (Vitest will report a transform/type failure.)
+
+- [ ] **Step 3: Add the variant to the type and defaults**
+
+Edit `src/lib/config/logo-server.ts`. Replace the `LogoVariant` type and the `DEFAULT_ICONS` map:
+
+```ts
+export type LogoVariant =
+  | 'original.png'
+  | 'icon-192.png'
+  | 'icon-512.png'
+  | 'icon-512-maskable.png'
+  | 'favicon-32.png'
+  | 'apple-touch-icon-180.png';
+
+const DEFAULT_ICONS: Record<string, string> = {
+  'icon-192.png': '/defaults/logos/icon-192.png',
+  'icon-512.png': '/defaults/logos/icon-512.png',
+  'icon-512-maskable.png': '/defaults/logos/icon-512-maskable.png',
+  'favicon-32.png': '/defaults/logos/favicon-32.png',
+  'apple-touch-icon-180.png': '/defaults/logos/icon-192.png',
+  'original.png': '/defaults/logos/fieldmapper.png',
+};
+```
+
+Note: the `apple-touch-icon-180.png` default deliberately points at the existing `icon-192.png` static asset to avoid shipping a new file. iOS will downscale 192→180 cleanly, and this default only applies to orgs that have not uploaded a logo.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- src/lib/config/__tests__/logo-server.test.ts --run`
+Expected: PASS, all assertions green.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run type-check`
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/config/logo-server.ts src/lib/config/__tests__/logo-server.test.ts
+git commit -m "feat(logo): add apple-touch-icon-180 variant to LogoVariant type"
+```
+
+---
+
+### Task 2: Switch icon generation to white background + `fit: 'contain'`
+
+**Files:**
+- Modify: `src/app/admin/settings/logo-actions.ts:36-62`
+
+This task changes the bytes of every generated variant. There are no automated tests for binary image output (consistent with existing code), so verification is by code review and the manual PWA install in Task 4.
+
+- [ ] **Step 1: Replace the variant-generation block**
+
+Open `src/app/admin/settings/logo-actions.ts`. Replace lines 36-62 (the comment `// Generate variants` through the final `variants.push({ name: 'favicon-32.png', buffer: favicon });` line) with:
+
+```ts
+  // Generate variants
+  const variants: { name: string; buffer: Buffer }[] = [];
+
+  // Solid white background applied to every square variant so non-square
+  // logos render letterboxed (not cropped) and platform masks (Android
+  // adaptive icons, iOS rounded-rect) don't expose colored padding.
+  const white = { r: 255, g: 255, b: 255, alpha: 1 } as const;
+
+  // Original (max 1024px, preserve aspect ratio, no background fill)
+  const original = await sharp(buffer)
+    .resize(1024, 1024, { fit: 'inside', withoutEnlargement: true })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'original.png', buffer: original });
+
+  // PWA icons (square, contain on white so non-square logos aren't cropped)
+  const icon192 = await sharp(buffer)
+    .resize(192, 192, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'icon-192.png', buffer: icon192 });
+
+  const icon512 = await sharp(buffer)
+    .resize(512, 512, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'icon-512.png', buffer: icon512 });
+
+  // Maskable icon: 80% inner safe zone, 10% padding on each side, white fill
+  const maskableInner = Math.floor(512 * 0.8);
+  const padding = Math.floor((512 - maskableInner) / 2);
+  const maskable = await sharp(buffer)
+    .resize(maskableInner, maskableInner, { fit: 'contain', background: white })
+    .extend({ top: padding, bottom: padding, left: padding, right: padding, background: white })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'icon-512-maskable.png', buffer: maskable });
+
+  // Apple touch icon (180x180 retina, white background — iOS does not honor
+  // PNG transparency on home-screen icons)
+  const appleTouch = await sharp(buffer)
+    .resize(180, 180, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'apple-touch-icon-180.png', buffer: appleTouch });
+
+  // Favicon
+  const favicon = await sharp(buffer)
+    .resize(32, 32, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'favicon-32.png', buffer: favicon });
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run type-check`
+Expected: No errors.
+
+- [ ] **Step 3: Run the existing test suite**
+
+Run: `npm run test -- --run`
+Expected: All tests pass (the `logo-actions.ts` change has no unit tests; only verifying nothing else broke).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/settings/logo-actions.ts
+git commit -m "fix(logo): white background + fit:contain for PWA icons (#314)"
+```
+
+---
+
+### Task 3: Wire favicon and apple-touch-icon to org logo in `layout.tsx`
+
+**Files:**
+- Modify: `src/app/layout.tsx:1-13` (imports), `src/app/layout.tsx:67-76` (head block)
+
+- [ ] **Step 1: Add the import**
+
+Open `src/app/layout.tsx`. The file currently has these imports near the top:
+
+```ts
+import '@/styles/globals.css';
+import Navigation from '@/components/layout/Navigation';
+import { PuckRootRenderer } from '@/components/puck/PuckRootRenderer';
+import { ConfigProvider } from '@/lib/config/client';
+import { getConfig } from '@/lib/config/server';
+import { resolveTheme, themeToCssVars } from '@/lib/config/themes';
+```
+
+Add `getLogoUrlServer` next to the existing `@/lib/config/server` import. Replace:
+
+```ts
+import { getConfig } from '@/lib/config/server';
+```
+
+with:
+
+```ts
+import { getConfig } from '@/lib/config/server';
+import { getLogoUrlServer } from '@/lib/config/logo-server';
+```
+
+- [ ] **Step 2: Replace the static favicon link and add the apple-touch-icon link**
+
+Find the head block (around line 67-76):
+
+```tsx
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: `:root { ${cssVars} }` }} />
+        <link rel="manifest" href="/api/manifest.json" />
+        <link rel="preconnect" href="https://basemaps.cartocdn.com" crossOrigin="anonymous" />
+        <meta name="theme-color" content="#2563eb" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/defaults/logos/favicon-32.png" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+      </head>
+```
+
+Replace it with:
+
+```tsx
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: `:root { ${cssVars} }` }} />
+        <link rel="manifest" href="/api/manifest.json" />
+        <link rel="preconnect" href="https://basemaps.cartocdn.com" crossOrigin="anonymous" />
+        <meta name="theme-color" content="#2563eb" />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href={getLogoUrlServer(config.logoUrl, 'favicon-32.png')}
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href={getLogoUrlServer(config.logoUrl, 'apple-touch-icon-180.png')}
+        />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+      </head>
+```
+
+The `config` variable is already in scope on line 53 (`const config = await getConfig();`). `getLogoUrlServer` returns the static default when `config.logoUrl` is null, preserving zero-config behavior.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run type-check`
+Expected: No errors.
+
+- [ ] **Step 4: Build to confirm SSR resolves the URLs**
+
+Run: `npm run build`
+Expected: Build succeeds. (No need to start the server here — Task 4 covers manual verification.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/layout.tsx
+git commit -m "feat(layout): dynamic favicon + apple-touch-icon per org (#314)"
+```
+
+---
+
+### Task 4: Manual verification + visual diff screenshots
+
+This task produces the artifacts required for the PR description per `docs/playbooks/visual-diff-screenshots.md`.
+
+**Files:** none modified — verification + screenshots only.
+
+- [ ] **Step 1: Start dev server**
+
+Run: `npm run dev`
+Expected: Server up on localhost.
+
+- [ ] **Step 2: Upload a non-square test logo**
+
+In a browser, log in as an org admin, navigate to admin settings → logo, upload a deliberately non-square logo (e.g., a wide horizontal logo PNG). Confirm the upload succeeds.
+
+- [ ] **Step 3: Inspect generated variants**
+
+In Supabase Studio (or via the storage explorer), open `vault-public/{orgId}/`. Confirm all six files exist:
+- `original.png`
+- `icon-192.png`
+- `icon-512.png`
+- `icon-512-maskable.png`
+- `apple-touch-icon-180.png`
+- `favicon-32.png`
+
+Open each variant. Confirm:
+- The non-square logo is fully visible (letterboxed on white), not cropped.
+- The maskable icon's padding is white, not blue.
+
+- [ ] **Step 4: Verify manifest references**
+
+Open `http://localhost:3000/api/manifest.json` in a browser. Confirm the `icons[]` URLs resolve to the new files (open each in a new tab — they should render correctly).
+
+- [ ] **Step 5: Install PWA on Android**
+
+Use Chrome on a real Android device (or an emulator) to install the site as a PWA. Confirm the home-screen icon shows no blue halo.
+
+Capture a screenshot. Save to a temp location for the PR description.
+
+- [ ] **Step 6: Install on iOS**
+
+Use Safari on iOS to "Add to Home Screen". Confirm the home-screen icon shows the org logo (not the default `fieldmapper.png` or generic).
+
+Capture a screenshot.
+
+- [ ] **Step 7: Capture before/after**
+
+Per `docs/playbooks/visual-diff-screenshots.md`, save before/after screenshots into the location the playbook specifies and reference them in the PR description.
+
+No commit for this task — verification only.
+
+---
+
+## Self-Review
+
+Spec coverage:
+- Spec §1 maskable padding → Task 2 ✓
+- Spec §1 fit cover → contain → Task 2 ✓
+- Spec §1 new apple-touch-icon-180 variant → Task 2 ✓
+- Spec §2 LogoVariant type + DEFAULT_ICONS → Task 1 ✓
+- Spec §3 logo-server tests → Task 1 ✓
+- Spec §4 layout.tsx apple-touch-icon link → Task 3 ✓
+- Spec §4 dynamic favicon href → Task 3 ✓
+- Spec §5 no manifest changes → not needed ✓
+- Verification (manual + visual diff) → Task 4 ✓
+
+No placeholders. Variant names consistent across tasks (`apple-touch-icon-180.png` everywhere). White color literal `{ r:255, g:255, b:255, alpha:1 }` used consistently.

--- a/docs/superpowers/specs/2026-05-03-pwa-logo-artifacts-design.md
+++ b/docs/superpowers/specs/2026-05-03-pwa-logo-artifacts-design.md
@@ -1,0 +1,102 @@
+# PWA Logo Artifacts Fix
+
+**Issue:** [#314](https://github.com/patjackson52/birdhouse-mapper/issues/314)
+**Followup wish:** [#315](https://github.com/patjackson52/birdhouse-mapper/issues/315) — per-org configurable PWA icon background color
+**Date:** 2026-05-03
+
+## Problem
+
+When an admin uploads an org logo and the user installs the site as a PWA, the home-screen icon renders with a blue ring/halo around the logo on Android (see screenshot in #314).
+
+## Root cause
+
+`src/app/admin/settings/logo-actions.ts:50-58` generates the maskable icon variant with a 20% safe-zone padding filled with **opaque blue `#2563eb`**:
+
+```ts
+.extend({ top: padding, bottom: padding, left: padding, right: padding,
+          background: { r: 37, g: 99, b: 235, alpha: 1 } })
+```
+
+Android's adaptive-icon system applies a circular (or other) mask to maskable PNGs and exposes the safe-zone padding around the logo. Because the padding is filled with brand-blue rather than the manifest's white `background_color`, every installed PWA icon shows a blue halo regardless of the org's actual logo or branding.
+
+Two adjacent quality issues are also fixed in this PR:
+
+1. **`fit: 'cover'`** on `icon-192`, `icon-512`, `icon-512-maskable` (inner), and `favicon-32` crops non-square logos to a square. Wide or tall logos get edges chopped.
+2. **No `apple-touch-icon`** declared in `app/layout.tsx` — iOS home-screen install falls back to the default `/defaults/logos/favicon-32.png`, ignoring the org's logo entirely.
+
+## Goals
+
+- Maskable icon renders cleanly on Android with no colored halo.
+- Non-square logos render fully (letterboxed on white) instead of cropped.
+- iOS home-screen install uses the org's logo.
+
+## Non-goals
+
+- Per-org configurable `theme_color` / `background_color` / icon padding color → tracked in #315.
+- Backfilling existing org icons. The single property in production will re-upload its logo after deploy.
+- Refactoring `theme_color: '#2563eb'` in `manifest.json/route.ts` and `<meta name="theme-color">` in `layout.tsx` → covered by #315.
+- Automated tests of binary image output. Verification is manual (install PWA, inspect storage).
+
+## Changes
+
+### 1. `src/app/admin/settings/logo-actions.ts`
+
+Switch all variant backgrounds to white and all `fit` modes to `contain` so the full logo is visible inside each icon.
+
+- `icon-192`: `fit: 'cover'` → `fit: 'contain'` with `background: { r:255, g:255, b:255, alpha:1 }`
+- `icon-512`: same treatment
+- `icon-512-maskable`:
+  - Inner resize: `fit: 'cover'` → `fit: 'contain'` with white background
+  - `extend` padding: blue `#2563eb` → white `#ffffff`
+- `favicon-32`: `fit: 'cover'` → `fit: 'contain'` with white background
+- **New variant** `apple-touch-icon-180.png`: 180×180, `fit: 'contain'`, white background. Apple recommends 180×180 for retina home-screen icons; iOS will not render transparency, so the white background is required for a clean rounded-rect render.
+
+The `original.png` variant (line 40) is unchanged — already uses `fit: 'inside'` with no background fill.
+
+### 2. `src/lib/config/logo-server.ts`
+
+Extend the `LogoVariant` union with `'apple-touch-icon-180.png'` and add a default fallback entry to `DEFAULT_ICONS`. To avoid shipping a new static asset, the default for `apple-touch-icon-180.png` points at the existing `/defaults/logos/icon-192.png` — iOS will downscale 192→180 cleanly, and this fallback only applies to orgs that have not uploaded a logo.
+
+### 3. `src/lib/config/__tests__/logo-server.test.ts`
+
+Add an assertion that `getLogoUrlServer(null, 'apple-touch-icon-180.png')` returns the `/defaults/logos/icon-192.png` fallback, plus a positive case asserting the variant builds a storage URL when `basePath` is set.
+
+### 4. `src/app/layout.tsx`
+
+In the non-platform branch (`<head>` block, lines 67-76):
+
+- Add `<link rel="apple-touch-icon" sizes="180x180" href={getLogoUrlServer(config.logoUrl, 'apple-touch-icon-180.png')} />`
+- Switch the existing favicon `href` from the hard-coded `/defaults/logos/favicon-32.png` to `getLogoUrlServer(config.logoUrl, 'favicon-32.png')` so desktop browsers and iOS Safari also pick up the org's logo. (The org's `favicon-32.png` is already generated on every upload.)
+
+`getLogoUrlServer` already falls back to the default logo path when an org has no uploaded logo, so the existing zero-config behavior is preserved for orgs that haven't customized branding.
+
+### 5. No changes to `manifest.json/route.ts`
+
+Manifest icons already reference variant filenames; only the bytes behind those URLs change.
+
+## Migration / rollout
+
+- No DB migration.
+- After deploy, the single production property must re-upload its logo via admin to regenerate variants with the fix. This is acceptable per user direction — backfill script not warranted at current scale.
+- New variant `apple-touch-icon-180.png` is generated on the next upload; orgs that don't re-upload continue to fall back to the default logo for the apple-touch-icon, which is fine.
+
+## Verification
+
+Manual, since image generation has no existing automated test coverage:
+
+1. `npm run dev`, log in as admin, upload a non-square test logo via admin settings.
+2. Inspect Supabase `vault-public/{orgId}/` — confirm presence of `icon-192.png`, `icon-512.png`, `icon-512-maskable.png`, `favicon-32.png`, `apple-touch-icon-180.png`, `original.png`.
+3. Open `/api/manifest.json` — confirm icon URLs resolve.
+4. Install PWA on Android Chrome — confirm no blue halo on home-screen icon.
+5. Install on iOS Safari ("Add to Home Screen") — confirm apple-touch-icon shows the org logo, not the default.
+6. Type-check + tests: `npm run type-check` && `npm run test`.
+7. Follow `docs/playbooks/visual-diff-screenshots.md` — capture before/after PWA install screenshots for the PR description.
+
+## Files touched
+
+- `src/app/admin/settings/logo-actions.ts` — background color + fit mode + new `apple-touch-icon-180.png` variant
+- `src/lib/config/logo-server.ts` — extend `LogoVariant` union and `DEFAULT_ICONS` map
+- `src/lib/config/__tests__/logo-server.test.ts` — add coverage for new variant
+- `src/app/layout.tsx` — `<link rel="apple-touch-icon">` + dynamic favicon href
+
+Estimated total: ~25 lines net change.

--- a/src/app/admin/settings/__tests__/logo-actions.test.ts
+++ b/src/app/admin/settings/__tests__/logo-actions.test.ts
@@ -90,18 +90,19 @@ describe('uploadLogo', () => {
     expect(result.error).toBe('Image must be under 5MB');
   });
 
-  it('uploads 5 variants for org scope', async () => {
+  it('uploads 6 variants for org scope', async () => {
     const result = await uploadLogo(makeFormData(), 'org');
 
     expect(result.success).toBe(true);
     expect(result.basePath).toBe('test-org-id');
-    expect(uploadedFiles).toHaveLength(5);
+    expect(uploadedFiles).toHaveLength(6);
 
     const paths = uploadedFiles.map((f) => f.path);
     expect(paths).toContain('test-org-id/original.png');
     expect(paths).toContain('test-org-id/icon-192.png');
     expect(paths).toContain('test-org-id/icon-512.png');
     expect(paths).toContain('test-org-id/icon-512-maskable.png');
+    expect(paths).toContain('test-org-id/apple-touch-icon-180.png');
     expect(paths).toContain('test-org-id/favicon-32.png');
   });
 

--- a/src/app/admin/settings/logo-actions.ts
+++ b/src/app/admin/settings/logo-actions.ts
@@ -79,7 +79,10 @@ export async function uploadLogo(
     .toBuffer();
   variants.push({ name: 'apple-touch-icon-180.png', buffer: appleTouch });
 
-  // Favicon
+  // Favicon (32x32). Letterboxing wide wordmark logos with white gutters at
+  // this tiny size is intentional — preserves the full logo at the cost of
+  // shrinking it. The alternative (fit: 'cover') would crop wide logos to
+  // an unreadable center slice.
   const favicon = await sharp(buffer)
     .resize(32, 32, { fit: 'contain', background: white })
     .png()

--- a/src/app/admin/settings/logo-actions.ts
+++ b/src/app/admin/settings/logo-actions.ts
@@ -36,29 +36,54 @@ export async function uploadLogo(
   // Generate variants
   const variants: { name: string; buffer: Buffer }[] = [];
 
-  // Original (max 1024px, preserve aspect ratio)
-  const original = await sharp(buffer).resize(1024, 1024, { fit: 'inside', withoutEnlargement: true }).png().toBuffer();
+  // Solid white background applied to every square variant so non-square
+  // logos render letterboxed (not cropped) and platform masks (Android
+  // adaptive icons, iOS rounded-rect) don't expose colored padding.
+  const white = { r: 255, g: 255, b: 255, alpha: 1 } as const;
+
+  // Original (max 1024px, preserve aspect ratio, no background fill)
+  const original = await sharp(buffer)
+    .resize(1024, 1024, { fit: 'inside', withoutEnlargement: true })
+    .png()
+    .toBuffer();
   variants.push({ name: 'original.png', buffer: original });
 
-  // PWA icons (square, cover)
-  const icon192 = await sharp(buffer).resize(192, 192, { fit: 'cover' }).png().toBuffer();
+  // PWA icons (square, contain on white so non-square logos aren't cropped)
+  const icon192 = await sharp(buffer)
+    .resize(192, 192, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
   variants.push({ name: 'icon-192.png', buffer: icon192 });
 
-  const icon512 = await sharp(buffer).resize(512, 512, { fit: 'cover' }).png().toBuffer();
+  const icon512 = await sharp(buffer)
+    .resize(512, 512, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
   variants.push({ name: 'icon-512.png', buffer: icon512 });
 
-  // Maskable icon (20% safe zone padding)
+  // Maskable icon: 80% inner safe zone, 10% padding on each side, white fill
   const maskableInner = Math.floor(512 * 0.8);
   const padding = Math.floor((512 - maskableInner) / 2);
   const maskable = await sharp(buffer)
-    .resize(maskableInner, maskableInner, { fit: 'cover' })
-    .extend({ top: padding, bottom: padding, left: padding, right: padding, background: { r: 37, g: 99, b: 235, alpha: 1 } })
+    .resize(maskableInner, maskableInner, { fit: 'contain', background: white })
+    .extend({ top: padding, bottom: padding, left: padding, right: padding, background: white })
     .png()
     .toBuffer();
   variants.push({ name: 'icon-512-maskable.png', buffer: maskable });
 
+  // Apple touch icon (180x180 retina, white background — iOS does not honor
+  // PNG transparency on home-screen icons)
+  const appleTouch = await sharp(buffer)
+    .resize(180, 180, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
+  variants.push({ name: 'apple-touch-icon-180.png', buffer: appleTouch });
+
   // Favicon
-  const favicon = await sharp(buffer).resize(32, 32, { fit: 'cover' }).png().toBuffer();
+  const favicon = await sharp(buffer)
+    .resize(32, 32, { fit: 'contain', background: white })
+    .png()
+    .toBuffer();
   variants.push({ name: 'favicon-32.png', buffer: favicon });
 
   // Upload all variants to vault-public bucket

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Navigation from '@/components/layout/Navigation';
 import { PuckRootRenderer } from '@/components/puck/PuckRootRenderer';
 import { ConfigProvider } from '@/lib/config/client';
 import { getConfig } from '@/lib/config/server';
+import { getLogoUrlServer } from '@/lib/config/logo-server';
 import { resolveTheme, themeToCssVars } from '@/lib/config/themes';
 import { UserLocationProvider } from '@/lib/location/provider';
 import QueryProvider from '@/components/QueryProvider';
@@ -70,7 +71,17 @@ export default async function RootLayout({
         <link rel="manifest" href="/api/manifest.json" />
         <link rel="preconnect" href="https://basemaps.cartocdn.com" crossOrigin="anonymous" />
         <meta name="theme-color" content="#2563eb" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/defaults/logos/favicon-32.png" />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href={getLogoUrlServer(config.logoUrl, 'favicon-32.png')}
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href={getLogoUrlServer(config.logoUrl, 'apple-touch-icon-180.png')}
+        />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
       </head>

--- a/src/lib/config/__tests__/logo-server.test.ts
+++ b/src/lib/config/__tests__/logo-server.test.ts
@@ -20,7 +20,13 @@ describe('getLogoUrlServer', () => {
     expect(getLogoUrlServer(null, 'icon-512.png')).toBe('/defaults/logos/icon-512.png');
     expect(getLogoUrlServer(null, 'icon-512-maskable.png')).toBe('/defaults/logos/icon-512-maskable.png');
     expect(getLogoUrlServer(null, 'favicon-32.png')).toBe('/defaults/logos/favicon-32.png');
+    expect(getLogoUrlServer(null, 'apple-touch-icon-180.png')).toBe('/defaults/logos/icon-192.png');
     expect(getLogoUrlServer(null, 'original.png')).toBe('/defaults/logos/fieldmapper.png');
+  });
+
+  it('builds storage URL for apple-touch-icon-180 variant', () => {
+    const url = getLogoUrlServer('org-123', 'apple-touch-icon-180.png');
+    expect(url).toBe('https://storage.test/vault-public/org-123/apple-touch-icon-180.png');
   });
 
   it('builds storage URL for org logo with variant', () => {

--- a/src/lib/config/logo-server.ts
+++ b/src/lib/config/logo-server.ts
@@ -1,12 +1,19 @@
 import { createClient } from '@/lib/supabase/server';
 
-export type LogoVariant = 'original.png' | 'icon-192.png' | 'icon-512.png' | 'icon-512-maskable.png' | 'favicon-32.png';
+export type LogoVariant =
+  | 'original.png'
+  | 'icon-192.png'
+  | 'icon-512.png'
+  | 'icon-512-maskable.png'
+  | 'favicon-32.png'
+  | 'apple-touch-icon-180.png';
 
-const DEFAULT_ICONS: Record<string, string> = {
+const DEFAULT_ICONS: Record<LogoVariant, string> = {
   'icon-192.png': '/defaults/logos/icon-192.png',
   'icon-512.png': '/defaults/logos/icon-512.png',
   'icon-512-maskable.png': '/defaults/logos/icon-512-maskable.png',
   'favicon-32.png': '/defaults/logos/favicon-32.png',
+  'apple-touch-icon-180.png': '/defaults/logos/icon-192.png', // iOS downscales 192→180; reuse existing default asset
   'original.png': '/defaults/logos/fieldmapper.png',
 };
 

--- a/src/lib/config/logo.ts
+++ b/src/lib/config/logo.ts
@@ -1,6 +1,12 @@
 import { createClient } from '@/lib/supabase/client';
 
-export type LogoVariant = 'original.png' | 'icon-192.png' | 'icon-512.png' | 'icon-512-maskable.png' | 'favicon-32.png';
+export type LogoVariant =
+  | 'original.png'
+  | 'icon-192.png'
+  | 'icon-512.png'
+  | 'icon-512-maskable.png'
+  | 'favicon-32.png'
+  | 'apple-touch-icon-180.png';
 
 const DEFAULT_LOGO_PATH = '/defaults/logos/fieldmapper.png';
 


### PR DESCRIPTION
Closes #314.

## Summary
- Maskable icon's safe-zone padding switched from opaque brand-blue `#2563eb` to white — matches manifest `background_color`, eliminates the Android adaptive-icon halo.
- All square sharp variants (`icon-192`, `icon-512`, `icon-512-maskable` inner, `apple-touch-icon-180`, `favicon-32`) now use `fit: 'contain'` on a white background. Wide / tall org logos letterbox cleanly instead of being center-cropped.
- New `apple-touch-icon-180.png` variant generated on every upload, plus a `<link rel="apple-touch-icon">` in `app/layout.tsx`. iOS home-screen install now uses the org logo instead of falling back to the default favicon.
- Existing `<link rel="icon">` favicon switched from a hard-coded default to `getLogoUrlServer(config.logoUrl, 'favicon-32.png')` so desktop browsers and iOS Safari also pick up the org's logo.
- `LogoVariant` union extended on both server (`logo-server.ts`) and client (`logo.ts`) for the new variant. `DEFAULT_ICONS` tightened to `Record<LogoVariant, string>` for compile-time exhaustiveness.

## Out of scope
- Per-org configurable PWA icon background / theme color → tracked in #315.
- Backfill of existing orgs' icons. The single production property must re-upload its logo after deploy to regenerate variants with the fix.
- `theme_color: '#2563eb'` in `manifest.json/route.ts` and `layout.tsx` — unchanged here, lives in #315.

## Design / plan
- Spec: `docs/superpowers/specs/2026-05-03-pwa-logo-artifacts-design.md`
- Plan: `docs/superpowers/plans/2026-05-03-pwa-logo-artifacts.md`

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run test` — full suite green (38/38 logo-related, 1426/1426 overall)
- [ ] Manual on-device — required before merging out of draft:
  - [ ] Upload a non-square test logo via admin → confirm 6 variants (`original`, `icon-192`, `icon-512`, `icon-512-maskable`, `apple-touch-icon-180`, `favicon-32`) in `vault-public/{orgId}/`
  - [ ] `/api/manifest.json` resolves all icon URLs
  - [ ] Android Chrome → Install PWA → no blue halo on home-screen icon
  - [ ] iOS Safari → Add to Home Screen → org logo (not default) on rounded-rect tile
  - [ ] Desktop Chrome install → 512 icon not cropped
  - [ ] Wordmark logo readable in 32px tab favicon (letterboxing tradeoff documented in `logo-actions.ts`)
  - [ ] Visual diff screenshots per `docs/playbooks/visual-diff-screenshots.md`

## Notes
- Returning users with the old PWA installed may need to uninstall/reinstall (or clear PWA cache) to see the fix — caching is expected, not a regression.
- Pre-existing minor: maskable canvas is 511×511 due to `Math.floor` rounding (declared 512). Tolerated by browsers; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)