### PR TITLE
fix(security): scope org-admin checks to current org (cross-org-admin bug)

### DIFF
--- a/src/app/admin/properties/[slug]/invites/__tests__/actions.test.ts
+++ b/src/app/admin/properties/[slug]/invites/__tests__/actions.test.ts
@@ -31,6 +31,10 @@ function chain(terminal?: any) {
 const mockServiceChain = chain();
 const mockUserChain = chain();
 
+// Controls for the cross-org admin-scoping tests (see the last describe block).
+let mockIsPlatformAdmin = true;
+let mockAdminOrgIds: string[] = [];
+
 vi.mock('@/lib/supabase/server', () => ({
   createClient: () => ({
     auth: {
@@ -46,12 +50,45 @@ vi.mock('@/lib/supabase/server', () => ({
             eq: () => ({
               single: () =>
                 Promise.resolve({
-                  data: { is_platform_admin: true },
+                  data: { is_platform_admin: mockIsPlatformAdmin },
                   error: null,
                 }),
             }),
           }),
         };
+      }
+      if (table === 'org_memberships') {
+        // Honour the .eq('org_id', ...) scoping so the mock reflects the real
+        // cross-org check: a row is returned only when the filtered org_id is
+        // one the user actually admins.
+        const filters: Record<string, unknown> = {};
+        const b: any = {
+          select: () => b,
+          eq: (col: string, val: unknown) => {
+            filters[col] = val;
+            return b;
+          },
+          limit: () => {
+            const baseMatch =
+              filters['user_id'] === 'admin-user-id' &&
+              filters['status'] === 'active' &&
+              filters['roles.base_role'] === 'org_admin' &&
+              mockAdminOrgIds.length > 0;
+            // If the query DID scope by org_id, only match when it's an org the
+            // user admins. If it did NOT (the bug), the unscoped query would
+            // return the user's membership in *any* org — so this test fails
+            // loudly if the `.eq('org_id', ...)` fix is ever removed.
+            const orgMatch =
+              filters['org_id'] === undefined
+                ? true
+                : mockAdminOrgIds.includes(filters['org_id'] as string);
+            return Promise.resolve({
+              data: baseMatch && orgMatch ? [{ id: 'm-1' }] : [],
+              error: null,
+            });
+          },
+        };
+        return b;
       }
       return mockUserChain;
     },
@@ -106,6 +143,8 @@ describe('createInvite', () => {
     insertedTable = '';
     countResponse = 0;
     mockOrgId = 'org-123';
+    mockIsPlatformAdmin = true;
+    mockAdminOrgIds = [];
     vi.clearAllMocks();
   });
 
@@ -151,5 +190,47 @@ describe('createInvite', () => {
     await createInvite({ ...validOpts, displayName: '' });
 
     expect(insertedPayload.display_name).toBeNull();
+  });
+});
+
+describe('createInvite — org-admin scoping (cross-org)', () => {
+  beforeEach(() => {
+    insertedPayload = {};
+    insertedTable = '';
+    countResponse = 0;
+    mockOrgId = 'org-123';
+    mockIsPlatformAdmin = false;
+    mockAdminOrgIds = [];
+    vi.clearAllMocks();
+  });
+
+  it('allows an org_admin of the current org', async () => {
+    mockAdminOrgIds = ['org-123'];
+
+    const result = await createInvite(validOpts);
+
+    expect(result.error).toBeUndefined();
+    expect(result.token).toBe('raw-token-abc');
+    expect(insertedPayload.org_id).toBe('org-123');
+  });
+
+  it('REJECTS an org_admin of a different org', async () => {
+    // Admin of org-999, but the tenant is org-123 → must be denied.
+    mockAdminOrgIds = ['org-999'];
+
+    const result = await createInvite(validOpts);
+
+    expect(result.error).toBe('Admin access required');
+    expect(insertedPayload.org_id).toBeUndefined();
+  });
+
+  it('allows a platform admin regardless of org membership', async () => {
+    mockIsPlatformAdmin = true;
+    mockAdminOrgIds = [];
+
+    const result = await createInvite(validOpts);
+
+    expect(result.error).toBeUndefined();
+    expect(result.token).toBe('raw-token-abc');
   });
 });

--- a/src/app/admin/properties/[slug]/invites/__tests__/actions.test.ts
+++ b/src/app/admin/properties/[slug]/invites/__tests__/actions.test.ts
@@ -34,6 +34,17 @@ const mockUserChain = chain();
 // Controls for the cross-org admin-scoping tests (see the last describe block).
 let mockIsPlatformAdmin = true;
 let mockAdminOrgIds: string[] = [];
+// org_id filter captured from the getInvites list query.
+let capturedInvitesOrgId: unknown;
+
+// getInvites queries the service invites table as select().eq('org_id').order().
+// Capture the org filter and make order() terminal so getInvites resolves.
+// createInvite doesn't hit these (it uses the count sub-object + insert).
+mockServiceChain.eq = vi.fn((col: string, val: unknown) => {
+  if (col === 'org_id') capturedInvitesOrgId = val;
+  return mockServiceChain;
+});
+mockServiceChain.order = vi.fn(() => Promise.resolve({ data: [], error: null }));
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: () => ({
@@ -128,7 +139,7 @@ vi.mock('@/lib/invites/tokens', () => ({
 }));
 
 // vi.mock is hoisted by vitest, so regular imports work
-import { createInvite } from '../actions';
+import { createInvite, getInvites } from '../actions';
 
 const validOpts = {
   displayName: 'Test User',
@@ -232,5 +243,22 @@ describe('createInvite — org-admin scoping (cross-org)', () => {
 
     expect(result.error).toBeUndefined();
     expect(result.token).toBe('raw-token-abc');
+  });
+});
+
+describe('getInvites — org scoping', () => {
+  beforeEach(() => {
+    mockOrgId = 'org-123';
+    mockIsPlatformAdmin = true; // bypass membership; focus on the list query
+    mockAdminOrgIds = [];
+    capturedInvitesOrgId = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('scopes the invites list query to the current org', async () => {
+    await getInvites();
+    // Fails if the `.eq('org_id', tenant.orgId)` on the service-client query
+    // is removed — the list would otherwise leak every org's invites.
+    expect(capturedInvitesOrgId).toBe('org-123');
   });
 });

--- a/src/app/admin/properties/[slug]/invites/actions.ts
+++ b/src/app/admin/properties/[slug]/invites/actions.ts
@@ -6,7 +6,11 @@ import { generateToken, hashToken } from '@/lib/invites/tokens';
 import { INVITE_LINK_TTL_MS, MAX_ACTIVE_INVITES } from '@/lib/invites/constants';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-async function isOrgAdmin(supabase: SupabaseClient, userId: string): Promise<boolean> {
+async function isOrgAdmin(
+  supabase: SupabaseClient,
+  userId: string,
+  orgId: string
+): Promise<boolean> {
   const { data: userRow } = await supabase
     .from('users')
     .select('is_platform_admin')
@@ -15,10 +19,13 @@ async function isOrgAdmin(supabase: SupabaseClient, userId: string): Promise<boo
 
   if (userRow?.is_platform_admin) return true;
 
+  // Must be org_admin OF THIS org — the `.eq('org_id', orgId)` scoping stops
+  // an admin of any other org from passing (cross-org-admin bug, 2026-07-02 audit).
   const { data } = await supabase
     .from('org_memberships')
     .select('id, roles!inner(base_role)')
     .eq('user_id', userId)
+    .eq('org_id', orgId)
     .eq('status', 'active')
     .eq('roles.base_role', 'org_admin')
     .limit(1);
@@ -60,7 +67,7 @@ export async function createInvite(opts: {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
 
-  if (!(await isOrgAdmin(supabase, user.id))) {
+  if (!(await isOrgAdmin(supabase, user.id, tenant.orgId))) {
     return { error: 'Admin access required' };
   }
 
@@ -116,7 +123,10 @@ export async function getInvites() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
 
-  if (!(await isOrgAdmin(supabase, user.id))) {
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
+
+  if (!(await isOrgAdmin(supabase, user.id, tenant.orgId))) {
     return { error: 'Admin access required' };
   }
 
@@ -172,7 +182,10 @@ export async function convertAccount(opts: {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
 
-  if (!(await isOrgAdmin(supabase, user.id))) {
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
+
+  if (!(await isOrgAdmin(supabase, user.id, tenant.orgId))) {
     return { error: 'Admin access required' };
   }
 
@@ -230,7 +243,10 @@ export async function revokeAccess(userId: string) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
 
-  if (!(await isOrgAdmin(supabase, user.id))) {
+  const tenant = await getTenantContext();
+  if (!tenant.orgId) return { error: 'No org context' };
+
+  if (!(await isOrgAdmin(supabase, user.id, tenant.orgId))) {
     return { error: 'Admin access required' };
   }
 

--- a/src/app/admin/properties/[slug]/invites/actions.ts
+++ b/src/app/admin/properties/[slug]/invites/actions.ts
@@ -138,6 +138,9 @@ export async function getInvites() {
       claimed_by, claimed_at, created_at,
       role_id, roles!invites_role_id_fkey ( name )
     `)
+    // Scope to the current org — this query uses the service client (RLS
+    // bypass), so without this filter it returns EVERY org's invites.
+    .eq('org_id', tenant.orgId)
     .order('created_at', { ascending: false });
 
   if (error) return { error: error.message };

--- a/src/app/admin/properties/[slug]/qr-codes/__tests__/actions.test.ts
+++ b/src/app/admin/properties/[slug]/qr-codes/__tests__/actions.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mutable state for controlling mock behavior per test
 let mockUser: any = { id: 'user-1' };
 let mockIsAdmin = true;
+// org ids the user is an active org_admin of (for cross-org scoping tests)
+let mockAdminOrgIds: string[] = [];
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: () => ({
@@ -22,6 +24,32 @@ vi.mock('@/lib/supabase/server', () => ({
             }),
           }),
         };
+      }
+      if (table === 'org_memberships') {
+        // Honour the .eq('org_id', ...) scoping. Models the unscoped-query bug:
+        // when the query omits org_id, an admin of ANY org would match — so the
+        // cross-org reject test fails loudly if the org scoping is removed.
+        const filters: Record<string, unknown> = {};
+        const b: any = {
+          select: () => b,
+          eq: (col: string, val: unknown) => {
+            filters[col] = val;
+            return b;
+          },
+          limit: () => {
+            const baseMatch =
+              filters['user_id'] === mockUser?.id &&
+              filters['status'] === 'active' &&
+              filters['roles.base_role'] === 'org_admin' &&
+              mockAdminOrgIds.length > 0;
+            const orgMatch =
+              filters['org_id'] === undefined
+                ? true
+                : mockAdminOrgIds.includes(filters['org_id'] as string);
+            return Promise.resolve({ data: baseMatch && orgMatch ? [{ id: 'm-1' }] : [], error: null });
+          },
+        };
+        return b;
       }
       return {
         select: vi.fn().mockReturnThis(),
@@ -60,6 +88,7 @@ describe('QR code actions', () => {
     vi.clearAllMocks();
     mockUser = { id: 'user-1' };
     mockIsAdmin = true;
+    mockAdminOrgIds = [];
   });
 
   it('rejects unauthenticated users', async () => {
@@ -74,6 +103,18 @@ describe('QR code actions', () => {
 
   it('rejects non-admin users', async () => {
     mockIsAdmin = false;
+    const result = await createQrCode({
+      propertyId: mockProperty.id,
+      propertySlug: mockProperty.slug,
+      placement: 'entrance',
+    });
+    expect(result).toEqual({ error: 'Admin access required' });
+  });
+
+  it('rejects an org_admin of a different org (cross-org scoping)', async () => {
+    // Admin of org-2, but the tenant is org-1 → must be denied.
+    mockIsAdmin = false;
+    mockAdminOrgIds = ['org-2'];
     const result = await createQrCode({
       propertyId: mockProperty.id,
       propertySlug: mockProperty.slug,

--- a/src/app/admin/properties/[slug]/qr-codes/actions.ts
+++ b/src/app/admin/properties/[slug]/qr-codes/actions.ts
@@ -23,6 +23,7 @@ async function requireOrgAdmin() {
       .from('org_memberships')
       .select('id, roles!inner(base_role)')
       .eq('user_id', user.id)
+      .eq('org_id', tenant.orgId)
       .eq('status', 'active')
       .eq('roles.base_role', 'org_admin')
       .limit(1);


### PR DESCRIPTION
Fixes the cross-org-admin finding + a related invites data-leak from the 2026-07-02 audit. All changes fail-closed and are **mutation-verified** (revert the fix → the matching test fails).

## Bugs fixed
1. **Cross-org admin (Medium).** `qr-codes` `requireOrgAdmin` and `invites` `isOrgAdmin` checked `org_memberships` by `user_id` + `base_role` but **not `org_id`** — an org_admin of *any* org passed for *any other* org.
2. **getInvites data leak.** `getInvites` read `invites` via the service client (RLS bypass) with **no org filter** → returned every org's invites.

## Fix
- **qr-codes:** add `.eq('org_id', tenant.orgId)` to the membership lookup.
- **invites:** thread `orgId` into `isOrgAdmin` + add the filter; `getInvites`/`convertAccount`/`revokeAccess` now fetch + guard tenant context (they didn't before — why the check couldn't be scoped); add `.eq('org_id', tenant.orgId)` to the `getInvites` list query. (`invites.org_id` exists since migration 009.)

## Tests (mutation-verified)
- invites: org-aware `org_memberships` mock + allow-own-org / **reject-other-org** / platform-admin cases; `getInvites` list scoped-to-org assertion.
- qr-codes: org-aware mock + cross-org reject case.
- Each models the *unscoped-query bug*, so removing any `.eq('org_id', …)` fails the corresponding test. All existing tests still green.

## Relationship to #332
Independent minimal fix. These sites can later adopt `requireOrgAdmin()` from #332 to delete the duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)