### PR TITLE
fix(security): require org-admin + org scoping on communications actions

### DIFF
--- a/src/lib/communications/__tests__/actions.test.ts
+++ b/src/lib/communications/__tests__/actions.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockAuth: any;
+let mockOwnedTopics: Array<{ id: string }> = [];
+const ops: string[] = [];
+
+function makeSupabase() {
+  return {
+    from: (table: string) => {
+      if (table === 'communication_topics') {
+        return {
+          insert: () => { ops.push('topics:insert'); return { select: () => ({ single: () => Promise.resolve({ data: { id: 'topic-1', name: 'T' }, error: null }) }) }; },
+          update: () => ({ eq: () => ({ eq: () => { ops.push('topics:update'); return Promise.resolve({ error: null }); } }) }),
+          select: () => ({ eq: () => ({ in: () => Promise.resolve({ data: mockOwnedTopics }) }) }),
+        };
+      }
+      if (table === 'properties') {
+        return { select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { id: 'prop-1' } }) }) }) }) };
+      }
+      return {};
+    },
+  };
+}
+
+vi.mock('@/lib/auth/require-org', () => ({
+  isAuthFailure: (r: any) => 'error' in r,
+  requireOrgAdmin: () => Promise.resolve(mockAuth),
+}));
+// createClient is only used by the user-scoped actions, not exercised here.
+vi.mock('@/lib/supabase/server', () => ({ createClient: () => makeSupabase() }));
+
+import { createTopic, updateTopic, sendNotification } from '../actions';
+
+beforeEach(() => {
+  ops.length = 0;
+  mockOwnedTopics = [];
+  mockAuth = { supabase: makeSupabase(), user: { id: 'u-1' }, tenant: { orgId: 'org-1' }, orgId: 'org-1' };
+});
+
+const notif = { org_id: 'org-1', topic_ids: ['topic-1'], title: 'Hi', body: 'Body', channels: ['in_app'] as ('in_app')[] };
+
+describe('communications — admin required', () => {
+  beforeEach(() => { mockAuth = { error: 'Admin access required' }; });
+
+  it('createTopic refuses non-admins', async () => {
+    expect(await createTopic({ org_id: 'org-1', name: 'T' })).toEqual({ error: 'Admin access required' });
+    expect(ops).toHaveLength(0);
+  });
+  it('updateTopic refuses non-admins', async () => {
+    expect(await updateTopic('topic-1', { name: 'X' })).toEqual({ error: 'Admin access required' });
+    expect(ops).toHaveLength(0);
+  });
+  it('sendNotification refuses non-admins', async () => {
+    expect(await sendNotification(notif)).toEqual({ error: 'Admin access required' });
+  });
+});
+
+describe('communications — org scoping', () => {
+  it('createTopic rejects another org', async () => {
+    expect(await createTopic({ org_id: 'org-2', name: 'T' })).toEqual({ error: 'Cannot create a topic for another org' });
+    expect(ops).not.toContain('topics:insert');
+  });
+
+  it('sendNotification rejects another org', async () => {
+    expect(await sendNotification({ ...notif, org_id: 'org-2' })).toEqual({ error: 'Cannot send notifications for another org' });
+  });
+
+  it('sendNotification rejects topics not owned by the org', async () => {
+    mockOwnedTopics = []; // ownership query returns none of the requested topics
+    expect(await sendNotification(notif)).toEqual({ error: 'One or more topics do not belong to this org' });
+  });
+
+  it('createTopic succeeds for the caller own org', async () => {
+    const r = await createTopic({ org_id: 'org-1', name: 'Announcements' });
+    expect('success' in r && r.success).toBe(true);
+    expect(ops).toContain('topics:insert');
+  });
+
+  it('updateTopic succeeds for an admin (org-scoped)', async () => {
+    expect(await updateTopic('topic-1', { name: 'X' })).toEqual({ success: true });
+    expect(ops).toContain('topics:update');
+  });
+});

--- a/src/lib/communications/actions.ts
+++ b/src/lib/communications/actions.ts
@@ -2,6 +2,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgAdmin, isAuthFailure } from '@/lib/auth/require-org';
 import type { CommunicationTopic } from './types';
 
 // ---------------------------------------------------------------------------
@@ -15,14 +16,21 @@ export async function createTopic(input: {
   description?: string;
   sort_order?: number;
 }): Promise<{ success: true; topic: CommunicationTopic } | { error: string }> {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: 'Not authenticated' };
