### PR TITLE
ci: validate PR migrations against local DB (drop prod-link token dependency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,19 @@ jobs:
         with:
           version: latest
 
-      - name: Link Supabase project
-        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      # Validate migrations against a throwaway local Postgres — `supabase start`
+      # applies every file in supabase/migrations/ on boot and fails if any of
+      # them errors. This needs NO prod credentials (no access token / project
+      # ref), so it can't break when a token expires, and a bad migration can
+      # never touch production during a PR. Same local-stack approach the E2E
+      # workflow already relies on.
+      - name: Apply all migrations to a local database
+        run: supabase start
 
-      - name: Dry-run migrations against production
-        run: supabase db push --dry-run
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      # Prove a clean-slate re-apply also works (catches ordering / idempotency
+      # issues that a warm DB would hide).
+      - name: Re-apply migrations from scratch
+        run: supabase db reset
 
   migrate:
     name: Apply Migrations


### PR DESCRIPTION
## Problem
The `Migration Dry Run` job did `supabase link --project-ref` + `supabase db push --dry-run`, which needs a live **account-level** `SUPABASE_ACCESS_TOKEN`. When that token expired, the check went **red on every PR and every branch regardless of content** — the real reason PRs #327/#328/#329 all showed a failing migration check. It also failed `Apply Migrations` on `main`, so prod migrations stopped applying.

## Change
Validate migrations against a **throwaway local Postgres** instead of prod:
- `supabase start` — applies every file in `supabase/migrations/` on boot, fails on any bad SQL
- `supabase db reset` — re-applies from scratch (catches ordering/idempotency issues)

No prod credentials in the PR path → can't break on token expiry, and a bad migration can't touch production during a PR. This is the same local-stack approach `e2e.yml` already relies on. Job name kept as `Migration Dry Run` so required-check config still matches.

## Scope
- **This PR:** the per-PR check only.
- **Not here (P1-CI-2):** the `main` → `Apply Migrations` job still uses the account token; a follow-up moves it to a scoped `SUPABASE_DB_URL` connection string and then `SUPABASE_ACCESS_TOKEN` can be deleted from repo secrets entirely.

## Test plan
- `supabase start`/`db reset` is the proven pattern from `e2e.yml` (seed.sql already applies cleanly there).
- YAML validated. Watch this PR's own `Migration Dry Run` check go green with no token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)