### PR TITLE
fix(security): block /setup actions once setup_complete (anon → admin escalation)

### DIFF
--- a/src/app/setup/__tests__/actions.test.ts
+++ b/src/app/setup/__tests__/actions.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Controls the org's setup_complete flag returned by the guard query.
+let mockSetupComplete = false;
+// Records every mutation the service client performs, so we can assert that a
+// blocked action performs NONE.
+let calls: Array<{ table?: string; op: string; payload?: unknown; email?: string }> = [];
+
+vi.mock('@/lib/config/server', () => ({ invalidateConfig: () => {} }));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServiceClient: () => ({
+    from: (table: string) => {
+      if (table === 'orgs') {
+        return {
+          // guard query + setupSaveConfig's org lookup both use select().limit().single()
+          select: () => ({
+            limit: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { setup_complete: mockSetupComplete, id: 'org-1', default_property_id: 'prop-1' },
+                  error: null,
+                }),
+            }),
+          }),
+          update: (payload: unknown) => {
+            calls.push({ table: 'orgs', op: 'update', payload });
+            return {
+              eq: () => Promise.resolve({ error: null }),
+              limit: () => Promise.resolve({ error: null }),
+            };
+          },
+        };
+      }
+      if (table === 'item_types') {
+        return {
+          select: () => Promise.resolve({ data: [], error: null }),
+          insert: (payload: unknown) => {
+            calls.push({ table: 'item_types', op: 'insert', payload });
+            return { select: () => ({ single: () => Promise.resolve({ data: { id: 'it-1' }, error: null }) }) };
+          },
+          delete: () => ({
+            eq: () => {
+              calls.push({ table: 'item_types', op: 'delete' });
+              return Promise.resolve({ error: null });
+            },
+          }),
+        };
+      }
+      if (table === 'custom_fields') {
+        return {
+          insert: (payload: unknown) => {
+            calls.push({ table: 'custom_fields', op: 'insert', payload });
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      if (table === 'users') {
+        return {
+          select: () => ({ limit: () => Promise.resolve({ data: [], error: null }) }),
+          upsert: (payload: unknown) => {
+            calls.push({ table: 'users', op: 'upsert', payload });
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      return {};
+    },
+    auth: {
+      admin: {
+        listUsers: () => Promise.resolve({ data: { users: [] } }),
+        createUser: (opts: { email: string }) => {
+          calls.push({ op: 'createUser', email: opts.email });
+          return Promise.resolve({ data: { user: { id: 'new-user-1' } }, error: null });
+        },
+      },
+    },
+  }),
+}));
+
+import {
+  setupCreateAdmin,
+  setupComplete,
+  setupSaveConfig,
+  setupCreateItemType,
+  setupCreateCustomField,
+  setupClearItemTypes,
+} from '../actions';
+
+beforeEach(() => {
+  calls = [];
+  mockSetupComplete = false;
+  vi.clearAllMocks();
+});
+
+describe('setup actions — blocked once setup_complete is true', () => {
+  beforeEach(() => {
+    mockSetupComplete = true;
+  });
+
+  it('setupCreateAdmin refuses and creates NO user/admin', async () => {
+    const result = await setupCreateAdmin('attacker@evil.com', 'pw', 'Attacker');
+    expect(result).toEqual({ error: 'Setup already complete' });
+    expect(calls.find((c) => c.op === 'createUser')).toBeUndefined();
+    expect(calls.find((c) => c.op === 'upsert')).toBeUndefined();
+  });
+
+  it('setupComplete refuses and does not touch orgs', async () => {
+    const result = await setupComplete();
+    expect(result).toEqual({ error: 'Setup already complete' });
+    expect(calls.find((c) => c.table === 'orgs' && c.op === 'update')).toBeUndefined();
+  });
+
+  it('setupSaveConfig refuses and writes nothing', async () => {
+    const result = await setupSaveConfig([{ key: 'site_name', value: 'Hacked' }]);
+    expect(result).toEqual({ error: 'Setup already complete' });
+    expect(calls.length).toBe(0);
+  });
+
+  it('setupCreateItemType refuses', async () => {
+    const result = await setupCreateItemType('x', '📍', '#000', 0);
+    expect(result).toEqual({ error: 'Setup already complete' });
+    expect(calls.length).toBe(0);
+  });
+
+  it('setupCreateCustomField refuses', async () => {
+    const result = await setupCreateCustomField('it-1', 'f', 'text', null, false, 0);
+    expect(result).toEqual({ error: 'Setup already complete' });
+    expect(calls.length).toBe(0);
+  });
+
+  it('setupClearItemTypes refuses and deletes nothing', async () => {
+    const result = await setupClearItemTypes();
+    expect(result).toBeUndefined();
+    expect(calls.find((c) => c.op === 'delete')).toBeUndefined();
+  });
+});
+
+describe('setup actions — allowed during first-run (setup_complete false)', () => {
+  it('setupComplete proceeds and marks the org complete', async () => {
+    const result = await setupComplete();
+    expect(result).toEqual({ success: true });
+    expect(calls).toContainEqual({ table: 'orgs', op: 'update', payload: { setup_complete: true } });
+  });
+
+  it('setupCreateAdmin proceeds and provisions the first admin', async () => {
+    const result = await setupCreateAdmin('founder@org.com', 'pw', 'Founder');
+    expect(result).toEqual({ success: true });
+    expect(calls.find((c) => c.op === 'createUser')?.email).toBe('founder@org.com');
+    expect(calls.find((c) => c.op === 'upsert')?.payload).toMatchObject({ role: 'admin' });
+  });
+});

