### PR TITLE
fix(offline): scope geo_layers sync by org_id, not property_id

### DIFF
--- a/src/lib/offline/sync-engine.ts
+++ b/src/lib/offline/sync-engine.ts
@@ -179,8 +179,8 @@ export async function syncPropertyData(
 
     let query = supabase.from(tableName).select('*');
 
-    const propertyScoped = ['items', 'item_updates', 'photos', 'geo_layers'];
-    const orgScoped = ['item_types', 'custom_fields', 'update_types', 'update_type_fields', 'entities', 'entity_types', 'roles', 'org_memberships'];
+    const propertyScoped = ['items', 'item_updates', 'photos'];
+    const orgScoped = ['item_types', 'custom_fields', 'update_types', 'update_type_fields', 'entities', 'entity_types', 'geo_layers', 'roles', 'org_memberships'];
 
     if (propertyScoped.includes(tableName)) {
       query = query.eq('property_id', propertyId);


### PR DESCRIPTION
## Summary
- \`syncPropertyData\` was treating \`geo_layers\` as property-scoped, but the table only has \`org_id\` — every sync cycle hit PostgREST with \`?property_id=eq.<id>\` and got 400 \`column geo_layers.property_id does not exist\` (code 42703).
- Move \`geo_layers\` from \`propertyScoped\` to \`orgScoped\` so the query matches the actual schema.

## Why this matters
- Removes a recurring 400 from prod logs that's been there since the offline sync engine was written.
- Side effect of the bad query: the per-table \`sync_metadata\` row for \`geo_layers\` was permanently \`status: 'error'\`, and the loop never updated \`last_synced_at\` for that table — so geo_layers were never actually pulled into IDB on returning sessions.

## Test plan
- [x] \`npm run type-check\`
- [x] \`npx vitest run src/lib/offline/\` (43/43)
- [ ] Hard-reload prod \`/map\` while authenticated on mobile, confirm no \`geo_layers.property_id\` 400 in network tab

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)