### PR TITLE
fix(map): unstick infinite spinner on IDB versionchange-blocked upgrade

### DIFF
--- a/src/components/map/HomeMapView.tsx
+++ b/src/components/map/HomeMapView.tsx
@@ -97,6 +97,16 @@ function HomeMapViewContent() {
 
   mark('ttrc:hydrate-start');
 
+  // Safety net: if loading work hangs (e.g. IDB versionchange upgrade blocked
+  // by another connection — Dexie's db.open() can wait indefinitely with no
+  // throw), force the spinner off after 8s so the user isn't stuck. The map
+  // will render with whatever state we have (typically empty), and any later
+  // success path will populate it.
+  useEffect(() => {
+    const safetyNet = setTimeout(() => setLoading(false), 8000);
+    return () => clearTimeout(safetyNet);
+  }, []);
+
   useEffect(() => {
     async function fetchData() {
       if (!propertyId) { setLoading(false); return; }

--- a/src/lib/offline/db.ts
+++ b/src/lib/offline/db.ts
@@ -89,6 +89,17 @@ let dbInstance: OfflineDatabase | null = null;
 export function getOfflineDb(): OfflineDatabase {
   if (!dbInstance) {
     dbInstance = new OfflineDatabase();
+    if (typeof window !== 'undefined') {
+      // If a Dexie schema upgrade is blocked by another open connection (e.g.
+      // a stale service worker holding the prior schema version), `db.open()`
+      // hangs indefinitely with no resolution and no throw — the page renders
+      // a spinner forever. Reload to drop our connection so the upgrade can
+      // proceed; on the second load the new SW has activated.
+      dbInstance.on('blocked', () => {
+        console.warn('[offline-db] schema upgrade blocked; reloading');
+        window.location.reload();
+      });
+    }
   }
   return dbInstance;
 }


### PR DESCRIPTION
## Root cause

Phase 3 (#316) bumped the Dexie schema to v3 (added the new `geo_layer_cache` table). On users with **pre-existing IndexedDB at v2**, the new code triggers a `versionchange` upgrade on first load. When **any other open connection** (typically a stale service worker, or another tab) holds v2 open, IndexedDB's spec requires the upgrade to wait until that connection closes — Dexie's `db.open()` then hangs indefinitely with **neither resolution nor throw**.

In `HomeMapViewContent.fetchData`, the first `await offlineStore.db.properties.get(propertyId)` triggers the implicit `db.open()` and hangs. The wrapping `try/catch/finally` added in #185 doesn't help because:
- there's no throw to `catch`
- there's no resolution to reach the `finally`

`setLoading(false)` never fires. Spinner shows forever. More common on mobile where SW + tab lifecycle is managed more aggressively.

## Fix

Two defensive changes — neither fixes the upgrade-blocked condition itself, both ensure the user is not stuck on a spinner:

1. **`src/lib/offline/db.ts`** — register Dexie `blocked` event handler that logs and reloads. The reload drops our page's connection so the upgrade can proceed; on the second load the new SW has activated and there's no longer a conflicting v2 connection.

2. **`src/components/map/HomeMapView.tsx`** — safety-net `setTimeout` that forces `setLoading(false)` after 8s. Even if `db.open()` never resolves, the user sees the map UI (empty if needed) instead of an infinite spinner.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run test -- src/components/map src/lib/offline` — 47 tests pass
- [ ] Vercel preview on mobile with cached state — spinner clears within 8s; if upgrade was blocked, page auto-reloads via `blocked` handler

## Notes

- This does not address the root upgrade-blocked condition (which is largely outside our control — IDB spec behavior). It addresses the user-visible symptom.
- A follow-up could detect SW updates proactively and prompt reload before the upgrade is even attempted, but that's a larger UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)