### PR TITLE
fix(security): block SSRF in ai-context processUrlContext

### DIFF
--- a/src/lib/ai-context/actions.ts
+++ b/src/lib/ai-context/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { safeFetch } from '@/lib/security/ssrf';
 import type {
   AiContextItem,
   AiContextSummary,
@@ -497,7 +498,10 @@ export async function processUrlContext(
 
     let html: string;
     try {
-      const response = await fetch(url, {
+      // safeFetch blocks SSRF: non-http(s) schemes and hosts that resolve to
+      // private / loopback / link-local / cloud-metadata addresses, including
+      // across redirect hops.
+      const response = await safeFetch(url, {
         signal: controller.signal,
         headers: {
           'User-Agent': 'FieldMapper-ContextBot/1.0 (+https://fieldmapper.io)',

--- a/src/lib/security/__tests__/ssrf.test.ts
+++ b/src/lib/security/__tests__/ssrf.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isBlockedIp, assertSafeUrl, safeFetch } from '../ssrf';
+
+// Deterministic injectable resolvers (no real DNS).
+const resolvesTo = (address: string) => async () => [{ address }];
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isBlockedIp', () => {
+  it.each([
+    '127.0.0.1', '10.1.2.3', '172.16.0.1', '172.31.255.255', '192.168.1.1',
+    '169.254.169.254', '100.64.0.1', '0.0.0.0', '224.0.0.1',
+    '::1', 'fe80::1', 'fc00::1', 'fd12::34', '::ffff:127.0.0.1',
+  ])('blocks %s', (ip) => {
+    expect(isBlockedIp(ip)).toBe(true);
+  });
+
+  it.each(['8.8.8.8', '1.1.1.1', '93.184.216.34', '172.15.0.1', '172.32.0.1', '::ffff:8.8.8.8'])(
+    'allows public %s',
+    (ip) => {
+      expect(isBlockedIp(ip)).toBe(false);
+    }
+  );
+});
+
+describe('assertSafeUrl', () => {
+  it('rejects non-http(s) schemes', async () => {
+    await expect(assertSafeUrl('ftp://example.com')).rejects.toThrow(/http/i);
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow(/http/i);
+  });
+
+  it('rejects a malformed URL', async () => {
+    await expect(assertSafeUrl('not a url')).rejects.toThrow(/invalid url/i);
+  });
+
+  it('rejects IP-literal internal targets (metadata, loopback, private)', async () => {
+    await expect(assertSafeUrl('http://169.254.169.254/latest/meta-data')).rejects.toThrow(/disallowed/i);
+    await expect(assertSafeUrl('http://127.0.0.1:8080/')).rejects.toThrow(/disallowed/i);
+    await expect(assertSafeUrl('http://10.0.0.5/')).rejects.toThrow(/disallowed/i);
+  });
+
+  it('rejects a hostname that resolves to a private address (rebinding)', async () => {
+    await expect(assertSafeUrl('https://evil.example.com', resolvesTo('10.0.0.5'))).rejects.toThrow(/disallowed/i);
+  });
+
+  it('allows a public hostname', async () => {
+    await expect(assertSafeUrl('https://example.com/page', resolvesTo('93.184.216.34'))).resolves.toBeInstanceOf(URL);
+  });
+});
+
+describe('safeFetch', () => {
+  it('fetches a public URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+    const res = await safeFetch('https://example.com');
+    expect(res.status).toBe(200);
+  });
+
+  it('blocks a redirect that points at an internal address', async () => {
+    // First hop 302 → cloud metadata; safeFetch must re-validate and refuse.
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/' } })
+    ));
+    await expect(safeFetch('https://example.com', { maxRedirects: 2 })).rejects.toThrow(/disallowed/i);
+  });
+});

--- a/src/lib/security/ssrf.ts
+++ b/src/lib/security/ssrf.ts
@@ -1,0 +1,94 @@
+import { lookup } from 'node:dns/promises';
+import net from 'node:net';
+
+/**
+ * SSRF guard for server-side fetches of user-supplied URLs.
+ *
+ * A server action that fetches an arbitrary client URL can be tricked into
+ * reaching internal services — the cloud metadata endpoint (169.254.169.254),
+ * localhost, or private RFC-1918 ranges. These helpers restrict outbound
+ * requests to public http(s) hosts and re-validate every redirect hop.
+ */
+
+/** True if the IP is loopback, private, link-local, or otherwise not public. */
+export function isBlockedIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const [a, b] = ip.split('.').map(Number);
+    if (a === 0) return true;                         // "this" network
+    if (a === 127) return true;                       // loopback
+    if (a === 10) return true;                        // private
+    if (a === 172 && b >= 16 && b <= 31) return true; // private
+    if (a === 192 && b === 168) return true;          // private
+    if (a === 169 && b === 254) return true;          // link-local + cloud metadata
+    if (a === 100 && b >= 64 && b <= 127) return true;// CGNAT
+    if (a >= 224) return true;                         // multicast / reserved
+    return false;
+  }
+  const lower = ip.toLowerCase();
+  if (lower.startsWith('::ffff:')) return isBlockedIp(lower.slice('::ffff:'.length)); // IPv4-mapped
+  if (lower === '::1' || lower === '::') return true;  // loopback / unspecified
+  if (lower.startsWith('fe80')) return true;           // link-local
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // unique-local
+  return false;
+}
+
+/** Resolve a hostname to its IP addresses. Injectable for testing. */
+export type HostResolver = (host: string) => Promise<Array<{ address: string }>>;
+
+const defaultResolver: HostResolver = (host) => lookup(host, { all: true });
+
+/**
+ * Validate a URL is a public http(s) endpoint. Rejects non-http schemes and
+ * any host that resolves to a blocked address (checking ALL resolved records,
+ * which also blunts basic DNS-rebinding). Returns the parsed URL.
+ */
+export async function assertSafeUrl(raw: string, resolve: HostResolver = defaultResolver): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Only http and https URLs are allowed');
+  }
+
+  const host = url.hostname;
+  if (net.isIP(host)) {
+    if (isBlockedIp(host)) throw new Error('URL points to a disallowed address');
+    return url;
+  }
+
+  const resolved = await resolve(host);
+  if (resolved.length === 0) throw new Error('Host did not resolve');
+  for (const { address } of resolved) {
+    if (isBlockedIp(address)) throw new Error('URL resolves to a disallowed address');
+  }
+  return url;
+}
+
+/**
+ * `fetch` that SSRF-validates the initial URL and every redirect hop. Redirects
+ * are followed manually (up to `maxRedirects`) so a public URL cannot bounce
+ * the request to an internal address.
+ */
+export async function safeFetch(
+  raw: string,
+  init: RequestInit & { maxRedirects?: number } = {}
+): Promise<Response> {
+  const { maxRedirects = 3, ...rest } = init;
+  let current = raw;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    await assertSafeUrl(current);
+    const res = await fetch(current, { ...rest, redirect: 'manual' });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) return res;
+      current = new URL(location, current).toString();
+      continue;
+    }
+    return res;
+  }
+  throw new Error('Too many redirects');
+}


