### PR TITLE
feat(auth): requireOrgContext/requireOrgAdmin helpers (security foundation)

### DIFF
--- a/src/lib/auth/__tests__/require-org.test.ts
+++ b/src/lib/auth/__tests__/require-org.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mock state, controlled per test -------------------------------------
+let mockUser: { id: string } | null = { id: 'user-1' };
+let mockTenant: { orgId: string | null; orgSlug?: string | null } = {
+  orgId: 'org-1',
+  orgSlug: 'test-org',
+};
+let mockIsPlatformAdmin = false;
+// Active org_admin memberships for the user, by org id. requireOrgAdmin must
+// only match the row whose org_id equals the CURRENT tenant org.
+let mockAdminOrgIds: string[] = [];
+
+// Captures the eq() filters applied to the org_memberships query so the mock
+// can honour the .eq('org_id', ...) scoping the real helper must enforce.
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: () => Promise.resolve({ data: { user: mockUser } }),
+    },
+    from: (table: string) => {
+      if (table === 'users') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { is_platform_admin: mockIsPlatformAdmin },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      if (table === 'org_memberships') {
+        const filters: Record<string, unknown> = {};
+        const builder: any = {
+          select: () => builder,
+          eq: (col: string, val: unknown) => {
+            filters[col] = val;
+            return builder;
+          },
+          limit: () => {
+            const orgId = filters['org_id'];
+            const userMatches = filters['user_id'] === mockUser?.id;
+            const roleMatches = filters['roles.base_role'] === 'org_admin';
+            const statusActive = filters['status'] === 'active';
+            const orgMatches =
+              typeof orgId === 'string' && mockAdminOrgIds.includes(orgId);
+            const hit =
+              userMatches && roleMatches && statusActive && orgMatches;
+            return Promise.resolve({ data: hit ? [{ id: 'm-1' }] : [], error: null });
+          },
+        };
+        return builder;
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+        single: vi.fn().mockResolvedValue({ data: null }),
+      };
+    },
+  }),
+}));
+
+vi.mock('@/lib/tenant/server', () => ({
+  getTenantContext: () => Promise.resolve(mockTenant),
+}));
+
+import { requireOrgContext, requireOrgAdmin, isAuthFailure } from '../require-org';
+
+beforeEach(() => {
+  mockUser = { id: 'user-1' };
+  mockTenant = { orgId: 'org-1', orgSlug: 'test-org' };
+  mockIsPlatformAdmin = false;
+  mockAdminOrgIds = [];
+});
+
+describe('requireOrgContext', () => {
+  it('returns {error} when there is no org context', async () => {
+    mockTenant = { orgId: null };
+    const r = await requireOrgContext();
+    expect(isAuthFailure(r)).toBe(true);
+    expect((r as { error: string }).error).toMatch(/org context/i);
+  });
+
+  it('returns {error} when the user is not authenticated', async () => {
+    mockUser = null;
+    const r = await requireOrgContext();
+    expect(isAuthFailure(r)).toBe(true);
+    expect((r as { error: string }).error).toMatch(/not authenticated/i);
+  });
+
+  it('returns the org-scoped context on success', async () => {
+    const r = await requireOrgContext();
+    expect(isAuthFailure(r)).toBe(false);
+    if (isAuthFailure(r)) throw new Error('unreachable');
+    expect(r.orgId).toBe('org-1');
+    expect(r.user.id).toBe('user-1');
+    expect(r.tenant.orgId).toBe('org-1');
+  });
+});
+
+describe('requireOrgAdmin', () => {
+  it('rejects an unauthenticated caller', async () => {
+    mockUser = null;
+    const r = await requireOrgAdmin();
+    expect(isAuthFailure(r)).toBe(true);
+  });
+
+  it('allows a platform admin without any org membership', async () => {
+    mockIsPlatformAdmin = true;
+    mockAdminOrgIds = [];
+    const r = await requireOrgAdmin();
+    expect(isAuthFailure(r)).toBe(false);
+  });
+
+  it('allows an org_admin OF THE CURRENT org', async () => {
+    mockAdminOrgIds = ['org-1'];
+    const r = await requireOrgAdmin();
+    expect(isAuthFailure(r)).toBe(false);
+  });
+
+  it('REJECTS an admin of a DIFFERENT org (cross-org scoping)', async () => {
+    // User is org_admin of org-2 but the tenant is org-1 → must be denied.
+    mockAdminOrgIds = ['org-2'];
+    mockTenant = { orgId: 'org-1', orgSlug: 'test-org' };
+    const r = await requireOrgAdmin();
+    expect(isAuthFailure(r)).toBe(true);
+    expect((r as { error: string }).error).toMatch(/admin/i);
+  });
+
+  it('rejects a non-admin member', async () => {
+    mockAdminOrgIds = [];
+    const r = await requireOrgAdmin();
+    expect(isAuthFailure(r)).toBe(true);
+  });
+});

--- a/src/lib/auth/require-org.ts
+++ b/src/lib/auth/require-org.ts
@@ -1,3 +1,4 @@
+import type { User } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
 import { getTenantContext } from '@/lib/tenant/server';
 
