### PR TITLE
chore(docs): backfill ADRs + memory entries from 2026-05-03 PR sweep

### DIFF
--- a/docs/adr/0009-geo-layer-swr-cache.md
+++ b/docs/adr/0009-geo-layer-swr-cache.md
@@ -1,0 +1,71 @@
+# ADR-0009: Stale-While-Revalidate Cache for Org Geo-Layer GeoJSON
+
+**Status:** Accepted
+
+**Date:** 2026-05-03
+
+**Issue / PR:** [#316](https://github.com/patjackson52/birdhouse-mapper/pulls/316) — "perf(map): IDB-cached GeoJSON with stale-while-revalidate (Phase 3)"
+
+## Context
+
+GeoJSON payloads for org geo-layers can be large (hundreds of features). Before PR #316, `HomeMapView` fetched every visible layer's full GeoJSON from Supabase on every `/map` load via `getGeoLayerPublic`. On warm visits (repeat page loads) this was wasteful: the data had not changed but the client had no way to know that, so it re-transferred the full payload every time.
+
+The `geo_layers` table had no `updated_at` column, making any version check impossible. Measurement via the `?perf=1` overlay (see `docs/playbooks/map-perf-investigation.md`) showed that `idb-resolved → geolayers-resolved` was the dominant latency gap on warm visits, driven entirely by these redundant full fetches.
+
+Phase 3 of the map TTRC improvement initiative targeted this gap.
+
+## Decision
+
+1. **Add `updated_at` to `geo_layers` (migration `supabase/migrations/051_geo_layers_updated_at.sql`).** The column is auto-maintained by the existing `update_updated_at()` trigger. Existing rows are backfilled to `created_at`.
+
+2. **Expose `updated_at` on `GeoLayerSummary` (`src/lib/geo/types.ts`).** The lightweight summary returned by list actions now carries the version token without fetching the full GeoJSON.
+
+3. **Add a `geo_layer_cache` table to IndexedDB (Dexie schema v3, `src/lib/offline/db.ts`).** Schema: `{ id, version, geojson, fetchedAt }` keyed on layer id. Helpers live in `src/lib/offline/geo-layer-cache.ts` (`getCachedLayer`, `putCachedLayer`, `bulkGetCachedLayers`).
+
+4. **Add `getGeoLayerPublicIfNewer` server action (`src/app/admin/geo-layers/actions.ts`).** Queries with `.gt('updated_at', knownVersion).maybeSingle()` — returns `{ unchanged: true }` when nothing changed, full layer otherwise. No extra round-trip for version check; the condition is pushed into Postgres.
+
+5. **Implement SWR in `HomeMapViewContent` (`src/components/map/HomeMapView.tsx`).** On each page load:
+   - Fetch the lightweight layer manifest (`getPropertyGeoLayersPublic`) — small, metadata only.
+   - Bulk-read cached GeoJSON from IndexedDB (`bulkGetCachedLayers`) — zero network.
+   - Render immediately from cache if present.
+   - In parallel, compare each cached row's `version` to the manifest's `updated_at`. If equal, skip. If different (or no cache), call `getGeoLayerPublicIfNewer`. Replace the rendered layer only if the server returns a newer payload.
+   - Write updated payloads back to IDB via `putCachedLayer`.
+
+   The same SWR logic applies to the boundary layer and to layers toggled on by the user (`loadLayerCacheFirst`).
+
+## Alternatives Considered
+
+- **Revalidate on every load (no cache).** Simple but wastes bandwidth and adds ~200–800ms latency on every warm visit. Rejected — the measured TTRC gap was the primary motivation.
+- **Cache forever (no revalidation).** Zero latency on warm visits but stale layers show indefinitely after admin edits. Rejected — layers are editable and org admins expect changes to appear promptly on the public map.
+- **ETag / `If-None-Match` HTTP header check.** Natural fit but Supabase server actions run as Next.js Server Actions over POST, not cacheable HTTP GET responses. No way to plumb HTTP conditional request headers through the action boundary. Rejected — `updated_at` comparison pushed to Postgres achieves the same semantic with the tools available.
+- **Polling / WebSocket for cache invalidation.** Adds persistent connection complexity for a relatively static asset. Rejected — geo-layer edits are infrequent; lazy revalidation on page load is sufficient.
+- **Service Worker Cache API instead of IndexedDB.** The rest of the offline layer (items, photos, sync metadata) uses Dexie/IDB. Splitting storage engines for one asset type adds complexity with no benefit. Rejected.
+
+## Consequences
+
+**Positive:**
+- Warm visits skip full GeoJSON transfer for unchanged layers; `geolayers-resolved` mark fires as soon as IDB reads complete rather than waiting for network.
+- Cold visits (no IDB entry) are unchanged in behaviour — full fetch, then write to cache.
+- Admin edits propagate on the next page load (`updated_at` mismatch → revalidate); no stale-forever risk.
+- IDB schema versioning (Dexie v3) is additive; existing v1/v2 databases upgrade automatically.
+
+**Negative:**
+- First load after clearing IndexedDB (or first ever visit) is unchanged — no cache hit possible.
+- Dexie schema upgrade blocked by a stale service worker causes a `blocked` event; the `db.ts` handler reloads the page once to resolve it (see comment in `src/lib/offline/db.ts`).
+
+**Neutral:**
+- `geo_layer_cache` is a separate IDB table from the `geo_layers` sync-engine table (which stores layer metadata without GeoJSON). Two separate concerns; deliberate separation.
+
+## Related Files
+
+- `supabase/migrations/051_geo_layers_updated_at.sql`
+- `src/lib/geo/types.ts` — `GeoLayerSummary.updated_at`
+- `src/lib/offline/db.ts` — Dexie schema v3, `geo_layer_cache` table
+- `src/lib/offline/geo-layer-cache.ts` — get/put/bulkGet helpers
+- `src/app/admin/geo-layers/actions.ts` — `getGeoLayerPublicIfNewer`
+- `src/components/map/HomeMapView.tsx` — SWR logic in geo-layer `useEffect`
+- `docs/playbooks/map-perf-investigation.md` — measurement runbook, `ttrc:geolayers-resolved` mark
+
+## Tags
+
+`performance`, `offline`, `geo`, `indexeddb`, `caching`

--- a/docs/adr/0010-richtext-sanitization-boundary.md
+++ b/docs/adr/0010-richtext-sanitization-boundary.md
@@ -1,0 +1,118 @@
+# 0010 — Richtext Sanitization Boundary
+
+**Status:** Accepted
+**Date:** 2026-05-03
+**Issue:** [#304](https://github.com/patjackson52/birdhouse-mapper/issues/304)
+**PR:** [#307](https://github.com/patjackson52/birdhouse-mapper/pull/307)
+**Spec:** [docs/superpowers/specs/2026-05-02-puck-html-sanitize-design.md](../superpowers/specs/2026-05-02-puck-html-sanitize-design.md)
+
+## Context
+
+The Puck editor stores richtext field content as raw HTML strings inside JSON blobs in `properties.puck_pages`, `properties.puck_pages_draft`, `properties.puck_root`, and `properties.puck_root_draft`. These columns are later rendered via `dangerouslySetInnerHTML` in `RichText.tsx`.
+
+Users can paste content from external rich-text editors (Quill, Google Docs, Microsoft Word). Such pastes arrive with foreign wrapper `<div>` tags, `xmlns` attributes, inline `style` attributes, and `class` names. More critically, a malicious or compromised user could submit HTML with XSS payloads such as `<a href="javascript:...">`, `<img onerror="...">`, or `<script>` blocks. Because the editor sends its data to server actions that write directly to Supabase, any unsanitized HTML becomes persistent and is served to every viewer of that property's public pages.
+
+PR #303 added a Tier 1 CSS workaround that prevents visible layout breakage from NBSP-induced overflow. PR #307 (this ADR) adds the Tier 2 data-layer fix: sanitize at write time so the stored data is clean.
+
+## Decision
+
+### Boundary statement
+
+**All richtext HTML is untrusted until it passes through `sanitizePuckDataForWrite` in a server action. Any value read from `properties.puck_pages`, `properties.puck_pages_draft`, `properties.puck_root`, or `properties.puck_root_draft` after a write that went through a current server action is trusted — the stored data contains only the allow-listed tags and attributes defined in `src/lib/puck/sanitize-html.ts`.**
+
+### Where sanitization happens
+
+Sanitization occurs on the server, inside `'use server'` actions, before any Supabase write:
+
+| Entry point | File | Column(s) written |
+|---|---|---|
+| `savePuckPageDraft` | `src/app/admin/site-builder/actions.ts` | `puck_pages_draft` |
+| `savePuckRootDraft` | `src/app/admin/site-builder/actions.ts` | `puck_root_draft` |
+| `publishPuckPages` | `src/app/admin/site-builder/actions.ts` | `puck_pages` (defense-in-depth re-sanitize) |
+| `publishPuckRoot` | `src/app/admin/site-builder/actions.ts` | `puck_root` (defense-in-depth re-sanitize) |
+| `applyTemplate` | `src/app/admin/site-builder/actions.ts` | `puck_root`, `puck_root_draft`, `puck_pages`, `puck_pages_draft` |
+
+The render path (`RichText.tsx`, any server component reading `puck_pages`) does **not** sanitize. It relies on the stored data being clean.
+
+### How sanitization works
+
+Two functions compose the sanitization pipeline:
+
+**`sanitizePuckDataForWrite(data: Data): Data`** (`src/lib/puck/sanitize-data.ts`)
+- Deep-clones the Puck data tree.
+- Walks every component in `data.content`, `data.zones`, and `data.root.content`, recursing into slot arrays.
+- For each richtext prop (`content`, `text`, `quote`): empty strings become `null`; non-empty strings are passed to `sanitizeRichTextHtml`.
+- Non-richtext props are untouched.
+
+**`sanitizeRichTextHtml(input: string): string`** (`src/lib/puck/sanitize-html.ts`)
+- Runs the string through `isomorphic-dompurify` with a strict allow-list configuration.
+- Post-processes the DOMPurify output to normalize NBSP runs.
+- Fail-closed: any exception returns `''` (never propagates malformed content).
+
+### Allow-list
+
+**Tags (19):** `p`, `a`, `strong`, `em`, `u`, `s`, `code`, `pre`, `blockquote`, `ul`, `ol`, `li`, `h2`, `h3`, `h4`, `br`, `hr`, `img`
+
+Everything not on this list has its tag stripped but text content preserved (DOMPurify default). This means foreign wrapper `<div>`, `<span>`, `<table>`, `<h1>`, `<h5>`, `<h6>`, `<script>`, `<iframe>`, `<style>`, `<form>`, `<input>` etc. are all stripped.
+
+**Attributes (7):** `href`, `target`, `rel`, `src`, `alt`, `width`, `height`
+
+All other attributes are stripped, including `class`, `style`, `id`, `xmlns`, and all `data-*` attributes (`ALLOW_DATA_ATTR: false`). Event handler attributes (`onclick`, `onerror`, etc.) are stripped by DOMPurify's default XSS rules.
+
+**URI scheme enforcement:** DOMPurify's default `ALLOWED_URI_REGEXP` rejects `javascript:`, `data:`, and `vbscript:` in `href` and `src`. No override is applied — we rely on the DOMPurify default.
+
+**`target="_blank"` auto-hardening:** A global `afterSanitizeAttributes` hook on the `isomorphic-dompurify` singleton automatically adds `rel="noopener noreferrer"` to any `<a>` with `target="_blank"`. Note: this hook mutates the singleton — if any other code in the process imports and calls `isomorphic-dompurify` directly it will also run this hook.
+
+### NBSP normalization
+
+After DOMPurify serializes output, `jsdom` re-encodes U+00A0 as `&nbsp;`. The pipeline decodes these back to literal U+00A0, then collapses runs of two or more consecutive U+0020 / U+00A0 characters (in any mix) to a single ASCII space. An isolated U+00A0 is preserved (legitimate "10 km", "Mr. Smith" usage). This runs after DOMPurify, on its output string.
+
+### Fail-closed behavior
+
+- Sanitization exception on any individual richtext prop → that prop becomes `''` (coerced to `null` by the walker). Other props in the same component and all other components proceed normally.
+- The server action does not swallow the exception globally; only the affected field is zeroed.
+- Data that fails Zod schema validation (`puckDataSchema.safeParse`) is rejected before sanitization is attempted.
+
+### Backfill
+
+Rows written before PR #307 may contain unsanitized HTML. A one-time backfill script at `scripts/backfill-puck-sanitize.ts` runs every existing `puck_pages` and `puck_pages_draft` row through `sanitizePuckDataForWrite`. Defaults to `--dry-run`; `--apply` to persist. Idempotent. Operator playbook: `docs/playbooks/puck-html-sanitize.md`.
+
+## Consequences
+
+**Positive:**
+- XSS payloads (script injection, javascript: URIs, event-handler attributes) cannot survive a save through any current server action.
+- Foreign paste artifacts (xmlns, class, style, wrapper divs) are stripped at write time, keeping stored data minimal.
+- Render path is simple — `dangerouslySetInnerHTML` is safe against stored XSS for content written after this ADR.
+- Allow-list is centralized in one file (`sanitize-html.ts`); extending it is a one-line PR.
+
+**Negative:**
+- Defense-in-depth re-sanitize on publish adds a small constant cost (acceptable; save is a rare user action).
+- The `afterSanitizeAttributes` DOMPurify hook is a global singleton mutation; any future direct use of `isomorphic-dompurify` elsewhere in the process will also run the `target="_blank"` hook.
+- `isomorphic-dompurify` pulls in `jsdom` as a server-side DOM, which required externalizing the package in `next.config.js` (`experimental.serverComponentsExternalPackages`) to prevent webpack from bundling jsdom's `fs.readFileSync` asset load.
+- Rows written before the backfill is run may still contain unsanitized HTML. The render path has no fallback sanitizer — operators must run the backfill.
+
+**Neutral:**
+- `sanitizePuckData` (load-side, empty-string → null) semantics are unchanged; `sanitizePuckDataForWrite` is a superset that adds HTML sanitization on top.
+- The allow-list intentionally excludes `<table>`, `<h1>`, `<h5>`, `<h6>`, `<div>`, `<span>`. Adding them requires a deliberate PR to `sanitize-html.ts`.
+
+## Alternatives considered
+
+- **Client-side sanitization only.** Rejected — client-side sanitization can be bypassed by a modified client or direct API call. The server action is the only trustworthy enforcement point.
+- **Render-time sanitization (sanitize on every page view).** Rejected — it papers over a data-quality problem, adds overhead on the hot render path, and means stored data remains dirty indefinitely.
+- **`DOMPurify` in the browser bundle (no `isomorphic-dompurify`).** Rejected — server actions run in Node, not the browser; `DOMPurify` requires a DOM environment. `isomorphic-dompurify` provides the jsdom shim transparently for both runtimes.
+- **`sanitize-html` npm package instead of DOMPurify.** Rejected — `isomorphic-dompurify` is faster, has broader XSS coverage, and is more widely battle-tested per the spec evaluation.
+- **Allow-list extension (permissive).** Rejected — there is no existing content that requires tables, span, or div; a strict forward-only allow-list is cheaper to maintain and reduces attack surface.
+
+## Related Files
+
+- `src/lib/puck/sanitize-html.ts` — DOMPurify config + allow-list + NBSP normalizer
+- `src/lib/puck/sanitize-data.ts` — tree walker; `sanitizePuckDataForWrite` + `sanitizePuckData`
+- `src/app/admin/site-builder/actions.ts` — all write entry points
+- `scripts/backfill-puck-sanitize.ts` — one-time backfill script
+- `src/lib/puck/__tests__/sanitize-html.test.ts` — unit tests for the sanitizer
+- `src/lib/puck/__tests__/sanitize-data.test.ts` — unit tests for the tree walker
+- `docs/playbooks/puck-html-sanitize.md` — operator playbook (backfill, allowlist extension, emergency disable)
+
+## Tags
+
+`security`, `puck`, `xss`, `sanitization`, `richtext`

--- a/memory/decisions/project-decisions.md
+++ b/memory/decisions/project-decisions.md
@@ -5,3 +5,5 @@ Tracks technical decisions specific to this project. For organization-wide decis
 | Date | Decision | Context | Status |
 |------|----------|---------|--------|
 | 2024-11-15 | Next.js 14 App Router + Supabase | Needed full-stack framework with auth, DB, and edge support. Next.js 14 gives us RSC and server actions; Supabase provides auth, Postgres, and RLS out of the box. | Accepted |
+| 2026-05-03 | Standalone landing/About-style routes deprecated; Puck site-editor is the single editable surface | PR #306 removed legacy landing-page code (closes #299). Same direction applies to About page (#319 still open). | Accepted |
+| 2026-05-03 | PWA icon variants use white background; per-org theme color stays a wish | Fixes Android maskable halo (#314 / PR #317). Spec: docs/superpowers/specs/2026-05-03-pwa-logo-artifacts-design.md. Per-org icon background tracked separately in #315. | Accepted |

--- a/memory/patterns/architecture-patterns.md
+++ b/memory/patterns/architecture-patterns.md
@@ -20,3 +20,20 @@ High-level architecture patterns used in the system.
 - Migrations managed via `supabase/migrations/`.
 - Database types are generated from the schema and kept in sync.
 - Use Supabase client libraries, not raw SQL, in application code.
+
+## Offline Sync Scoping
+
+**Rule:** When adding a table to the inbound sync loop (`syncPropertyData` in `src/lib/offline/sync-engine.ts`), classify it as either `propertyScoped` or `orgScoped` based on which FK column the table actually has — not by analogy to similar tables.
+
+**Why:** PR #321 fixed a silent bug where `geo_layers` was placed in `propertyScoped` with filter `.eq('property_id', propertyId)`. The `geo_layers` table has no `property_id` column; PostgREST returned `column geo_layers.property_id does not exist` (error 42703) on every sync cycle, meaning the local `geo_layers` IDB table was never populated via the sync engine. The correct scope is `orgScoped` (`.eq('org_id', orgId)`), matching the schema.
+
+**How to apply when adding a new offline-cached table:**
+
+1. Check the migration: does the table have `property_id` or only `org_id`?
+   - `property_id` present → `propertyScoped` list.
+   - `org_id` only → `orgScoped` list.
+   - Neither (e.g. lookup/reference table) → handle explicitly (like `properties` or `orgs`), or omit from sync.
+2. Add the table name to the correct array in `syncPropertyData`; never guess by analogy.
+3. The Dexie schema index in `src/lib/offline/db.ts` must include the scoping column so the deletion-reconciliation pass (`.where(scopeColumn).equals(scopeValue)`) can use an indexed query.
+
+**Note on `geo_layer_cache`:** This is a separate IDB table used for the SWR GeoJSON cache (see ADR-0009). It is **not** in `SYNC_TABLES` and is not subject to the inbound sync loop — it has its own revalidation path via `getGeoLayerPublicIfNewer`.

--- a/memory/patterns/coding-patterns.md
+++ b/memory/patterns/coding-patterns.md
@@ -23,3 +23,33 @@ Recurring patterns used across the codebase. Keep this updated as conventions ev
 - Use `describe` / `it` blocks with clear behavior descriptions.
 - Mock Supabase client in tests using `vi.mock`.
 - E2E tests in `e2e/` directory.
+
+## Dexie / IndexedDB Schema Upgrades
+
+**Rule:** When bumping Dexie's schema version, any tab/SW holding the DB at the old version blocks the upgrade. `db.open()` waits indefinitely — no resolution, no throw. Any code path that awaits the DB (e.g. `offlineStore.db.*`) hangs forever. Spinners that depend on that code path never clear.
+
+**Why (PR #320):** Phase 3 (#316) bumped schema v2 → v3 (added `geo_layer_cache` table). Users with existing IDB at v2 hit the blocked-upgrade path on first load. `HomeMapViewContent.fetchData` awaited `offlineStore.db.*`, triggering implicit `db.open()` that hung. The `try/catch/finally` from #185 was useless — no throw, no resolution, so `setLoading(false)` never fired. Infinite spinner. More common on mobile where SW lifecycle is aggressive.
+
+**How to apply when bumping Dexie schema version:**
+
+1. **Register the `blocked` handler in `src/lib/offline/db.ts`** (already present — do not remove):
+   ```ts
+   dbInstance.on('blocked', () => {
+     console.warn('[offline-db] schema upgrade blocked; reloading');
+     window.location.reload();
+   });
+   ```
+   Reload drops our connection; the blocked upgrade can then proceed. On second load the new SW is active.
+
+2. **Add a safety-net timeout in any component that gates UI on DB-ready.** Pattern from `src/components/map/HomeMapView.tsx`:
+   ```ts
+   useEffect(() => {
+     const safetyNet = setTimeout(() => setLoading(false), 8000);
+     return () => clearTimeout(safetyNet);
+   }, []);
+   ```
+   Even if `db.open()` never resolves, user sees the UI (empty) instead of an infinite spinner.
+
+3. The two handlers are **independent** — the `blocked` reload is the primary fix; the 8s timeout is a belt-and-suspenders fallback for any other hang source.
+
+**Handler locations:** `src/lib/offline/db.ts` (`getOfflineDb`), `src/components/map/HomeMapView.tsx` (`HomeMapViewContent`).


### PR DESCRIPTION
## Summary
Captures decisions and recurring patterns from the six PRs that merged 2026-05-03 so the memory-reminder CI hint is satisfied. No code changes.

- **ADR-0009** — geo-layer GeoJSON SWR cache (PR #316). Documents the IDB-backed \`getGeoLayerPublicIfNewer\` revalidation path and the Postgres \`updated_at\` version-token approach.
- **ADR-0010** — server-side richtext sanitization boundary (PR #307 / #304). Crisp boundary statement: untrusted until \`sanitizePuckDataForWrite\` runs in a server action; trusted on read.
- **memory/patterns/architecture-patterns.md** — offline-sync scoping rule (PR #321 fixed a silent 42703 from putting \`geo_layers\` in propertyScoped instead of orgScoped).
- **memory/patterns/coding-patterns.md** — Dexie \`versionchange\`-blocked recovery pattern (PR #320 — \`blocked\` handler reload + 8s safety-net timeout).
- **memory/decisions/project-decisions.md** — landing/About-style surfaces deprecated (PR #306 / #319) + PWA icon white-background decision (PR #317 / #314, per-org via #315).

## Test plan
- [x] No code changes; nothing to run.
- [ ] Skim the two ADRs for accuracy if you have context on the originating PRs.

## Related
- Cleanup report: \`/Users/patrick/Library/Application Support/Claude/local-agent-mode-sessions/.../cleanup_report.md\`
- Companion cleanup: closed #309 + #310 (assigned @patjackson52); deleted 93 merged remote branches (144 → 51) and 2 local branches whose upstream was gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)