### PR TITLE
ci: apply prod migrations via scoped SUPABASE_DB_URL (drop account token)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,13 @@ jobs:
         with:
           version: latest
 
-      - name: Link Supabase project
-        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-
+      # Push migrations over a direct database connection instead of the
+      # account-level Management API. SUPABASE_DB_URL is the project's pooler
+      # connection string (Project Settings → Database → Connection string).
+      # Its blast radius is this one database — it cannot manage/delete
+      # projects or reach other projects the way SUPABASE_ACCESS_TOKEN can.
+      # No `supabase link` step and no access token required.
       - name: Push migrations to production
-        run: supabase db push
+        run: supabase db push --db-url "$SUPABASE_DB_URL"
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}


### PR DESCRIPTION
## ⚠️ Needs a new secret before merge
This PR won't work (and shouldn't be merged) until you add:
```
SUPABASE_DB_URL = postgresql://postgres.<ref>:<db-password>@<region>.pooler.supabase.com:6543/postgres
```
from **Project Settings → Database → Connection string** (URI / pooler). Add via:
```
echo -n 'postgresql://...' | gh secret set SUPABASE_DB_URL
```

## Change
The `Apply Migrations` job (push → `main`) used `supabase link` + `supabase db push`, needing the **account-level** `SUPABASE_ACCESS_TOKEN` — a credential that can manage/delete *every* project on the account. This swaps to a direct DB connection:
```yaml
- run: supabase db push --db-url "$SUPABASE_DB_URL"
```
Blast radius shrinks from the whole Supabase account to **this one database** — a leaked `SUPABASE_DB_URL` can't delete projects, mint API keys, or reach other projects. No `link` step, no access token.

## Payoff
Once this **and** #330 (PR-check → local DB) are merged, **no CI path needs the account token** — you can delete `SUPABASE_ACCESS_TOKEN` and `SUPABASE_PROJECT_REF` from repo secrets entirely. (Part of the Supabase-token hardening from the 2026-07-02 audit; the token expiry is what silently broke all CI.)

## Before merge
- Add the `SUPABASE_DB_URL` secret (above).
- Confirm `supabase db push --db-url` on the pinned CLI (`supabase db push --help`) — flag name has been stable but verify.

## Test plan
- Job only runs on push to `main`, so it exercises after merge. Recommend: add the secret, merge, watch the first `main` push's `Apply Migrations` job go green, then remove the old token secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)