--- a/src/app/setup/actions.ts
+++ b/src/app/setup/actions.ts
@@ -3,6 +3,34 @@
 import { createServiceClient } from '@/lib/supabase/server';
 import { invalidateConfig } from '@/lib/config/server';
 
+/**
+ * Setup actions run pre-auth with the RLS-bypassing service client (no admin
+ * account exists during first-run setup). That makes them a privilege-
+ * escalation surface once setup is finished: `/setup` stays reachable, so
+ * without this guard any anonymous visitor could re-run setup — including
+ * `setupCreateAdmin` to mint a new admin, or clobber the org config.
+ *
+ * Every setup action must call this first and refuse once `setup_complete`
+ * is true. Fails closed: any lookup error also blocks.
+ */
+async function assertSetupIncomplete(
+  supabase: ReturnType<typeof createServiceClient>
+): Promise<{ error: string } | null> {
+  const { data: org, error } = await supabase
+    .from('orgs')
+    .select('setup_complete')
+    .limit(1)
+    .single();
+
+  if (error || !org) {
+    return { error: `Failed to verify setup state: ${error?.message ?? 'no org found'}` };
+  }
+  if (org.setup_complete === true) {
+    return { error: 'Setup already complete' };
+  }
+  return null;
+}
+
 /** Keys that map to columns on the orgs table */
 const ORG_KEY_TO_COLUMN: Record<string, string> = {
   site_name: 'name',
@@ -30,6 +58,8 @@ const PROPERTY_KEY_TO_COLUMN: Record<string, string> = {
  */
 export async function setupSaveConfig(entries: { key: string; value: unknown }[]) {
   const supabase = createServiceClient();
+  const guard = await assertSetupIncomplete(supabase);
+  if (guard) return guard;
 
   // Get the single org and default property
   const { data: org, error: orgLookupError } = await supabase
@@ -109,6 +139,8 @@ export async function setupSaveConfig(entries: { key: string; value: unknown }[]
  */
 export async function setupCreateAdmin(email: string, password: string, displayName: string) {
   const supabase = createServiceClient();
+  const guard = await assertSetupIncomplete(supabase);
+  if (guard) return guard;
 
   // Check if user already exists
   const { data: existingUsers } = await supabase.auth.admin.listUsers();
@@ -165,6 +197,8 @@ export async function setupCreateAdmin(email: string, password: string, displayN
  */
 export async function setupClearItemTypes() {
   const supabase = createServiceClient();
+  const guard = await assertSetupIncomplete(supabase);
+  if (guard) return;
 
   // Only delete types that have no items (safe for retry)
   // The migrated "Bird Box" type has items pointing to it, so it won't be deleted
@@ -193,6 +227,8 @@ export async function setupCreateItemType(
   sortOrder: number
 ) {
   const supabase = createServiceClient();
+  const guard = await assertSetupIncomplete(supabase);
+  if (guard) return guard;
 
   const { data, error } = await supabase
     .from('item_types')
@@ -219,6 +255,8 @@ export async function setupCreateCustomField(
   sortOrder: number
 ) {
   const supabase = createServiceClient();
+  const guard = await assertSetupIncomplete(supabase);
+  if (guard) return guard;
 
   const { error } = await supabase
     .from('custom_fields')
@@ -243,6 +281,8 @@ export async function setupCreateCustomField(
  */
 export async function setupComplete() {
   const supabase = createServiceClient();
+  const guard = await assertSetupIncomplete(supabase);
+  if (guard) return guard;
 
   const { error } = await supabase
     .from('orgs')

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -122,7 +122,7 @@ export default function SetupPage() {
         { key: 'about_content', value: aboutContent },
         { key: 'custom_map', value: overlayConfig },
       ]);
-      if (configResult.error) throw new Error(configResult.error);
+      if ('error' in configResult && configResult.error) throw new Error(configResult.error);
 
       // 2. Clear any item types from previous attempts, then create new ones
       await setupClearItemTypes();
@@ -130,17 +130,17 @@ export default function SetupPage() {
         const t = itemTypes[i];
         if (t.name.trim()) {
           const result = await setupCreateItemType(t.name, t.icon, t.color, i);
-          if (result.error) throw new Error(`Item type "${t.name}": ${result.error}`);
+          if ('error' in result && result.error) throw new Error(`Item type "${t.name}": ${result.error}`);
         }
       }
 
       // 3. Create admin account
       const adminResult = await setupCreateAdmin(adminEmail, adminPassword, adminName);
-      if (adminResult.error) throw new Error(adminResult.error);
+      if ('error' in adminResult && adminResult.error) throw new Error(adminResult.error);
 
       // 4. Mark setup complete
       const completeResult = await setupComplete();
-      if (completeResult.error) throw new Error(completeResult.error);
+      if ('error' in completeResult && completeResult.error) throw new Error(completeResult.error);
 
       // Redirect to home
       router.push('/');


### PR DESCRIPTION
## Critical — C1 from the 2026-07-02 audit
Every `/setup` server action (`src/app/setup/actions.ts`) uses the **RLS-bypassing service client** with **no auth check** and **no `setup_complete` guard**, and `/setup` stays reachable after setup finishes (middleware exempts it). So on a live, already-set-up org, any **anonymous** visitor could POST:
- `setupCreateAdmin(email, password, …)` → **mint a new admin account** (or promote themselves)
- `setupSaveConfig` / `setupComplete` → overwrite the org/property config

Verified independently by 3 audit agents.

## Fix (fails closed)
Add `assertSetupIncomplete(supabase)` — reads `orgs.setup_complete` (a `NOT NULL DEFAULT false` column) and returns an error once it's `true`; any lookup failure also blocks. All **6** setup actions call it first. Legitimate first-run setup (`setup_complete=false`) is unaffected; the moment `setupComplete()` flips the flag, every setup action is sealed.

## Tests (`src/app/setup/__tests__/actions.test.ts`)
- **6 blocked-path** cases: each action, with `setup_complete=true`, returns `{ error: 'Setup already complete' }` **and performs zero mutations** (no `createUser`, no `upsert role:admin`, no config writes).
- **2 allowed-path** cases: with `setup_complete=false`, first-run still provisions the admin (`role: admin`) and marks setup complete — proving the guard doesn't break onboarding.
- **Mutation-verified**: removing a guard fails the matching refusal test.

## Scope / follow-ups (rest of P1-SEC-2)
This is the highest-severity item. Still open in P1-SEC-2, as separate reviewed PRs: adopt `requireOrgAdmin` in `domains` + `communications` actions, and the `ai-context` SSRF (`processUrlContext` URL allowlist). A defense-in-depth middleware redirect of `/setup`→`/` when complete is also worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)