### PR TITLE
fix(security): require org-admin + org scoping on custom-domain actions

### DIFF
--- a/src/lib/domains/__tests__/actions.test.ts
+++ b/src/lib/domains/__tests__/actions.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Auth context returned by requireOrgAdmin (swapped per test).
+let mockAuth: any;
+// Domain row returned by the org-scoped custom_domains fetch (null = not owned).
+let mockDomainRow: { domain: string } | null = null;
+const vercelCalls: string[] = [];
+
+function makeSupabase() {
+  return {
+    from: (table: string) => {
+      if (table === 'properties') {
+        return { select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { id: 'prop-1' } }) }) }) }) };
+      }
+      if (table === 'custom_domains') {
+        return {
+          select: () => ({ eq: () => ({ eq: () => ({ single: () => Promise.resolve({ data: mockDomainRow, error: mockDomainRow ? null : { message: 'not found' } }) }) }) }),
+          insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 'dom-1' }, error: null }) }) }),
+          delete: () => ({ eq: () => ({ eq: () => Promise.resolve({ error: null }) }) }),
+          update: () => ({ eq: () => ({ eq: () => Promise.resolve({ error: null }) }) }),
+        };
+      }
+      return {};
+    },
+  };
+}
+
+vi.mock('@/lib/auth/require-org', () => ({
+  isAuthFailure: (r: any) => 'error' in r,
+  requireOrgAdmin: () => Promise.resolve(mockAuth),
+}));
+
+vi.mock('../vercel', () => ({
+  addDomainToVercel: (d: string) => { vercelCalls.push(`add:${d}`); return Promise.resolve({ verified: false, verification: [] }); },
+  removeDomainFromVercel: (d: string) => { vercelCalls.push(`remove:${d}`); return Promise.resolve(); },
+  checkDomainOnVercel: (d: string) => { vercelCalls.push(`check:${d}`); return Promise.resolve({ verified: true, verification: [] }); },
+}));
+
+import { addCustomDomain, removeCustomDomain, checkDomainStatus } from '../actions';
+
+beforeEach(() => {
+  vercelCalls.length = 0;
+  mockDomainRow = null;
+  mockAuth = { supabase: makeSupabase(), user: { id: 'u-1' }, tenant: { orgId: 'org-1' }, orgId: 'org-1' };
+});
+
+describe('domains actions — auth required', () => {
+  beforeEach(() => { mockAuth = { error: 'Admin access required' }; });
+
+  it('addCustomDomain refuses non-admins and never calls Vercel', async () => {
+    const r = await addCustomDomain('org-1', 'x.com');
+    expect(r).toEqual({ success: false, error: 'Admin access required' });
+    expect(vercelCalls).toHaveLength(0);
+  });
+
+  it('removeCustomDomain refuses non-admins and never calls Vercel', async () => {
+    const r = await removeCustomDomain('dom-1');
+    expect(r).toEqual({ success: false, error: 'Admin access required' });
+    expect(vercelCalls).toHaveLength(0);
+  });
+
+  it('checkDomainStatus refuses non-admins', async () => {
+    const r = await checkDomainStatus('dom-1');
+    expect(r.error).toBe('Admin access required');
+    expect(r.verified).toBe(false);
+    expect(vercelCalls).toHaveLength(0);
+  });
+});
+
+describe('domains actions — org scoping', () => {
+  it('addCustomDomain rejects registering a domain for another org', async () => {
+    // caller is admin of org-1 but passes org-2
+    const r = await addCustomDomain('org-2', 'x.com');
+    expect(r).toEqual({ success: false, error: 'Cannot add a domain for another org' });
+    expect(vercelCalls).toHaveLength(0);
+  });
+
+  it('removeCustomDomain treats a domain outside the caller org as not found', async () => {
+    mockDomainRow = null; // org-scoped fetch finds nothing
+    const r = await removeCustomDomain('dom-other-org');
+    expect(r).toEqual({ success: false, error: 'Domain not found' });
+    expect(vercelCalls).toHaveLength(0);
+  });
+
+  it('addCustomDomain succeeds for the caller own org', async () => {
+    const r = await addCustomDomain('org-1', 'mine.com');
+    expect(r.success).toBe(true);
+    expect(r.domainId).toBe('dom-1');
+    expect(vercelCalls).toContain('add:mine.com');
+  });
+
+  it('removeCustomDomain succeeds for an owned domain', async () => {
+    mockDomainRow = { domain: 'mine.com' };
+    const r = await removeCustomDomain('dom-1');
+    expect(r).toEqual({ success: true });
+    expect(vercelCalls).toContain('remove:mine.com');
+  });
+});