+  const ctx = await requireOrgAdmin();
+  if (isAuthFailure(ctx)) return { error: ctx.error };
+  const { supabase, orgId } = ctx;
+
+  if (input.org_id !== orgId) return { error: 'Cannot create a topic for another org' };
+  if (input.property_id) {
+    const { data: prop } = await supabase
+      .from('properties').select('id').eq('id', input.property_id).eq('org_id', orgId).maybeSingle();
+    if (!prop) return { error: 'Property not found in this org' };
+  }
 
   const { data, error } = await supabase
     .from('communication_topics')
     .insert({
-      org_id: input.org_id,
+      org_id: orgId,
       property_id: input.property_id ?? null,
       name: input.name.trim(),
       description: input.description?.trim() ?? null,
@@ -45,9 +53,9 @@ export async function updateTopic(
     sort_order?: number;
   }
 ): Promise<{ success: true } | { error: string }> {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: 'Not authenticated' };
+  const ctx = await requireOrgAdmin();
+  if (isAuthFailure(ctx)) return { error: ctx.error };
+  const { supabase, orgId } = ctx;
 
   const payload: Record<string, unknown> = {};
   if (updates.name !== undefined) payload.name = updates.name.trim();
@@ -60,7 +68,8 @@ export async function updateTopic(
   const { error } = await supabase
     .from('communication_topics')
     .update(payload)
-    .eq('id', topicId);
+    .eq('id', topicId)
+    .eq('org_id', orgId);
 
   if (error) return { error: error.message };
   return { success: true };
@@ -176,14 +185,26 @@ export async function sendNotification(input: {
   link?: string;
   channels: ('email' | 'in_app')[];
 }): Promise<{ success: true; sent: { email: number; inApp: number } } | { error: string }> {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { error: 'Not authenticated' };
+  const ctx = await requireOrgAdmin();
+  if (isAuthFailure(ctx)) return { error: ctx.error };
+  const { supabase, orgId } = ctx;
 
+  if (input.org_id !== orgId) return { error: 'Cannot send notifications for another org' };
   if (input.topic_ids.length === 0) return { error: 'At least one topic is required' };
   if (!input.title.trim()) return { error: 'Title is required' };
   if (!input.body.trim()) return { error: 'Body is required' };
   if (input.channels.length === 0) return { error: 'At least one channel is required' };
+
+  // Every target topic must belong to the caller's org (topic_ids are client-
+  // supplied — otherwise an admin could blast another org's subscribers).
+  const { data: ownedTopics } = await supabase
+    .from('communication_topics')
+    .select('id')
+    .eq('org_id', orgId)
+    .in('id', input.topic_ids);
+  if (!ownedTopics || ownedTopics.length !== input.topic_ids.length) {
+    return { error: 'One or more topics do not belong to this org' };
+  }
 
   // Rate limit: check if a notification was sent to any of these topics in the last hour
   const { data: recentSends } = await supabase
@@ -251,7 +272,7 @@ export async function sendNotification(input: {
       if (prefs.inApp) {
         notificationRows.push({
           user_id: userId,
-          org_id: input.org_id,
+          org_id: orgId,
           property_id: input.property_id ?? null,
           topic_id: prefs.topicId,
           title: input.title.trim(),
@@ -294,7 +315,7 @@ export async function sendNotification(input: {
         try {
           await sendNotificationEmail({
             userId,
-            orgId: input.org_id,
+            orgId,
             topicId: prefs.topicId,
             title: input.title.trim(),
             body: input.body.trim(),


### PR DESCRIPTION
2026-07-02 audit (**High**). `src/lib/communications/actions.ts`:
- `createTopic` / `updateTopic` / `deleteTopic` only checked `getUser()` (not admin), trusted the client `org_id`, and `updateTopic` mutated by `topicId` with **no org scope**.
- `sendNotification` only checked `getUser()` with client-supplied `org_id` + `topic_ids` → any authenticated user could **email/notify another org's subscribers**, spoofing the org identity.

## Fix
Adopt `requireOrgAdmin()` (from #332) + scope to the caller's org:
- **createTopic** — reject `org_id` ≠ caller org; verify `property_id` belongs to the org; insert with the authoritative org id.
- **updateTopic** (and `deleteTopic` via it) — admin + `.eq('org_id', orgId)` on the update.
- **sendNotification** — reject `org_id` ≠ caller org; **verify every `topic_id` belongs to the org** before sending; use the authoritative org id on the notification rows and email.

**Unchanged:** the user-scoped actions (`subscribe`, `updateSubscription`, `mark*Read`, `unsubscribeAll`) — already correctly scoped by `user_id` and legitimate for any authenticated user.

## Tests (8)
Non-admins refused with no writes; cross-org create/send rejected; sending to an unowned topic rejected; own-org happy paths still work.

## P1-SEC-2 progress
C1 `/setup` (#336 ✅) · domains (#337 ✅) · communications (this) · **last:** ai-context SSRF (on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)