### PR TITLE
fix(ci): pin Supabase CLI + instrument key extraction (P1-CI-6 root cause)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,12 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned — `version: latest` silently changed the keys emitted by
+          # `supabase status --output env`, which fed an empty/wrong
+          # SUPABASE_SERVICE_ROLE_KEY into the app → getConfig() hit
+          # "permission denied for table orgs" → `/` 404'd → E2E readiness
+          # failed for weeks. Bump deliberately, not implicitly.
+          version: 2.84.2
 
       - name: Start local Supabase
         run: supabase start
@@ -46,6 +51,19 @@ jobs:
         id: supabase
         run: |
           eval "$(supabase status --output env)"
+          echo "supabase CLI: $(supabase --version)"
+          # Decode the role claim from each JWT (payload is not a secret) so a
+          # key/role mix-up is obvious in the log instead of surfacing as a
+          # runtime "permission denied for table orgs".
+          jwt_role() { echo "${1:-}" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | grep -oE '"role":"[a-z_]+"' || echo '(undecodable / not a legacy JWT)'; }
+          echo "ANON_KEY role:         $(jwt_role "$ANON_KEY")"
+          echo "SERVICE_ROLE_KEY role: $(jwt_role "$SERVICE_ROLE_KEY")"
+          # Fail loudly (not silently 404 at runtime) if extraction came back empty.
+          if [ -z "${ANON_KEY:-}" ] || [ -z "${SERVICE_ROLE_KEY:-}" ]; then
+            echo "::error::Supabase anon/service keys are empty — 'supabase status --output env' output shape likely changed. Full output:"
+            supabase status --output env
+            exit 1
+          fi
           echo "api_url=${API_URL}" >> "$GITHUB_OUTPUT"
           echo "anon_key=${ANON_KEY}" >> "$GITHUB_OUTPUT"
           echo "service_role_key=${SERVICE_ROLE_KEY}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Root cause (P1-CI-6: E2E `/` 404)
Traced the months-long E2E readiness failure to its source. `/` 404s because `getConfig()` logs **`permission denied for table orgs`** → returns `DEFAULT_CONFIG` (setupComplete=false) → the home page 404s.

**Verified locally** against a real Supabase stack:
- `service_role` JWT → the exact getConfig query **succeeds** (returns org data)
- empty key → supabase-js **throws** `supabaseKey is required` (a 500, *not* permission-denied)

Since the CI error is a *query-level* grant error (createClient succeeded), CI's `SUPABASE_SERVICE_ROLE_KEY` is a **valid JWT for the wrong role** (or the extraction changed) — produced by `supabase status --output env` under a drifting `version: latest` CLI. (`version: latest` has bitten this repo repeatedly — see the migration-token saga.)

## Changes (e2e.yml only — surgical)
- **Pin `setup-cli` to `2.84.2`** — locally confirmed to emit a `role=service_role` JWT under `SERVICE_ROLE_KEY`. Likely the fix.
- **Instrument "Get Supabase credentials"** — print the CLI version, decode + print each JWT's `role` claim (payload only, not a secret), and **fail loudly** with the full `--output env` dump if a key is empty. Converts a silent runtime 404 into an obvious CI error and — if the pin doesn't fully fix it — reveals the exact role on the next run.

Leaves `ci.yml` `migrate` / `migration-check` untouched (they don't consume the key output and are green).

## Test plan
- YAML validated; the JWT-role decoder tested locally (service_role→`service_role`, anon→`anon`, empty→undecodable).
- On merge/run: the E2E `Get Supabase credentials` log will show `SERVICE_ROLE_KEY role: "role":"service_role"`. If readiness then reports `HTTP 200 on /` (not 404), the config path is fixed and the suite runs for real.

## Honesty
Local repro couldn't perfectly mirror CI (my node_modules is missing `isomorphic-dompurify` and my dev DB has drifted grants), so this pins the most-likely cause and instruments for certainty rather than claiming a definitive one-line fix. The next CI run confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)