@@ -22,7 +23,7 @@ type Tenant = Awaited<ReturnType<typeof getTenantContext>>;
 
 export interface OrgContext {
   supabase: SupabaseServerClient;
-  user: { id: string; [key: string]: unknown };
+  user: User;
   tenant: Tenant;
   /** Non-null — narrowed from `tenant.orgId` by the guard above. */
   orgId: string;
@@ -52,7 +53,7 @@ export async function requireOrgContext(): Promise<OrgContext | AuthFailure> {
   } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
 
-  return { supabase, user: user as OrgContext['user'], tenant, orgId: tenant.orgId };
+  return { supabase, user, tenant, orgId: tenant.orgId };
 }
 
 /**

--- a/src/lib/auth/require-org.ts
+++ b/src/lib/auth/require-org.ts
@@ -1,0 +1,91 @@
+import { createClient } from '@/lib/supabase/server';
+import { getTenantContext } from '@/lib/tenant/server';
+
+/**
+ * Shared authentication/authorization prologue for server actions.
+ *
+ * Before this existed the same ~5-line prologue (`createClient` +
+ * `auth.getUser()` + `getTenantContext()` + null checks) was copy-pasted
+ * across ~60 server actions, and the admin variant was re-implemented per
+ * file — several of those copies forgot to scope the `org_memberships`
+ * lookup by `org_id`, so an admin of *any* org passed the check (the
+ * cross-org-admin bug from the 2026-07-02 audit). Routing everything
+ * through these helpers fixes that in one place.
+ *
+ * Both helpers FAIL CLOSED: on any missing precondition they return
+ * `{ error }` (never throw, never fall through to a privileged path).
+ * Callers narrow with `isAuthFailure(result)`.
+ */
+
+type SupabaseServerClient = ReturnType<typeof createClient>;
+type Tenant = Awaited<ReturnType<typeof getTenantContext>>;
+
+export interface OrgContext {
+  supabase: SupabaseServerClient;
+  user: { id: string; [key: string]: unknown };
+  tenant: Tenant;
+  /** Non-null — narrowed from `tenant.orgId` by the guard above. */
+  orgId: string;
+}
+
+export interface AuthFailure {
+  error: string;
+}
+
+export function isAuthFailure(
+  result: OrgContext | AuthFailure
+): result is AuthFailure {
+  return 'error' in result;
+}
+
+/**
+ * Require an authenticated user within a resolved org context.
+ * Returns the Supabase client, the user, the tenant, and a non-null `orgId`.
+ */
+export async function requireOrgContext(): Promise<OrgContext | AuthFailure> {
+  const supabase = createClient();
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  return { supabase, user: user as OrgContext['user'], tenant, orgId: tenant.orgId };
+}
+
+/**
+ * Require the caller to be an admin of the CURRENT org: either a platform
+ * admin, or an active `org_admin` member **of this tenant's org**. The
+ * `.eq('org_id', orgId)` scoping is the fix for the cross-org-admin bug —
+ * without it, being org_admin of any org anywhere passes.
+ */
+export async function requireOrgAdmin(): Promise<OrgContext | AuthFailure> {
+  const ctx = await requireOrgContext();
+  if (isAuthFailure(ctx)) return ctx;
+
+  const { supabase, user, orgId } = ctx;
+
+  // Platform admins bypass org membership.
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('is_platform_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (userRow?.is_platform_admin) return ctx;
+
+  const { data } = await supabase
+    .from('org_memberships')
+    .select('id, roles!inner(base_role)')
+    .eq('user_id', user.id)
+    .eq('org_id', orgId)
+    .eq('status', 'active')
+    .eq('roles.base_role', 'org_admin')
+    .limit(1);
+
+  if ((data?.length ?? 0) === 0) return { error: 'Admin access required' };
+
+  return ctx;
+}


### PR DESCRIPTION
Foundation for the 2026-07-02 audit's #1 finding. **Additive — no call sites changed**, so it's safe to land now; adoption is a reviewed follow-up.

## Why
~60 server actions copy-paste the same 5-line prologue (`createClient` + `auth.getUser()` + `getTenantContext()` + null checks), and the admin variant is re-implemented per file. Several copies — `qr-codes/actions.ts` `requireOrgAdmin`, `invites/actions.ts` `isOrgAdmin` — query `org_memberships` by `user_id` + `base_role` but **omit `.eq('org_id', ...)`**, so an admin of *any* org passes the check (Medium security finding). A single canonical helper fixes that in one place and makes the fix enforceable everywhere.

## What
`src/lib/auth/require-org.ts`:
- `requireOrgContext()` — authenticated user + resolved org, non-null `orgId`, **fails closed** (`{ error }`, never throws/falls through)
- `requireOrgAdmin()` — the above **plus** platform-admin **or** active `org_admin` **of the current org** (includes the missing org scoping)
- `isAuthFailure()` type guard

## Tests
`src/lib/auth/__tests__/require-org.test.ts` — 8 unit tests, all green, including the key case: **an org_admin of org-2 is rejected when the tenant is org-1.**

## Follow-up (separate reviewed PRs — behavior changes)
1. Adopt `requireOrgAdmin()` in the two buggy sites → fixes the cross-org bug.
2. Adopt `requireOrgContext()` in the unauth'd Critical/High actions the audit flagged (`domains`, `communications`, `ai-context`) + the `setup.ts` anon-admin Critical (its own setup_complete guard).
3. Mechanical adoption across the remaining ~60 prologues (removes ~250-300 lines).

## Test plan
`npx vitest run src/lib/auth` → 8/8. No runtime surface changed (nothing imports it yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)