--- a/src/lib/domains/actions.ts
+++ b/src/lib/domains/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { requireOrgAdmin, isAuthFailure } from '@/lib/auth/require-org';
 import { addDomainToVercel, removeDomainFromVercel, checkDomainOnVercel } from './vercel';
 
 interface AddDomainResult {
@@ -19,11 +19,26 @@ export async function addCustomDomain(
   domain: string,
   propertyId?: string
 ): Promise<AddDomainResult> {
-  const supabase = await createClient();
+  const ctx = await requireOrgAdmin();
+  if (isAuthFailure(ctx)) return { success: false, error: ctx.error };
+  const { supabase, user, orgId: callerOrgId } = ctx;
 
-  // Validate caller is org admin
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { success: false, error: 'Not authenticated' };
+  // The `orgId` argument is client-supplied — an org admin must not be able to
+  // register a domain against a different org. Pin to the caller's own org.
+  if (orgId !== callerOrgId) {
+    return { success: false, error: 'Cannot add a domain for another org' };
+  }
+
+  // If scoping to a property, it must belong to this org.
+  if (propertyId) {
+    const { data: prop } = await supabase
+      .from('properties')
+      .select('id')
+      .eq('id', propertyId)
+      .eq('org_id', callerOrgId)
+      .maybeSingle();
+    if (!prop) return { success: false, error: 'Property not found in this org' };
+  }
 
   // Register with Vercel
   let vercelResponse;
@@ -41,7 +56,7 @@ export async function addCustomDomain(
   const { data, error } = await supabase
     .from('custom_domains')
     .insert({
-      org_id: orgId,
+      org_id: callerOrgId,
       property_id: propertyId ?? null,
       domain,
       status: vercelResponse.verified ? 'active' : 'verifying',
@@ -73,13 +88,17 @@ export async function addCustomDomain(
  * Removes from Vercel and deletes from database.
  */
 export async function removeCustomDomain(domainId: string): Promise<{ success: boolean; error?: string }> {
-  const supabase = await createClient();
+  const ctx = await requireOrgAdmin();
+  if (isAuthFailure(ctx)) return { success: false, error: ctx.error };
+  const { supabase, orgId } = ctx;
 
-  // Fetch the domain
+  // Fetch the domain scoped to the caller's org — prevents removing another
+  // org's domain and avoids leaking whether an id exists.
   const { data: domainRow, error: fetchError } = await supabase
     .from('custom_domains')
     .select('domain')
     .eq('id', domainId)
+    .eq('org_id', orgId)
     .single();
 
   if (fetchError || !domainRow) return { success: false, error: 'Domain not found' };
@@ -95,7 +114,8 @@ export async function removeCustomDomain(domainId: string): Promise<{ success: b
   const { error } = await supabase
     .from('custom_domains')
     .delete()
-    .eq('id', domainId);
+    .eq('id', domainId)
+    .eq('org_id', orgId);
 
   if (error) return { success: false, error: error.message };
 
@@ -112,12 +132,15 @@ export async function checkDomainStatus(domainId: string): Promise<{
   verificationRecords?: { type: string; domain: string; value: string }[];
   error?: string;
 }> {
-  const supabase = await createClient();
+  const ctx = await requireOrgAdmin();
+  if (isAuthFailure(ctx)) return { status: 'unauthorized', verified: false, error: ctx.error };
+  const { supabase, orgId } = ctx;
 
   const { data: domainRow } = await supabase
     .from('custom_domains')
     .select('domain, status')
     .eq('id', domainId)
+    .eq('org_id', orgId)
     .single();
 
   if (!domainRow) return { status: 'not_found', verified: false, error: 'Domain not found' };


### PR DESCRIPTION
2026-07-02 audit (**High**). `src/lib/domains/actions.ts`:
- `addCustomDomain` only checked `getUser()` and **trusted the client-supplied `orgId`** → any authenticated user could register a domain against any org.
- `removeCustomDomain` / `checkDomainStatus` had **no auth check** and acted on any `domainId` (relying solely on RLS).

## Fix
Adopt `requireOrgAdmin()` (landed in #332) in all three, and scope every DB access to the caller's org:
- **addCustomDomain** — reject when the passed `orgId` ≠ caller's org; verify a supplied `propertyId` belongs to the org; insert with the authoritative org id.
- **removeCustomDomain / checkDomainStatus** — fetch (and delete/update) with `.eq('org_id', callerOrgId)`, so another org's domain reads as *not found*.

Fails closed.

## Tests (`src/lib/domains/__tests__/actions.test.ts`)
- Unauthorized callers get an error and **never reach Vercel** (all three).
- Cross-org `addCustomDomain` is rejected.
- A domain outside the caller's org reads as *not found* on remove.
- Owned-domain happy paths still succeed.
- Mutation-verified (removing the cross-org guard fails the matching test).

## P1-SEC-2 progress
C1 `/setup` (#336, merged) ✅ · domains (this) · **next:** communications (`sendNotification` + topic CRUD), then ai-context SSRF (on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)