### PR DESCRIPTION
2026-07-02 audit (**High**) — the last P1-SEC-2 item. `processUrlContext` fetches a **client-supplied URL** server-side with no validation → an attacker could reach the cloud metadata endpoint (`169.254.169.254`), `localhost`, or private RFC-1918 services, and redirects were unguarded.

## Fix — reusable `src/lib/security/ssrf.ts`
- **`isBlockedIp()`** — loopback / private / link-local / CGNAT / metadata / unique-local (IPv4 + IPv6, incl. IPv4-mapped).
- **`assertSafeUrl()`** — http(s) only; rejects IP-literal internal targets and hostnames that resolve to blocked addresses (checks **all** A/AAAA records to blunt DNS rebinding). Resolver injectable for tests.
- **`safeFetch()`** — validates the URL **and re-validates every redirect hop** (manual, capped), so a public URL can't bounce the request to an internal one.

`processUrlContext` now calls `safeFetch`; its existing `catch` surfaces a rejection as `{ error }`.

## Tests (27)
Blocked/allowed IP matrix, scheme + malformed-URL rejection, metadata/loopback/private literals, DNS-rebinding via injected resolver, and a redirect-to-metadata that `safeFetch` refuses.

## 🎉 P1-SEC-2 complete
C1 `/setup` (#336 ✅) · domains (#337 ✅) · communications (#338) · **ai-context SSRF (this)**. All audit Critical/High unauth'd-action findings now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)