### PR TITLE
fix(admin): visible active-state for sidebar (#323)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-admin-sidemenu-active-state.md
+++ b/docs/superpowers/plans/2026-05-03-admin-sidemenu-active-state.md
@@ -1,0 +1,194 @@
+# Admin Sidebar Active-State Styling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the visible active-item indicator (warm tan background + 4px golden left border + bold dark text) in the admin sidebar by replacing the broken `border-l-3` Tailwind class and the near-invisible `bg-sage-light/50` wash on `AdminSidebar.tsx:59`.
+
+**Architecture:** Single-component fix. `AdminSidebar` already computes `isActive` correctly via `usePathname`; only the className string needs to change. A new Vitest case asserts the active-state utility classes are applied so a typo like `border-l-3` (which Tailwind silently drops) cannot regress unnoticed.
+
+**Tech Stack:** Next.js 14 App Router, Tailwind CSS, Vitest + @testing-library/react.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-admin-sidemenu-active-state-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `src/components/admin/AdminSidebar.tsx` — replace the active-state class string on the `<Link>` element.
+- **Modify** `src/__tests__/admin/AdminSidebar.test.tsx` — add a regression test that asserts the active item carries `bg-golden/10`, `border-l-4`, `border-golden`, and `font-semibold`, and that an inactive item does not.
+
+---
+
+### Task 1: Add the active-state regression test (failing)
+
+**Files:**
+- Modify: `src/__tests__/admin/AdminSidebar.test.tsx`
+
+The existing test mocks `usePathname` to return `'/admin'`. With items `Dashboard` (`/admin`) and `Properties` (`/admin/properties`), `Dashboard` is the active item. We assert the *intended* class set, which currently passes only partially because `border-l-3` is a no-op utility.
+
+- [ ] **Step 1: Add the new test case**
+
+Open `src/__tests__/admin/AdminSidebar.test.tsx` and append a new `it` block inside the existing `describe('AdminSidebar', ...)`. The full file should read:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdminSidebar } from '@/components/admin/AdminSidebar';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin',
+}));
+
+describe('AdminSidebar', () => {
+  it('renders section headers as non-clickable labels', () => {
+    const items = [
+      { label: 'Dashboard', href: '/admin' },
+      { type: 'section' as const, label: 'Data' },
+      { label: 'AI Context', href: '/admin/ai-context' },
+      { label: 'Geo Layers', href: '/admin/geo-layers' },
+    ];
+
+    render(<AdminSidebar title="Test Org" items={items} />);
+
+    // Section header renders as text, not a link
+    const sectionHeader = screen.getByText('Data');
+    expect(sectionHeader.tagName).not.toBe('A');
+    expect(sectionHeader.closest('a')).toBeNull();
+
+    // Nav items render as links
+    expect(screen.getByText('AI Context').closest('a')).toBeTruthy();
+    expect(screen.getByText('Geo Layers').closest('a')).toBeTruthy();
+  });
+
+  it('applies the visible active-state utilities to the link matching pathname', () => {
+    const items = [
+      { label: 'Dashboard', href: '/admin' },
+      { label: 'Properties', href: '/admin/properties' },
+    ];
+
+    render(<AdminSidebar title="Test Org" items={items} />);
+
+    const dashboardLink = screen.getByText('Dashboard').closest('a');
+    expect(dashboardLink).toBeTruthy();
+    expect(dashboardLink!.className).toContain('bg-golden/10');
+    expect(dashboardLink!.className).toContain('border-l-4');
+    expect(dashboardLink!.className).toContain('border-golden');
+    expect(dashboardLink!.className).toContain('font-semibold');
+
+    const propertiesLink = screen.getByText('Properties').closest('a');
+    expect(propertiesLink).toBeTruthy();
+    expect(propertiesLink!.className).not.toContain('bg-golden/10');
+    expect(propertiesLink!.className).not.toContain('border-l-4');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `npm run test -- src/__tests__/admin/AdminSidebar.test.tsx --run`
+
+Expected: the new `it('applies the visible active-state utilities ...')` case FAILS with messages similar to:
+
+```
+expect(dashboardLink!.className).toContain('bg-golden/10')
+  Expected substring: "bg-golden/10"
+  Received string:    "...bg-sage-light/50 text-forest-dark font-semibold border-l-3 border-golden..."
+```
+
+(The first test, `renders section headers as non-clickable labels`, still passes.)
+
+---
+
+### Task 2: Fix the active-state classes (make the test pass)
+
+**Files:**
+- Modify: `src/components/admin/AdminSidebar.tsx:57-61`
+
+- [ ] **Step 1: Replace the active-state className**
+
+Open `src/components/admin/AdminSidebar.tsx`. Find the `<Link>` className expression (around line 57-61):
+
+```tsx
+            className={`flex items-center justify-between px-4 py-2 text-sm ${
+              isActive
+                ? 'bg-sage-light/50 text-forest-dark font-semibold border-l-3 border-golden'
+                : 'text-gray-600 hover:bg-sage-light/30'
+            }`}
+```
+
+Replace the active-branch string. The full block becomes:
+
+```tsx
+            className={`flex items-center justify-between px-4 py-2 text-sm ${
+              isActive
+                ? 'bg-golden/10 text-forest-dark font-semibold border-l-4 border-golden'
+                : 'text-gray-600 hover:bg-sage-light/30'
+            }`}
+```
+
+The inactive branch is unchanged.
+
+- [ ] **Step 2: Run the test to confirm it passes**
+
+Run: `npm run test -- src/__tests__/admin/AdminSidebar.test.tsx --run`
+
+Expected: both `it` cases PASS (`Test Files  1 passed`, `Tests  2 passed`).
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run type-check`
+
+Expected: clean, no output.
+
+- [ ] **Step 4: Commit both files together**
+
+The test and the fix are one logical change — the test fails without the fix and passes with it. One commit:
+
+```bash
+git add src/__tests__/admin/AdminSidebar.test.tsx src/components/admin/AdminSidebar.tsx
+git commit -m "fix(admin): visible active-state for sidebar (#323)"
+```
+
+---
+
+### Task 3: Visual verification + screenshots
+
+No code changes — verification only, produces the artifacts the PR description needs.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+
+Expected: server starts on localhost.
+
+- [ ] **Step 2: Navigate to admin and confirm the visible indicator**
+
+In a browser, log in as an org admin and visit `/admin`. The current page's sidebar item (e.g. Dashboard) must show:
+- A 4px solid golden left border on the link.
+- A subtle warm tan background tint distinct from the parchment surround.
+- Dark forest text in semibold weight.
+
+Click into another sidebar item (e.g. Properties). The previously-active item returns to the inactive style; the newly-active item shows the same indicator treatment.
+
+- [ ] **Step 3: Capture before/after screenshots**
+
+Per `docs/playbooks/visual-diff-screenshots.md`, capture:
+- A "before" reference from the current `main` branch (or the issue's "currently looks like this" attachment).
+- An "after" from this branch with at least one active item visible.
+
+Save them where the playbook directs and reference them in the PR description.
+
+No commit for this task.
+
+---
+
+## Self-Review
+
+Spec coverage:
+- Spec § Decision (3 class changes) → Task 2 ✓
+- Spec § Test (new active-state test) → Task 1 ✓
+- Spec § Out of scope (mobile, section headers, hover, custom border-3 config) → no tasks created ✓
+- Spec § Verification (type-check, tests, manual + visual diff) → Tasks 1–3 ✓
+
+No placeholders. Class strings consistent across spec, plan, test, and source change (`bg-golden/10`, `border-l-4`, `border-golden`, `text-forest-dark`, `font-semibold`).

--- a/docs/superpowers/specs/2026-05-03-admin-sidemenu-active-state-design.md
+++ b/docs/superpowers/specs/2026-05-03-admin-sidemenu-active-state-design.md
@@ -1,0 +1,92 @@
+# Admin Sidebar Active-State Styling
+
+**Issue:** [#323](https://github.com/patjackson52/birdhouse-mapper/issues/323)
+**Date:** 2026-05-03
+
+## Problem
+
+The active/selected item in the admin sidebar (`AdminSidebar`) is not visually distinguishable from inactive items. The current and target designs from the issue:
+
+- **Target:** active item has a warm tan background tint, a 4px golden left border, dark forest text in semibold.
+- **Current:** active item has only `text-forest-dark font-semibold` rendered. The intended left border and background are missing or invisible.
+
+## Root cause
+
+`src/components/admin/AdminSidebar.tsx:59` declares the active item's classes:
+
+```tsx
+isActive
+  ? 'bg-sage-light/50 text-forest-dark font-semibold border-l-3 border-golden'
+  : 'text-gray-600 hover:bg-sage-light/30'
+```
+
+Two defects in those classes:
+
+1. **`border-l-3` is not a Tailwind utility.** The default border-width scale is 0/2/4/8 — `border-l-3` does not generate any CSS, and Tailwind's JIT silently drops it. The intended 3px golden left border has never rendered.
+
+2. **`bg-sage-light/50` is nearly invisible on parchment.** `--color-surface-light` resolves to `#EEF2EA` (very pale green-gray); at 50% opacity over the parchment background `#FDFBF7` the wash is indistinguishable from the surrounding sidebar.
+
+## Decision
+
+Replace the active-state class string in `AdminSidebar.tsx:59` with utilities that resolve to real CSS:
+
+```tsx
+isActive
+  ? 'bg-golden/10 text-forest-dark font-semibold border-l-4 border-golden'
+  : 'text-gray-600 hover:bg-sage-light/30'
+```
+
+Three changes:
+
+| Was | Now | Why |
+|---|---|---|
+| `bg-sage-light/50` | `bg-golden/10` | Warm tan tint matches the target screenshot; reuses the existing accent color (`--color-accent` = `#D4A853`). |
+| `border-l-3` | `border-l-4` | Built-in Tailwind utility — actually renders. 4px is closest to the target's visible left bar. |
+| `text-forest-dark font-semibold` | unchanged | Already correct. |
+
+The inactive state (`text-gray-600 hover:bg-sage-light/30`) is unchanged.
+
+## Test
+
+`src/__tests__/admin/AdminSidebar.test.tsx` currently only asserts structural behavior (sections vs links). Add a test that asserts the active item has each of the three intended utility classes — this would have caught the original `border-l-3` typo and prevents regression on the visibility classes:
+
+```tsx
+it('applies active-state utilities to the link matching pathname', () => {
+  const items = [
+    { label: 'Dashboard', href: '/admin' },
+    { label: 'Properties', href: '/admin/properties' },
+  ];
+  render(<AdminSidebar title="Test Org" items={items} />);
+  const dashboardLink = screen.getByText('Dashboard').closest('a')!;
+  expect(dashboardLink.className).toContain('bg-golden/10');
+  expect(dashboardLink.className).toContain('border-l-4');
+  expect(dashboardLink.className).toContain('border-golden');
+  expect(dashboardLink.className).toContain('font-semibold');
+
+  const propertiesLink = screen.getByText('Properties').closest('a')!;
+  expect(propertiesLink.className).not.toContain('bg-golden/10');
+  expect(propertiesLink.className).not.toContain('border-l-4');
+});
+```
+
+The existing `usePathname` mock at the top of the file (`/admin`) makes `Dashboard` the active item.
+
+## Out of scope
+
+- Mobile drawer styling — `AdminSidebar` is the same component used inside the mobile sheet; the same active-state classes apply automatically. No separate change needed.
+- Section header styling, badges, hover state on inactive items — already match the target.
+- Defining a custom `borderWidth: { 3: '3px' }` in `tailwind.config.ts` to preserve the original intent — rejected; built-in `border-l-4` is the simplest path and visually matches the target.
+
+## Verification
+
+- `npm run type-check` clean.
+- `npm run test -- src/__tests__/admin/AdminSidebar.test.tsx --run` — new active-state assertions pass; existing structural test still passes.
+- `npm run dev` → log in → visit `/admin` → confirm active item shows golden left border and warm tan background.
+- Capture before/after screenshots per `docs/playbooks/visual-diff-screenshots.md` for the PR.
+
+## Files touched
+
+- `src/components/admin/AdminSidebar.tsx` — single className change (lines 57-61).
+- `src/__tests__/admin/AdminSidebar.test.tsx` — add active-state test.
+
+Estimated diff: ~20 lines net (mostly the new test).

--- a/src/__tests__/admin/AdminSidebar.test.tsx
+++ b/src/__tests__/admin/AdminSidebar.test.tsx
@@ -27,4 +27,25 @@ describe('AdminSidebar', () => {
     expect(screen.getByText('AI Context').closest('a')).toBeTruthy();
     expect(screen.getByText('Geo Layers').closest('a')).toBeTruthy();
   });
+
+  it('applies the visible active-state utilities to the link matching pathname', () => {
+    const items = [
+      { label: 'Dashboard', href: '/admin' },
+      { label: 'Properties', href: '/admin/properties' },
+    ];
+
+    render(<AdminSidebar title="Test Org" items={items} />);
+
+    const dashboardLink = screen.getByText('Dashboard').closest('a');
+    expect(dashboardLink).toBeTruthy();
+    expect(dashboardLink!.className).toContain('bg-golden/10');
+    expect(dashboardLink!.className).toContain('border-l-4');
+    expect(dashboardLink!.className).toContain('border-golden');
+    expect(dashboardLink!.className).toContain('font-semibold');
+
+    const propertiesLink = screen.getByText('Properties').closest('a');
+    expect(propertiesLink).toBeTruthy();
+    expect(propertiesLink!.className).not.toContain('bg-golden/10');
+    expect(propertiesLink!.className).not.toContain('border-l-4');
+  });
 });

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -56,7 +56,7 @@ export function AdminSidebar({ title, items, backLink, onNavClick, hideTitle }: 
             href={navItem.href}
             className={`flex items-center justify-between px-4 py-2 text-sm ${
               isActive
-                ? 'bg-sage-light/50 text-forest-dark font-semibold border-l-3 border-golden'
+                ? 'bg-golden/10 text-forest-dark font-semibold border-l-4 border-golden'
                 : 'text-gray-600 hover:bg-sage-light/30'
             }`}
             onClick={onNavClick}


### PR DESCRIPTION
Closes #323.

## Summary
- The active item in the admin sidebar (\`AdminSidebar.tsx\`) currently has no visible indicator. Two defects in the existing className: \`border-l-3\` is not a Tailwind utility (default scale is 0/2/4/8 — silently dropped, no border ever rendered), and \`bg-sage-light/50\` (\`#EEF2EA\` at 50% opacity) is indistinguishable from the parchment surround.
- Replaced with \`border-l-4 border-golden\` (4px solid golden left bar) + \`bg-golden/10\` (warm tan tint matching the design target).
- Added a regression test asserting the four intended visibility classes are present on the active link and absent on inactive links — would have caught the original \`border-l-3\` typo.
- Inactive hover state and all other styling unchanged.

## Out of scope
- Per-org color theming, mobile drawer styling (same component, same classes apply automatically), section/badge styling — all already correct.

## Design / plan
- Spec: \`docs/superpowers/specs/2026-05-03-admin-sidemenu-active-state-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-03-admin-sidemenu-active-state.md\`

## Test plan
- [x] \`npm run type-check\` clean (no new errors; 3 pre-existing errors unrelated to touched files)
- [x] \`npm run test -- src/__tests__/admin/AdminSidebar.test.tsx --run\` — 2/2 pass
- [ ] Manual visual verification — required before promoting from draft:
  - [ ] \`/admin\` → active sidebar item shows golden 4px left border + warm tan background
  - [ ] Click another item → previously-active reverts to inactive style; new active shows the indicator
  - [ ] Mobile drawer (same component) — confirm same indicator works
  - [ ] Capture before/after screenshots per \`docs/playbooks/visual-diff-screenshots.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)